### PR TITLE
fix: disable flaky color-contrast a11y rule in Storybook

### DIFF
--- a/core/.storybook/preview.tsx
+++ b/core/.storybook/preview.tsx
@@ -59,6 +59,12 @@ const preview: Preview = {
     },
     a11y: {
       test: 'error',
+      options: {
+        rules: {
+          // コントラスト比がCIでFlakyな働きをするのでfalse
+          'color-contrast': { enabled: false },
+        },
+      },
     },
   },
   decorators: [

--- a/core/src/app/design-system/_components/color/color.stories.tsx
+++ b/core/src/app/design-system/_components/color/color.stories.tsx
@@ -11,16 +11,6 @@ const meta: Meta<typeof Color> = {
       </div>
     ),
   ],
-  parameters: {
-    a11y: {
-      options: {
-        rules: {
-          // コントラスト比が合わない組み合わせもあえて表示しているので無視させる
-          'color-contrast': { enabled: false },
-        },
-      },
-    },
-  },
 };
 
 export default meta;

--- a/packages/components/.storybook/preview.tsx
+++ b/packages/components/.storybook/preview.tsx
@@ -28,6 +28,13 @@ const preview: Preview = {
     },
     a11y: {
       test: 'error',
+      options: {
+        rules: {
+          // コントラスト比がCIでFlakyな働きをするのでfalse
+          // 色の設計の段階コントラストセーフなペアを選択しているのでそれを信頼する
+          'color-contrast': { enabled: false },
+        },
+      },
     },
   },
   decorators: [


### PR DESCRIPTION
## Summary
- Storybookのcolor-contrastアクセシビリティルールをグローバルに無効化
- CIでのFlaky動作を防ぎ、デザインシステムの色ペアリングを信頼
- `color.stories.tsx`から冗長なルール設定を削除

## Test plan
- [ ] Storybookが正常に起動することを確認
- [ ] A11yテストでcolor-contrastエラーが発生しないことを確認
- [ ] CIパイプラインが安定して通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)