### PR TITLE
コンポーネントツリー上にないデータ取得からcacheを剥がす

### DIFF
--- a/src/app/blog/_components/blog-layout/blog-layout.stories.tsx
+++ b/src/app/blog/_components/blog-layout/blog-layout.stories.tsx
@@ -1,12 +1,15 @@
 import { BlogLayout } from './blog-layout';
-import { getBlog, getBlogView } from '#src/mocks/actions/blog.mock';
+import {
+  getBlogWitoutCache,
+  getBlogView,
+} from '#src/mocks/actions/blog.mock';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof BlogLayout> = {
   title: 'app/blog/blog-layout',
   component: BlogLayout,
   beforeEach: () => {
-    getBlog.mockResolvedValue({
+    getBlogWitoutCache.mockResolvedValue({
       id: 1,
       title:
         'Reactの新しいルーティングライブラリ、TanStackRouterを学ぶ',

--- a/src/app/blog/color-certification-uc/opengraph-image.tsx
+++ b/src/app/blog/color-certification-uc/opengraph-image.tsx
@@ -1,4 +1,4 @@
-import { getBlog } from '#actions/blog';
+import { getBlogWitoutCache } from '#actions/blog';
 import { Parser, jaModel } from 'budoux';
 import { ImageResponse } from 'next/og';
 
@@ -13,7 +13,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function OpenGraphImage() {
-  const blog = await getBlog({
+  const blog = await getBlogWitoutCache({
     slug: 'color-certification-uc',
   });
 

--- a/src/app/blog/color-certification-uc/twitter-image.tsx
+++ b/src/app/blog/color-certification-uc/twitter-image.tsx
@@ -1,4 +1,4 @@
-import { getBlog } from '#actions/blog';
+import { getBlogWitoutCache } from '#actions/blog';
 import { Parser, jaModel } from 'budoux';
 import { ImageResponse } from 'next/og';
 
@@ -13,7 +13,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function TwitterImage() {
-  const blog = await getBlog({
+  const blog = await getBlogWitoutCache({
     slug: 'color-certification-uc',
   });
 

--- a/src/app/blog/color-contrast/opengraph-image.tsx
+++ b/src/app/blog/color-contrast/opengraph-image.tsx
@@ -1,4 +1,4 @@
-import { getBlog } from '#actions/blog';
+import { getBlogWitoutCache } from '#actions/blog';
 import { Parser, jaModel } from 'budoux';
 import { ImageResponse } from 'next/og';
 
@@ -14,7 +14,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function OpenGraphImage() {
-  const blog = await getBlog({
+  const blog = await getBlogWitoutCache({
     slug: 'color-contrast',
   });
 

--- a/src/app/blog/color-contrast/twitter-image.tsx
+++ b/src/app/blog/color-contrast/twitter-image.tsx
@@ -1,4 +1,4 @@
-import { getBlog } from '#actions/blog';
+import { getBlogWitoutCache } from '#actions/blog';
 import { Parser, jaModel } from 'budoux';
 import { ImageResponse } from 'next/og';
 
@@ -14,7 +14,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function TwitterImage() {
-  const blog = await getBlog({
+  const blog = await getBlogWitoutCache({
     slug: 'color-contrast',
   });
 

--- a/src/app/blog/color-perception/opengraph-image.tsx
+++ b/src/app/blog/color-perception/opengraph-image.tsx
@@ -1,4 +1,4 @@
-import { getBlog } from '#actions/blog';
+import { getBlogWitoutCache } from '#actions/blog';
 import { Parser, jaModel } from 'budoux';
 import { ImageResponse } from 'next/og';
 
@@ -13,7 +13,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function OpenGraphImage() {
-  const blog = await getBlog({
+  const blog = await getBlogWitoutCache({
     slug: 'color-perception',
   });
 

--- a/src/app/blog/color-perception/twitter-image.tsx
+++ b/src/app/blog/color-perception/twitter-image.tsx
@@ -1,4 +1,4 @@
-import { getBlog } from '#actions/blog';
+import { getBlogWitoutCache } from '#actions/blog';
 import { Parser, jaModel } from 'budoux';
 import { ImageResponse } from 'next/og';
 
@@ -13,7 +13,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function TwitterImage() {
-  const blog = await getBlog({
+  const blog = await getBlogWitoutCache({
     slug: 'color-perception',
   });
 

--- a/src/app/blog/feed/route.ts
+++ b/src/app/blog/feed/route.ts
@@ -1,5 +1,5 @@
 import { metadata } from '../layout';
-import { db } from '#database/db';
+import { getBlogsWithoutCache } from '#actions/blog';
 import { NextResponse } from 'next/server';
 import RSS from 'rss';
 
@@ -16,18 +16,7 @@ export async function GET() {
     language: 'ja',
   });
 
-  const blogs = await db.query.blogs.findMany({
-    with: {
-      blogTag: {
-        with: {
-          tag: true,
-        },
-      },
-    },
-    orderBy(fields, operators) {
-      return operators.desc(fields.createdAt);
-    },
-  });
+  const blogs = await getBlogsWithoutCache();
 
   for (const blog of blogs) {
     feed.item({
@@ -35,7 +24,7 @@ export async function GET() {
       description: blog.description,
       url: `${BLOG_URL}/${blog.slug}`,
       date: blog.updatedAt,
-      categories: blog.blogTag.map((blogTag) => blogTag.tag.name),
+      categories: blog.tags,
       author: 'k8o',
     });
   }

--- a/src/app/blog/promise-try/opengraph-image.tsx
+++ b/src/app/blog/promise-try/opengraph-image.tsx
@@ -1,4 +1,4 @@
-import { getBlog } from '#actions/blog';
+import { getBlogWitoutCache } from '#actions/blog';
 import { Parser, jaModel } from 'budoux';
 import { ImageResponse } from 'next/og';
 
@@ -14,7 +14,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function OpenGraphImage() {
-  const blog = await getBlog({
+  const blog = await getBlogWitoutCache({
     slug: 'promise-try',
   });
 

--- a/src/app/blog/promise-try/twitter-image.tsx
+++ b/src/app/blog/promise-try/twitter-image.tsx
@@ -1,4 +1,4 @@
-import { getBlog } from '#actions/blog';
+import { getBlogWitoutCache } from '#actions/blog';
 import { Parser, jaModel } from 'budoux';
 import { ImageResponse } from 'next/og';
 
@@ -14,7 +14,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function TwitterImage() {
-  const blog = await getBlog({
+  const blog = await getBlogWitoutCache({
     slug: 'promise-try',
   });
 

--- a/src/app/blog/tanstack-router-introduction/layout.tsx
+++ b/src/app/blog/tanstack-router-introduction/layout.tsx
@@ -1,10 +1,10 @@
 import { BlogLayout } from '../_components/blog-layout';
-import { getBlog } from '#actions/blog';
+import { getBlogWitoutCache } from '#actions/blog';
 import { Metadata } from 'next';
 import { PropsWithChildren } from 'react';
 
 export async function generateMetadata(): Promise<Metadata> {
-  const blog = await getBlog({
+  const blog = await getBlogWitoutCache({
     slug: 'tanstack-router-introduction',
   });
   if (!blog) {

--- a/src/app/blog/tanstack-router-introduction/twitter-image.tsx
+++ b/src/app/blog/tanstack-router-introduction/twitter-image.tsx
@@ -1,4 +1,4 @@
-import { getBlog } from '#actions/blog';
+import { getBlogWitoutCache } from '#actions/blog';
 import { Parser, jaModel } from 'budoux';
 import { ImageResponse } from 'next/og';
 
@@ -14,7 +14,7 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function TwitterImage() {
-  const blog = await getBlog({
+  const blog = await getBlogWitoutCache({
     slug: 'tanstack-router-introduction',
   });
 

--- a/src/mocks/actions/blog.mock.ts
+++ b/src/mocks/actions/blog.mock.ts
@@ -3,7 +3,15 @@ import { fn } from '@storybook/test';
 
 export const getBlogs = fn(actual.getBlogs).mockName('getBlogs');
 
+export const getBlogsWithoutCache = fn(
+  actual.getBlogsWithoutCache,
+).mockName('getBlogsWithoutCache');
+
 export const getBlog = fn(actual.getBlog).mockName('getBlog');
+
+export const getBlogWitoutCache = fn(
+  actual.getBlogWitoutCache,
+).mockName('getBlogWitoutCache');
 
 export const getBlogView = fn(actual.getBlogView).mockName(
   'getBlogView',


### PR DESCRIPTION
たまにdeployがこけるのはこれが原因のはず

> Memoization only applies to the React Component tree, this means:
It applies to fetch requests in generateMetadata, generateStaticParams, Layouts, Pages, and other Server Components.
It doesn't apply to fetch requests in Route Handlers as they are not a part of the React component tree.