### PR TITLE
LLMSリンクのprefetchを無効化

### DIFF
--- a/core/src/app/_components/global-layout/llm-link/llm-link.tsx
+++ b/core/src/app/_components/global-layout/llm-link/llm-link.tsx
@@ -4,7 +4,7 @@ import { FC } from 'react';
 
 export const LlmLink: FC = () => {
   return (
-    <IconLink href="/llms.txt" label="LLMS">
+    <IconLink href="/llms.txt" label="LLMS" prefetch={false}>
       <AIIcon size="lg" />
     </IconLink>
   );

--- a/core/src/components/icon-link/icon-link.tsx
+++ b/core/src/components/icon-link/icon-link.tsx
@@ -10,6 +10,7 @@ type IconLinkProps = PropsWithChildren<{
   label?: string;
   href: string;
   openInNewTab?: boolean;
+  prefetch?: boolean | 'auto';
 }>;
 
 export const IconLink: FC<IconLinkProps> = ({
@@ -19,6 +20,7 @@ export const IconLink: FC<IconLinkProps> = ({
   href,
   children,
   openInNewTab = false,
+  prefetch = 'auto',
 }) => {
   return isInternalRoute<Route>(href) && !openInNewTab ? (
     <Link
@@ -31,6 +33,7 @@ export const IconLink: FC<IconLinkProps> = ({
         size === 'lg' && 'p-3',
       )}
       href={href}
+      prefetch={prefetch}
     >
       <span className="sr-only">{label}</span>
       {children}


### PR DESCRIPTION
## Summary

- LLMSリンクのprefetchを無効化
- IconLinkコンポーネントにprefetchプロパティを追加
- /llms.txtへのリンクでprefetch={false}を設定

## Test plan

- [ ] LLMSリンクが正常に動作することを確認
- [ ] prefetchが無効化されていることを確認
- [ ] 他のIconLinkの動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)