### PR TITLE
Renovateのminor/patchグループからmonorepoパッケージを除外

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -14,7 +14,7 @@
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch"],
-      "matchPackageNames": ["!/^(pnpm|node)$/", "!/@storybook/", "!/storybook$/"],
+      "matchPackageNames": ["!/^(pnpm|node)$/", "!/@storybook/", "!/storybook$/", "!/react$/", "!/react-dom$/", "!/next$/", "!/vitest$/", "!/@vitejs/", "!/@vitest/"],
       "groupName": "minor and patch dependencies"
     }
   ]


### PR DESCRIPTION
## Summary

Renovateの設定を更新し、minor/patchの自動グループ化からmonorepoパッケージを除外します。

## 変更内容

### 除外対象パッケージの追加
- React関連: `\!/react$/`, `\!/react-dom$/`
- Next.js関連: `\!/next$/`
- Vitest関連: `\!/vitest$/`, `\!/@vitejs/`, `\!/@vitest/`

### 効果
- 各monorepoパッケージの個別レビューが可能
- より慎重なバージョン管理
- 重要なパッケージの変更を見落とすリスクを軽減

## Test plan

- [ ] Renovateの設定が正しく適用されることを確認
- [ ] 次回のRenovate実行時に該当パッケージが個別PRになることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)