### PR TITLE
feat: StorybookのURLをChromaticの新しいURLに置き換え

### DIFF
--- a/core/src/app/_components/comming-soon/comming-soon.stories.tsx
+++ b/core/src/app/_components/comming-soon/comming-soon.stories.tsx
@@ -17,7 +17,7 @@ export const HasDescription: Story = {
     description: (
       <p className="text-fg-mute text-sm">
         コンポーネントの一覧を管理する
-        <Anchor href="https://main--687a213c85e2e4589d8db1bb.chromatic.com">
+        <Anchor href="https://687a213c85e2e4589d8db1bb-mwvjqfhwpz.chromatic.com/">
           Storybook
         </Anchor>
         は閲覧できます。

--- a/core/src/app/design-system/_components/components/components.tsx
+++ b/core/src/app/design-system/_components/components/components.tsx
@@ -6,11 +6,11 @@ export const Components: FC = () => {
     <section className="flex h-full flex-col gap-4">
       <iframe
         className="h-full"
-        src="https://main--687a213c85e2e4589d8db1bb.chromatic.com"
+        src="https://687a213c85e2e4589d8db1bb-mwvjqfhwpz.chromatic.com/"
         title="Chromaticでビルドしたコンポーネントの一覧"
       />
       <div className="text-end">
-        <Anchor href="https://main--687a213c85e2e4589d8db1bb.chromatic.com/">
+        <Anchor href="https://687a213c85e2e4589d8db1bb-mwvjqfhwpz.chromatic.com/">
           <span className="text-sm">
             別のウィンドウでStorybookを開く
           </span>


### PR DESCRIPTION
## 概要
コードベース内のStorybookのURLを新しいChromaticのURLに置き換えました。

## 変更内容
- `https://main--687a213c85e2e4589d8db1bb.chromatic.com` → `https://687a213c85e2e4589d8db1bb-mwvjqfhwpz.chromatic.com/`

## 対象ファイル
- `core/src/app/design-system/_components/components/components.tsx` (2箇所)
- `core/src/app/_components/comming-soon/comming-soon.stories.tsx` (1箇所)

Closed #933

🤖 Generated with [Claude Code](https://claude.ai/code)