### PR TITLE
refactor: Move internal packages to root workspace

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -53,8 +53,6 @@
     "preview:dist": "pnpm dlx http-server dist"
   },
   "dependencies": {
-    "@k8o/helpers": "workspace:*",
-    "@k8o/hooks": "workspace:*",
     "@floating-ui/react": "0.27.13",
     "@mdx-js/loader": "3.1.0",
     "@mdx-js/react": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "@vitest/browser": "3.2.4",
     "@vitest/coverage-istanbul": "3.2.4",
     "@vitest/ui": "3.2.4",
-    "chromatic": "13.1.2",
     "eslint": "9.31.0",
     "eslint-config-next": "15.3.5",
     "eslint-config-prettier": "10.1.5",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.1.0",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": "22.17.0"
+  },
+  "packageManager": "pnpm@10.13.1",
   "scripts": {
     "dev": "turbo dev",
     "build": "turbo build",
@@ -59,9 +63,5 @@
     "typescript": "5.8.3",
     "typescript-eslint": "8.36.0",
     "vitest": "3.2.4"
-  },
-  "engines": {
-    "node": "22.17.0"
-  },
-  "packageManager": "pnpm@10.13.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "install-playwright": "playwright install --with-deps"
   },
   "dependencies": {
+    "@k8o/helpers": "workspace:*",
+    "@k8o/hooks": "workspace:*",
     "@upstash/ratelimit": "2.0.5",
     "@upstash/redis": "1.35.1",
     "react": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@k8o/helpers':
+        specifier: workspace:*
+        version: link:packages/helpers
+      '@k8o/hooks':
+        specifier: workspace:*
+        version: link:packages/hooks
       '@upstash/ratelimit':
         specifier: 2.0.5
         version: 2.0.5(@upstash/redis@1.35.1)
@@ -123,12 +129,6 @@ importers:
       '@floating-ui/react':
         specifier: 0.27.13
         version: 0.27.13(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@k8o/helpers':
-        specifier: workspace:*
-        version: link:../packages/helpers
-      '@k8o/hooks':
-        specifier: workspace:*
-        version: link:../packages/hooks
       '@mdx-js/loader':
         specifier: 3.1.0
         version: 3.1.0(webpack@5.93.0(esbuild@0.25.5))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,9 +69,6 @@ importers:
       '@vitest/ui':
         specifier: 3.2.4
         version: 3.2.4(vitest@3.2.4)
-      chromatic:
-        specifier: 13.1.2
-        version: 13.1.2
       eslint:
         specifier: 9.31.0
         version: 9.31.0(jiti@2.4.2)


### PR DESCRIPTION
## Summary
- Move @k8o/helpers and @k8o/hooks packages from core dependencies to root workspace dependencies
- Remove chromatic from core package since it's not needed there
- Reorganize package structure for better workspace management

## Test plan
- [x] Verify build passes
- [x] Verify all imports still work correctly
- [x] Check that development servers start properly

🤖 Generated with [Claude Code](https://claude.ai/code)