### PR TITLE
fix: renovate.json5の全角文字を半角文字に修正

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -15,15 +15,15 @@
     {
       "matchUpdateTypes": ["minor", "patch"],
       "matchPackageNames": [
-　　　　  "!/^(pnpm|node)$/",
-　　　　  "!/@storybook/",
-　　　　  "!/storybook$/",
-　　　　  "!/react$/",
-　　　　  "!/react-dom$/",
-　　　　  "!/next$/",
-　　　　  "!/vitest$/",
-　　　　  "!/@vitest/",
-        "@​typescript/native-preview",
+        "!/^(pnpm|node)$/",
+        "!/@storybook/",
+        "!/storybook$/",
+        "!/react$/",
+        "!/react-dom$/",
+        "!/next$/",
+        "!/vitest$/",
+        "!/@vitest/",
+        "@typescript/native-preview",
       ],
       "groupName": "minor and patch dependencies"
     }


### PR DESCRIPTION
renovate.json5ファイルの全角文字問題を修正しました。

## 修正内容
- 全角スペース（　）を通常のスペースに変更
- 全角アットマーク（＠）を通常のアットマーク（@）に変更
- インデントを適切に修正

Closes #905

Generated with [Claude Code](https://claude.ai/code)