### PR TITLE
zodをv4に更新

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "tailwindcss": "4.1.11",
     "uqr": "0.1.2",
     "ws": "8.18.3",
-    "zod": "3.25.74"
+    "zod": "4.0.2"
   },
   "devDependencies": {
     "@eslint/config-inspector": "1.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 15.3.5(@mdx-js/loader@3.1.0(webpack@5.93.0(esbuild@0.25.5)))(@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0))
       '@next/third-parties':
         specifier: 15.3.5
-        version: 15.3.5(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+        version: 15.3.5(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       '@react-email/components':
         specifier: 0.1.1
         version: 0.1.1(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -52,10 +52,10 @@ importers:
         version: 1.35.1
       '@vercel/analytics':
         specifier: 1.5.0
-        version: 1.5.0(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+        version: 1.5.0(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       '@vercel/speed-insights':
         specifier: 1.2.0
-        version: 1.2.0(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+        version: 1.2.0(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       baseline-status:
         specifier: 1.0.11
         version: 1.0.11
@@ -73,7 +73,7 @@ importers:
         version: 12.23.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next:
         specifier: 15.3.5
-        version: 15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       next-themes:
         specifier: 0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -117,8 +117,8 @@ importers:
         specifier: 8.18.3
         version: 8.18.3(bufferutil@4.0.8)
       zod:
-        specifier: 3.25.74
-        version: 3.25.74
+        specifier: 4.0.2
+        version: 4.0.2
     devDependencies:
       '@eslint/config-inspector':
         specifier: 1.1.0
@@ -128,7 +128,7 @@ importers:
         version: 9.30.1
       '@liam-hq/cli':
         specifier: 0.6.0
-        version: 0.6.0(@types/node@22.16.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(bufferutil@4.0.8)(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
+        version: 0.6.0(@types/node@22.16.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(bufferutil@4.0.8)(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)
       '@ls-lint/ls-lint':
         specifier: 2.3.1
         version: 2.3.1
@@ -146,10 +146,10 @@ importers:
         version: 9.0.9(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(vitest@3.2.4)
       '@storybook/nextjs':
         specifier: 9.0.9
-        version: 9.0.9(esbuild@0.25.5)(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(type-fest@4.41.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.93.0(esbuild@0.25.5))
+        version: 9.0.9(esbuild@0.25.5)(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(type-fest@4.41.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.93.0(esbuild@0.25.5))
       '@storybook/nextjs-vite':
         specifier: 9.0.9
-        version: 9.0.9(@babel/core@7.26.10)(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.19.1)(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(typescript@5.8.3)(vite@5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3))
+        version: 9.0.9(@babel/core@7.27.4)(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.19.1)(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(typescript@5.8.3)(vite@5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3))
       '@testing-library/dom':
         specifier: 10.4.0
         version: 10.4.0
@@ -239,10 +239,10 @@ importers:
         version: 0.6.13(prettier@3.6.2)
       react-email:
         specifier: 4.0.17
-        version: 4.0.17(@babel/core@7.26.10)(bufferutil@4.0.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 4.0.17(@babel/core@7.27.4)(bufferutil@4.0.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react-scan:
         specifier: 0.4.3
-        version: 0.4.3(@types/react@19.1.8)(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.19.1)
+        version: 0.4.3(@types/react@19.1.8)(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.19.1)
       sonda:
         specifier: 0.8.2
         version: 0.8.2
@@ -8325,8 +8325,8 @@ packages:
   zod@3.24.4:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
-  zod@3.25.74:
-    resolution: {integrity: sha512-J8poo92VuhKjNknViHRAIuuN6li/EwFbAC8OedzI8uxpEPGiXHGQu9wemIAioIpqgfB4SySaJhdk0mH5Y4ICBg==}
+  zod@4.0.2:
+    resolution: {integrity: sha512-X2niJNY54MGam4L6Kj0AxeedeDIi/E5QFW0On2faSX5J4/pfLk1tW+cRMIMoojnCavn/u5W/kX17e1CSGnKMxA==}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -9942,10 +9942,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@liam-hq/cli@0.6.0(@types/node@22.16.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(bufferutil@4.0.8)(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
+  '@liam-hq/cli@0.6.0(@types/node@22.16.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(bufferutil@4.0.8)(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(typescript@5.8.3)':
     dependencies:
       '@liam-hq/db-structure': 0.3.0(typescript@5.8.3)
-      '@liam-hq/erd-core': 0.4.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(typescript@5.8.3)
+      '@liam-hq/erd-core': 0.4.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(typescript@5.8.3)
       '@prisma/internals': 6.8.2(typescript@5.8.3)
       commander: 13.1.0
       glob: 11.0.3
@@ -9983,7 +9983,7 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@liam-hq/erd-core@0.4.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(typescript@5.8.3)':
+  '@liam-hq/erd-core@0.4.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(typescript@5.8.3)':
     dependencies:
       '@liam-hq/ui': 0.0.16(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))
       '@radix-ui/react-dialog': 1.1.14(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -9992,7 +9992,7 @@ snapshots:
       clsx: 2.1.1
       cmdk: 1.1.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       elkjs: 0.10.0
-      nuqs: 2.4.3(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      nuqs: 2.4.3(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
       pako: 2.1.0
       react: 19.1.0
       ts-pattern: 5.7.1
@@ -10152,9 +10152,9 @@ snapshots:
   '@next/swc-win32-x64-msvc@15.3.5':
     optional: true
 
-  '@next/third-parties@15.3.5(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@next/third-parties@15.3.5(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     dependencies:
-      next: 15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       third-party-capital: 1.0.20
 
@@ -11280,18 +11280,18 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@storybook/nextjs-vite@9.0.9(@babel/core@7.26.10)(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.19.1)(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(typescript@5.8.3)(vite@5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3))':
+  '@storybook/nextjs-vite@9.0.9(@babel/core@7.27.4)(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.19.1)(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(typescript@5.8.3)(vite@5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3))':
     dependencies:
       '@storybook/builder-vite': 9.0.9(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(vite@5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3))
       '@storybook/react': 9.0.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(typescript@5.8.3)
       '@storybook/react-vite': 9.0.9(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.19.1)(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(typescript@5.8.3)(vite@5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3))
-      next: 15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
       storybook: 9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2)
-      styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.27.4)(react@19.1.0)
       vite: 5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3)
-      vite-plugin-storybook-nextjs: 2.0.0(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(vite@5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3))
+      vite-plugin-storybook-nextjs: 2.0.0(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(vite@5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3))
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -11300,7 +11300,7 @@ snapshots:
       - rollup
       - supports-color
 
-  '@storybook/nextjs@9.0.9(esbuild@0.25.5)(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(type-fest@4.41.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.93.0(esbuild@0.25.5))':
+  '@storybook/nextjs@9.0.9(esbuild@0.25.5)(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(type-fest@4.41.0)(typescript@5.8.3)(webpack-hot-middleware@2.26.1)(webpack@5.93.0(esbuild@0.25.5))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-syntax-bigint': 7.8.3(@babel/core@7.26.10)
@@ -11324,7 +11324,7 @@ snapshots:
       css-loader: 6.11.0(webpack@5.93.0(esbuild@0.25.5))
       image-size: 2.0.2
       loader-utils: 3.3.1
-      next: 15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       node-polyfill-webpack-plugin: 2.0.1(webpack@5.93.0(esbuild@0.25.5))
       postcss: 8.5.6
       postcss-loader: 8.1.1(postcss@8.5.6)(typescript@5.8.3)(webpack@5.93.0(esbuild@0.25.5))
@@ -11899,9 +11899,9 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
-  '@vercel/analytics@1.5.0(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@vercel/analytics@1.5.0(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     optionalDependencies:
-      next: 15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
 
   '@vercel/functions@2.2.3': {}
@@ -11915,9 +11915,9 @@ snapshots:
       - utf-8-validate
     optional: true
 
-  '@vercel/speed-insights@1.2.0(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@vercel/speed-insights@1.2.0(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
     optionalDependencies:
-      next: 15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
 
   '@vitejs/plugin-react@4.6.0(vite@5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3))':
@@ -15468,7 +15468,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.3.5
       '@swc/counter': 0.1.3
@@ -15478,7 +15478,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
-      styled-jsx: 5.1.6(@babel/core@7.26.10)(react@19.1.0)
+      styled-jsx: 5.1.6(@babel/core@7.27.4)(react@19.1.0)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.3.5
       '@next/swc-darwin-x64': 15.3.5
@@ -15542,12 +15542,12 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuqs@2.4.3(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0):
+  nuqs@2.4.3(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0):
     dependencies:
       mitt: 3.0.1
       react: 19.1.0
     optionalDependencies:
-      next: 15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
   nwsapi@2.2.16:
     optional: true
@@ -16037,7 +16037,7 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
-  react-email@4.0.17(@babel/core@7.26.10)(bufferutil@4.0.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-email@4.0.17(@babel/core@7.27.4)(bufferutil@4.0.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@babel/parser': 7.27.5
       '@babel/traverse': 7.27.4
@@ -16049,7 +16049,7 @@ snapshots:
       glob: 11.0.2
       log-symbols: 7.0.0
       mime-types: 3.0.1
-      next: 15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       normalize-path: 3.0.0
       ora: 8.2.0
       socket.io: 4.8.1(bufferutil@4.0.8)
@@ -16132,7 +16132,7 @@ snapshots:
       react: 18.3.1
       react-dom: 19.1.0(react@19.1.0)
 
-  react-scan@0.4.3(@types/react@19.1.8)(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.19.1):
+  react-scan@0.4.3(@types/react@19.1.8)(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(rollup@4.19.1):
     dependencies:
       '@babel/core': 7.27.4
       '@babel/generator': 7.27.5
@@ -16154,7 +16154,7 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
       tsx: 4.19.3
     optionalDependencies:
-      next: 15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       unplugin: 2.1.0
     transitivePeerDependencies:
       - '@types/react'
@@ -16902,6 +16902,13 @@ snapshots:
     optionalDependencies:
       '@babel/core': 7.26.10
 
+  styled-jsx@5.1.6(@babel/core@7.27.4)(react@19.1.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.1.0
+    optionalDependencies:
+      '@babel/core': 7.27.4
+
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -17345,13 +17352,13 @@ snapshots:
       - supports-color
       - terser
 
-  vite-plugin-storybook-nextjs@2.0.0(next@15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(vite@5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3)):
+  vite-plugin-storybook-nextjs@2.0.0(next@15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(storybook@9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2))(vite@5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3)):
     dependencies:
       '@next/env': 15.3.5
       image-size: 2.0.2
       magic-string: 0.30.17
       module-alias: 2.2.3
-      next: 15.3.5(@babel/core@7.26.10)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.3.5(@babel/core@7.27.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       storybook: 9.0.9(@testing-library/dom@10.4.0)(bufferutil@4.0.8)(prettier@3.6.2)
       ts-dedent: 2.2.0
       vite: 5.3.5(@types/node@22.16.0)(lightningcss@1.30.1)(terser@5.31.3)
@@ -17640,7 +17647,7 @@ snapshots:
 
   zod@3.24.4: {}
 
-  zod@3.25.74: {}
+  zod@4.0.2: {}
 
   zustand@4.5.7(@types/react@19.1.8)(react@19.1.0):
     dependencies:

--- a/src/app/_api/contact-to-me.ts
+++ b/src/app/_api/contact-to-me.ts
@@ -3,7 +3,7 @@
 import { db } from '#database/db';
 import { comments } from '@/database/schema/comments';
 import { ratelimit } from '@k8o/helpers/ratelimit';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 import '@/libs/zod';
 
 const contactSchema = z.object({

--- a/src/app/api/blog/views/route.ts
+++ b/src/app/api/blog/views/route.ts
@@ -1,6 +1,6 @@
 import { getBlogContent } from '#api/blog';
 import { incrementBlogView } from '@/services/blogs/view';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export async function POST(req: Request): Promise<Response> {
   const schema = z.object({

--- a/src/app/sql-table-builder/_utils/statement.ts
+++ b/src/app/sql-table-builder/_utils/statement.ts
@@ -4,7 +4,7 @@ import {
   Restriction,
 } from '../_types/restriction';
 import { InvalidTable, Table } from '../_types/table';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 type Result =
   | {

--- a/src/libs/zod.ts
+++ b/src/libs/zod.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod/v4';
-import ja from 'zod/v4/locales/ja.js';
+import { z } from 'zod';
 
-z.config(ja());
+z.config(z.locales.ja());

--- a/src/services/subscriptions/subscribe.ts
+++ b/src/services/subscriptions/subscribe.ts
@@ -2,7 +2,7 @@ import { Result } from '../type';
 import { db } from '#database/db';
 import { subscribers } from '@/database/schema/subscribers';
 import { sendVerificationEmail } from '@/services/subscriptions/verify';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const subscribe = async (
   email: string,

--- a/src/services/subscriptions/verify.ts
+++ b/src/services/subscriptions/verify.ts
@@ -5,7 +5,7 @@ import VerifyEmail from '@/emails/verify-email';
 import { resend } from '@/services/email';
 import { compareDate } from '@k8o/helpers/date';
 import { eq } from 'drizzle-orm';
-import { z } from 'zod/v4';
+import { z } from 'zod';
 
 export const sendVerificationEmail = async (
   email: string,


### PR DESCRIPTION
## Summary
- zodをv3.25.74からv4.0.2に更新
- zodの古いimportパス（`zod/v4`）を新しいパス（`zod`）に変更
- zodの設定方法をv4のAPIに合わせて更新（`z.config(z.locales.ja())`）

## Test plan
- [ ] テストが通ることを確認
- [ ] リントが通ることを確認
- [ ] 型チェックが通ることを確認
- [ ] 開発サーバーが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)