### PR TITLE
RangeFieldコンポーネントを追加

### DIFF
--- a/src/app/qr-generator/_components/qr-generator/qr-generator.tsx
+++ b/src/app/qr-generator/_components/qr-generator/qr-generator.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/button';
 import { FormControl } from '@/components/form/form-control';
+import { RangeField } from '@/components/form/range-field';
 import { TextField } from '@/components/form/text-field';
 import { useState, useCallback, useMemo, ChangeEvent } from 'react';
 import { renderSVG } from 'uqr';
@@ -34,7 +35,7 @@ export const QrGenerator = () => {
   );
 
   const handleSizeChange = useCallback((newSize: number) => {
-    setSize(Math.max(100, Math.min(500, newSize)));
+    setSize(newSize);
   }, []);
 
   const handleDownload = useCallback(() => {
@@ -71,21 +72,15 @@ export const QrGenerator = () => {
         <FormControl
           label="サイズ調整"
           renderInput={(props) => (
-            <div className="flex items-center gap-4">
-              <input
-                type="range"
-                min="100"
-                max="500"
-                step="10"
-                value={size}
-                onChange={(e) => {
-                  handleSizeChange(Number(e.target.value));
-                }}
-                className="flex-1"
-                id={props.id}
-              />
-              <span className="w-16 text-sm">{size}px</span>
-            </div>
+            <RangeField
+              value={size}
+              onChange={handleSizeChange}
+              min={100}
+              max={500}
+              step={10}
+              unit="px"
+              {...props}
+            />
           )}
         />
       </div>

--- a/src/components/form/range-field/index.ts
+++ b/src/components/form/range-field/index.ts
@@ -1,0 +1,1 @@
+export { RangeField } from './range-field';

--- a/src/components/form/range-field/range-field.stories.tsx
+++ b/src/components/form/range-field/range-field.stories.tsx
@@ -1,0 +1,158 @@
+import { RangeField } from './range-field';
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { useState } from 'react';
+
+const meta: Meta<typeof RangeField> = {
+  title: 'components/form/RangeField',
+  component: RangeField,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    onChange: { action: 'changed' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RangeField>;
+
+export const Default: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value || 50);
+    return (
+      <div className="w-80">
+        <RangeField
+          {...args}
+          value={value}
+          onChange={(newValue) => {
+            setValue(newValue);
+            args.onChange(newValue);
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    value: 50,
+    min: 0,
+    max: 100,
+    step: 1,
+    isInvalid: false,
+    isDisabled: false,
+    isRequired: false,
+    showValue: true,
+  },
+};
+
+export const WithUnit: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value || 200);
+    return (
+      <div className="w-80">
+        <RangeField
+          {...args}
+          value={value}
+          onChange={(newValue) => {
+            setValue(newValue);
+            args.onChange(newValue);
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    value: 200,
+    min: 100,
+    max: 500,
+    step: 10,
+    unit: 'px',
+    isInvalid: false,
+    isDisabled: false,
+    isRequired: false,
+    showValue: true,
+  },
+};
+
+export const WithoutValue: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value || 75);
+    return (
+      <div className="w-80">
+        <RangeField
+          {...args}
+          value={value}
+          onChange={(newValue) => {
+            setValue(newValue);
+            args.onChange(newValue);
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    value: 75,
+    min: 0,
+    max: 100,
+    step: 5,
+    showValue: false,
+    isInvalid: false,
+    isDisabled: false,
+    isRequired: false,
+  },
+};
+
+export const Disabled: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value || 30);
+    return (
+      <div className="w-80">
+        <RangeField
+          {...args}
+          value={value}
+          onChange={(newValue) => {
+            setValue(newValue);
+            args.onChange(newValue);
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    value: 30,
+    min: 0,
+    max: 100,
+    step: 1,
+    isInvalid: false,
+    isDisabled: true,
+    isRequired: false,
+    showValue: true,
+  },
+};
+
+export const Invalid: Story = {
+  render: (args) => {
+    const [value, setValue] = useState(args.value || 90);
+    return (
+      <div className="w-80">
+        <RangeField
+          {...args}
+          value={value}
+          onChange={(newValue) => {
+            setValue(newValue);
+            args.onChange(newValue);
+          }}
+        />
+      </div>
+    );
+  },
+  args: {
+    value: 90,
+    min: 0,
+    max: 100,
+    step: 1,
+    isInvalid: true,
+    isDisabled: false,
+    isRequired: false,
+    showValue: true,
+  },
+};

--- a/src/components/form/range-field/range-field.tsx
+++ b/src/components/form/range-field/range-field.tsx
@@ -1,0 +1,68 @@
+import { cn } from '@/utils/cn';
+import { FC } from 'react';
+
+type Props = {
+  id?: string;
+  describedbyId?: string | undefined;
+  isInvalid: boolean;
+  isDisabled: boolean;
+  isRequired: boolean;
+  value: number;
+  onChange: (value: number) => void;
+  step?: number;
+  max?: number;
+  min?: number;
+  showValue?: boolean;
+  unit?: string;
+};
+
+export const RangeField: FC<Props> = ({
+  id,
+  describedbyId,
+  isInvalid,
+  isDisabled,
+  isRequired,
+  value,
+  onChange,
+  step = 1,
+  max = 100,
+  min = 0,
+  showValue = true,
+  unit = '',
+}) => {
+  return (
+    <div className="flex items-center gap-4">
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => {
+          onChange(Number(e.target.value));
+        }}
+        aria-describedby={describedbyId}
+        aria-invalid={isInvalid}
+        aria-valuemin={min}
+        aria-valuemax={max}
+        aria-valuenow={value}
+        required={isRequired}
+        disabled={isDisabled}
+        className={cn(
+          'bg-bg-subtle h-2 flex-1 cursor-pointer appearance-none rounded-lg',
+          'range-slider',
+          'focus:ring-border-info focus:ring-opacity-50 focus:ring-2 focus:outline-none',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          isInvalid && 'ring-border-error ring-2',
+        )}
+      />
+      {showValue && (
+        <span className="text-fg-base w-16 text-sm">
+          {value}
+          {unit}
+        </span>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- input rangeを再利用可能なコンポーネントとして実装
- QRGeneratorで使用されていたinput rangeをコンポーネント化

## Features
- ✅ FormControlと統一されたAPIデザイン
- ✅ カスタマイズ可能なmin/max/step設定
- ✅ 単位表示機能（px, %など）
- ✅ 値の表示/非表示切り替え
- ✅ アクセシビリティ対応（ARIA属性、キーボードナビゲーション）
- ✅ エラー状態とdisabled状態のサポート
- ✅ Storybookストーリー付き（5つのバリエーション）
- ✅ QRGeneratorでRangeFieldを使用するよう更新

## Component API
```tsx
<RangeField
  value={number}
  onChange={(value: number) => void}
  min={number}
  max={number}
  step={number}
  unit={string}
  showValue={boolean}
  isInvalid={boolean}
  isDisabled={boolean}
  isRequired={boolean}
/>
```

## Test plan
- [ ] Storybookでの各バリエーション表示確認
- [ ] QRGeneratorでのサイズ調整機能動作確認
- [ ] アクセシビリティ確認（キーボードナビゲーション、スクリーンリーダー）
- [ ] 値の範囲制限動作確認
- [ ] 単位表示機能確認

🤖 Generated with [Claude Code](https://claude.ai/code)