### PR TITLE
typedRoutesをやめる

### DIFF
--- a/core/next.config.ts
+++ b/core/next.config.ts
@@ -19,7 +19,6 @@ const nextConfig: NextConfig = {
     },
   },
   experimental: {
-    typedRoutes: true,
     viewTransition: true,
   },
   productionBrowserSourceMaps: process.env.ANALYZE === 'true',

--- a/core/src/app/_components/app-card/app-card.tsx
+++ b/core/src/app/_components/app-card/app-card.tsx
@@ -1,6 +1,5 @@
 import { Heading } from '../../../components/heading';
 import { InteractiveCard } from '@/components/card';
-import { Route } from 'next';
 import Link from 'next/link';
 import { ReactNode } from 'react';
 
@@ -10,7 +9,7 @@ export const AppCard = ({
   title,
   description,
 }: {
-  link: Route;
+  link: string;
   symbol: ReactNode;
   title: string;
   description: string;

--- a/core/src/app/blog/_components/blog-card/blog-card.tsx
+++ b/core/src/app/blog/_components/blog-card/blog-card.tsx
@@ -8,7 +8,6 @@ import {
 } from '@/components/icons';
 import { TextTag } from '@/components/text-tag';
 import { formatDate } from '@k8o/helpers/date';
-import { Route } from 'next';
 import Link from 'next/link';
 import { FC } from 'react';
 
@@ -31,7 +30,7 @@ export const BlogCard: FC<BlogCardProps> = ({
 }) => {
   return (
     <InteractiveCard>
-      <Link href={`/blog/${slug}` as Route} className="block h-full">
+      <Link href={`/blog/${slug}`} className="block h-full">
         <div className="flex h-full flex-col justify-between gap-4 p-4">
           <div className="flex flex-col gap-1">
             <ViewTransition name={`title-${slug}`}>

--- a/core/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/core/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -17,7 +17,6 @@ import { ScrollLinked } from '@/components/scroll-linked';
 import { Separator } from '@/components/separator';
 import { TextTag } from '@/components/text-tag';
 import { formatDate } from '@k8o/helpers/date';
-import { Route } from 'next';
 import { FC, ReactNode, Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
@@ -99,7 +98,7 @@ export const BlogLayout: FC<{
                     <TextTag
                       key={tag.id}
                       text={tag.name}
-                      href={`/tags/${tag.id.toString()}` as Route}
+                      href={`/tags/${tag.id.toString()}`}
                     />
                   );
                 })}

--- a/core/src/app/blog/_components/blog-layout/recommend/recommend.tsx
+++ b/core/src/app/blog/_components/blog-layout/recommend/recommend.tsx
@@ -4,7 +4,6 @@ import { Heading } from '@/components/heading';
 import { PublishDateIcon, TagIcon } from '@/components/icons';
 import { TextTag } from '@/components/text-tag';
 import { formatDate } from '@k8o/helpers/date';
-import { Route } from 'next';
 import Link from 'next/link';
 import { FC } from 'react';
 
@@ -20,7 +19,7 @@ export const Recommend: FC<{ slug: string }> = async ({ slug }) => {
       <div className="grid-cols-auto-fit-80 grid gap-4">
         {blogs.map((blog) => (
           <InteractiveCard key={blog.id}>
-            <Link href={`/blog/${blog.slug}` as Route}>
+            <Link href={`/blog/${blog.slug}`}>
               <div className="flex flex-col gap-4 p-4">
                 <Heading type="h4">{blog.title}</Heading>
                 <div className="flex flex-col flex-wrap gap-2">

--- a/core/src/app/tags/_components/tag-card/tag-card.tsx
+++ b/core/src/app/tags/_components/tag-card/tag-card.tsx
@@ -2,13 +2,12 @@ import { InteractiveCard } from '@/components/card';
 import { ChevronIcon } from '@/components/icons';
 import { Separator } from '@/components/separator';
 import { cn } from '@k8o/helpers/cn';
-import { Route } from 'next';
 import Link from 'next/link';
 import { FC } from 'react';
 
 export const TagCard: FC<{
   title: string;
-  href: Route;
+  href: string;
   count?: number;
   label: string;
   linkLabel: string;

--- a/core/src/app/tags/_components/tag-content/tag-content.tsx
+++ b/core/src/app/tags/_components/tag-content/tag-content.tsx
@@ -1,7 +1,6 @@
 import { TagCard } from '../tag-card';
 import { Heading } from '@/components/heading';
 import { TagIcon } from '@/components/icons';
-import { Route } from 'next';
 import Link from 'next/link';
 import { FC } from 'react';
 
@@ -47,7 +46,7 @@ export const TagContent: FC<{
                 <TagCard
                   key={service.id}
                   title={service.title}
-                  href={`/${service.slug}` as Route}
+                  href={`/${service.slug}`}
                   label="サービスを利用する"
                   linkLabel={`「${service.title}」のサービスを利用する`}
                 />
@@ -65,7 +64,7 @@ export const TagContent: FC<{
                 <TagCard
                   key={blog.id}
                   title={blog.title}
-                  href={`/blog/${blog.slug}` as Route}
+                  href={`/blog/${blog.slug}`}
                   label="ブログを読む"
                   linkLabel={`「${blog.title}」のブログを読む`}
                 />

--- a/core/src/app/tags/page.tsx
+++ b/core/src/app/tags/page.tsx
@@ -1,6 +1,5 @@
 import { TagCard } from './_components/tag-card';
 import { getTags } from '@/services/tags/tags';
-import { Route } from 'next';
 import { unstable_cache as cache } from 'next/cache';
 
 export default async function Page() {
@@ -15,7 +14,7 @@ export default async function Page() {
           <TagCard
             key={tag.id}
             title={tag.name}
-            href={`/tags/${tag.id.toString()}` as Route}
+            href={`/tags/${tag.id.toString()}`}
             count={tag.blogCount + tag.serviceCount + tag.talkCount}
             label="コンテンツを見る"
             linkLabel={`「${tag.name}」に関連するコンテンツを表示する`}

--- a/core/src/app/talks/_components/talk-card/talk-card.tsx
+++ b/core/src/app/talks/_components/talk-card/talk-card.tsx
@@ -10,7 +10,6 @@ import {
 import { LinkButton } from '@/components/link-button';
 import { TextTag } from '@/components/text-tag';
 import { formatDate } from '@k8o/helpers/date';
-import { Route } from 'next';
 import { FC } from 'react';
 
 export const TalkCard: FC<{
@@ -70,7 +69,7 @@ export const TalkCard: FC<{
               key={tag.id}
               size="sm"
               text={tag.name}
-              href={`/tags/${tag.id.toString()}` as Route}
+              href={`/tags/${tag.id.toString()}`}
             />
           ))}
         </div>
@@ -86,7 +85,7 @@ export const TalkCard: FC<{
           <LinkButton
             size="sm"
             startIcon={<BlogIcon size="sm" />}
-            href={`/blog/${blog.slug}` as Route}
+            href={`/blog/${blog.slug}`}
           >
             ブログで解説を読む
           </LinkButton>

--- a/core/src/components/anchor/anchor.tsx
+++ b/core/src/components/anchor/anchor.tsx
@@ -1,6 +1,5 @@
 import { ExternalLinkIcon } from '../icons';
 import { isInternalRoute } from '@k8o/helpers/is-internal-route';
-import { Route } from 'next';
 import Link from 'next/link';
 import { ReactNode } from 'react';
 
@@ -13,7 +12,7 @@ export const Anchor = ({
   children: ReactNode;
   openInNewTab?: boolean;
 }) => {
-  return isInternalRoute<Route>(href) && !openInNewTab ? (
+  return isInternalRoute(href) && !openInNewTab ? (
     <Link
       href={href}
       className="text-fg-info cursor-pointer hover:underline"

--- a/core/src/components/breadcrumb/breadcrumb.tsx
+++ b/core/src/components/breadcrumb/breadcrumb.tsx
@@ -1,6 +1,5 @@
 import { ChevronIcon } from '../icons';
 import { cn } from '@k8o/helpers/cn';
-import { Route } from 'next';
 import Link from 'next/link';
 import { FC, PropsWithChildren } from 'react';
 
@@ -38,7 +37,7 @@ const Separator: FC = () => {
 };
 
 const _Link: FC<
-  PropsWithChildren<{ href: Route; current?: boolean }>
+  PropsWithChildren<{ href: string; current?: boolean }>
 > = ({ href, current = false, children }) => {
   return current ? (
     <span className="text-fg-base">{children}</span>

--- a/core/src/components/icon-link/icon-link.tsx
+++ b/core/src/components/icon-link/icon-link.tsx
@@ -1,6 +1,5 @@
 import { cn } from '@k8o/helpers/cn';
 import { isInternalRoute } from '@k8o/helpers/is-internal-route';
-import { Route } from 'next';
 import Link from 'next/link';
 import { FC, PropsWithChildren } from 'react';
 
@@ -22,7 +21,7 @@ export const IconLink: FC<IconLinkProps> = ({
   openInNewTab = false,
   ...linkProps
 }) => {
-  return isInternalRoute<Route>(href) && !openInNewTab ? (
+  return isInternalRoute(href) && !openInNewTab ? (
     <Link
       className={cn(
         'hover:bg-bg-subtle focus-visible:ring-border-info active:bg-bg-emphasize block rounded-full focus-visible:ring-2',

--- a/core/src/components/link-button/link-button.tsx
+++ b/core/src/components/link-button/link-button.tsx
@@ -1,6 +1,5 @@
 import { cn } from '@k8o/helpers/cn';
 import { isInternalRoute } from '@k8o/helpers/is-internal-route';
-import { Route } from 'next';
 import Link from 'next/link';
 import { FC, ReactNode } from 'react';
 
@@ -41,7 +40,7 @@ export const LinkButton: FC<{
     Boolean(endIcon) && 'justify-between',
     active && 'text-fg-info hover:text-fg-info active:text-fg-info',
   );
-  return isInternalRoute<Route>(href) && !openInNewTab ? (
+  return isInternalRoute(href) && !openInNewTab ? (
     <Link className={className} aria-label={children} href={href}>
       {startIcon}
       {children}

--- a/core/src/components/text-tag/text-tag.tsx
+++ b/core/src/components/text-tag/text-tag.tsx
@@ -1,5 +1,4 @@
 import { cn } from '@k8o/helpers/cn';
-import { Route } from 'next';
 import Link from 'next/link';
 
 export const TextTag = ({
@@ -9,7 +8,7 @@ export const TextTag = ({
 }: {
   text: string;
   size?: 'sm' | 'md';
-  href?: Route;
+  href?: string;
 }) => {
   if (href) {
     return (

--- a/packages/helpers/src/is-internal-route/index.ts
+++ b/packages/helpers/src/is-internal-route/index.ts
@@ -1,8 +1,5 @@
-// NOTE:型推論は厳密ではないので注意が必要
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
-export const isInternalRoute = <Route extends string>(
-  href: string,
-): href is Route => !href.startsWith('http');
+export const isInternalRoute = (href: string) =>
+  !href.startsWith('http');
 
 if (import.meta.vitest) {
   it('httpから始まるhrefはexternalなものとして判定する', () => {


### PR DESCRIPTION
使えない機能がいくつかあるので廃止

turbopackが使えるようになったが、turbopackを使うとsubpath modulesを解決してくれないのでturbopackはお預け