### PR TITLE
Storybookのテーマ切り替えとプレビュー改善

### DIFF
--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -39,7 +39,12 @@ const preview: Preview = {
           : ('light' as 'light' | 'dark');
       return (
         <ComponentProvider>
-          <div className={cn('min-h-svh p-6', theme)}>
+          <div
+            className={cn(
+              'text-fg-base tracking-none bg-bg-base min-h-svh p-6 font-medium antialiased',
+              theme,
+            )}
+          >
             <Story />
           </div>
         </ComponentProvider>

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -3,6 +3,28 @@ import { ComponentProvider } from '../src/providers';
 import { cn } from '@k8o/helpers/cn';
 
 import '../src/styles.css';
+import Script from 'next/script';
+import { FC, memo, useState } from 'react';
+
+const ApplayThemeByStorybook: FC<{ theme: 'light' | 'dark' }> = memo(
+  ({ theme }) => {
+    const [prevTheme, setPrevTheme] = useState<'light' | 'dark'>(
+      theme,
+    );
+
+    if (prevTheme !== theme) {
+      document.documentElement.classList.remove(
+        prevTheme === 'dark' ? 'dark' : 'light',
+      );
+      document.documentElement.classList.add(
+        theme === 'dark' ? 'dark' : 'light',
+      );
+      setPrevTheme(theme);
+    }
+
+    return null;
+  },
+);
 
 const preview: Preview = {
   globalTypes: {
@@ -39,12 +61,13 @@ const preview: Preview = {
           : ('light' as 'light' | 'dark');
       return (
         <ComponentProvider>
-          <div
-            className={cn(
-              'text-fg-base tracking-none bg-bg-base min-h-svh p-6 font-medium antialiased',
-              theme,
-            )}
-          >
+          <Script>
+            document.body.classList.add('text-fg-base',
+            'tracking-none', 'bg-bg-base', 'font-medium',
+            'antialiased')
+          </Script>
+          <ApplayThemeByStorybook theme={theme} />
+          <div className="min-h-svh p-6">
             <Story />
           </div>
         </ComponentProvider>

--- a/packages/components/src/code/code.stories.tsx
+++ b/packages/components/src/code/code.stories.tsx
@@ -7,7 +7,6 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
-  tags: ['autodocs'],
 } satisfies Meta<typeof Code>;
 
 export default meta;

--- a/packages/components/src/dialog/dialog.stories.tsx
+++ b/packages/components/src/dialog/dialog.stories.tsx
@@ -54,7 +54,7 @@ export const PopoverDialog: Story = {
 
 export const ModalDialog: Story = {
   render: () => (
-    <Modal onClose={fn}>
+    <Modal defaultOpen>
       <Dialog.Root>
         <Dialog.Header title="モーダル" onClose={fn} />
         <Dialog.Content>こんにちは</Dialog.Content>

--- a/packages/components/src/modal/modal.stories.tsx
+++ b/packages/components/src/modal/modal.stories.tsx
@@ -13,6 +13,7 @@ type Story = StoryObj<typeof Modal>;
 
 export const Default: Story = {
   args: {
+    defaultOpen: true,
     children: (
       <Dialog.Root>
         <Dialog.Header title="Hello" onClose={fn()} />

--- a/packages/components/src/styles.css
+++ b/packages/components/src/styles.css
@@ -9,6 +9,7 @@
   dialog,
   [popover] {
     overscroll-behavior-block: contain;
+    color: var(--color-fg-base);
   }
 
   body {


### PR DESCRIPTION
## Summary
- Storybookでテーマ（light/dark）切り替えができるように改善
- プレビューに基本スタイル（text-fg-base, bg-bg-base等）を追加
- モーダルコンポーネントのストーリーでdefaultOpenを設定

## Test plan
- [ ] Storybookを起動してテーマ切り替えが正常に動作することを確認
- [ ] 各コンポーネントのストーリーが正しく表示されることを確認
- [ ] ダークテーマとライトテーマでの見た目が適切であることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)