### PR TITLE
漢字の部分はnotosansにする

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,9 +2,15 @@ import React from 'react';
 import type { Preview } from '@storybook/react';
 import '../src/app/_styles/globals.css';
 import { AppProvider } from '../src/providers/app';
-import { M_PLUS_2 } from 'next/font/google';
+import { M_PLUS_2, Noto_Sans_JP } from 'next/font/google';
+import clsx from 'clsx';
 
 const font = M_PLUS_2({ subsets: ['latin'] });
+
+const subFont = Noto_Sans_JP({
+  subsets: ['latin'],
+  variable: '--font-noto-sans-jp',
+});
 
 const preview: Preview = {
   parameters: {
@@ -19,7 +25,7 @@ const preview: Preview = {
   decorators: [
     (Story) => (
       <AppProvider>
-        <div className={font.className}>
+        <div className={clsx(font.className, subFont.variable)}>
           <Story />
         </div>
       </AppProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,13 +1,19 @@
 import { GlobalLayout } from './_components/global-layout';
 import './_styles/globals.css';
-import { M_PLUS_2 } from 'next/font/google';
+import { M_PLUS_2, Noto_Sans_JP } from 'next/font/google';
 import { Analytics } from '@vercel/analytics/react';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import '@/libs/zod';
 import { AppProvider } from '@/providers/app';
+import clsx from 'clsx';
 
 const font = M_PLUS_2({
   subsets: ['latin'],
+});
+
+const subFont = Noto_Sans_JP({
+  subsets: ['latin'],
+  variable: '--font-noto-sans-jp',
 });
 
 export const metadata = {
@@ -32,7 +38,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ja">
-      <body className={font.className}>
+      <body className={clsx(font.className, subFont.variable)}>
         <AppProvider>
           <GlobalLayout>{children}</GlobalLayout>
         </AppProvider>

--- a/src/app/quizzes/_components/answer/answer.tsx
+++ b/src/app/quizzes/_components/answer/answer.tsx
@@ -18,7 +18,9 @@ export const Answer: FC<{
 }) => {
   return (
     <div className="flex flex-col items-center gap-2">
-      {highlight && <p className="text-9xl">{highlight}</p>}
+      {highlight && (
+        <p className="font-notoSansJp text-9xl">{highlight}</p>
+      )}
       <FormControl
         label={question}
         renderInput={(props) => {

--- a/src/app/quizzes/_components/collection/collection.tsx
+++ b/src/app/quizzes/_components/collection/collection.tsx
@@ -9,7 +9,7 @@ export const CollectionByHighlight: CollectionProps = ({
   quizzes,
 }) => {
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className="font-notoSansJp flex flex-wrap justify-center gap-2">
       {quizzes.map((quiz) => (
         <div
           key={quiz.id}

--- a/src/app/quizzes/_components/feedback/feedback.tsx
+++ b/src/app/quizzes/_components/feedback/feedback.tsx
@@ -39,7 +39,9 @@ export const Feedback: FC<{
         </div>
         <div className="flex flex-col items-center">
           <p>{question}</p>
-          {highlight && <p className="text-9xl">{highlight}</p>}
+          {highlight && (
+            <p className="font-notoSansJp text-9xl">{highlight}</p>
+          )}
         </div>
       </div>
       <div className="flex w-full flex-col gap-1">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -30,6 +30,9 @@ module.exports = {
         bgDark: colors.slate[800],
         focusRing: colors.blue[500],
       },
+      fontFamily: {
+        notoSansJp: ['var(--font-noto-sans-jp)'],
+      },
       aria: {
         invalid: 'invalid="true"',
       },


### PR DESCRIPTION
close #156

highlightだけフォント変えるとわかりやすいので漢字に限らず全部そうした。

コレクションを中央寄せにしたが末尾の要素が満たないときにも中央寄せになる
flexでは無理なのでtailwindのgridをちゃんと調べてみる(別pr)

多分カスタム定義することになる

