### PR TITLE
Update Claude Code workflows to use v1 action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -24,17 +24,13 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
-          allowed_tools: >-
-            mcp__github__create_pending_pull_request_review,
-            mcp__github__add_pull_request_review_comment_to_pending_review,
-            mcp__github__submit_pending_pull_request_review,
-            mcp__github__get_pull_request_diff,
-            mcp__github__get_pull_request_comments
-          direct_prompt: |
+          claude_args: |
+            --allowed_tools mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_comments
+          prompt: |
             このPRをGitHubのレビュー機能を使ってフィードバックを提供してください。
 
             フィードバックは以下の手順に従ってください。

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,9 +32,9 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@beta
+        uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          custom_instructions: |
-            日本語で応答してください。
-          timeout_minutes: '20'
+          claude_args: |
+            --system-prompt "日本語で応答してください。"
+            --max-turns 20


### PR DESCRIPTION
## Summary
- Migrate from beta to v1 version of anthropics/claude-code-action
- Update parameter format to use new claude_args structure
- Maintain existing functionality for both PR reviews and general Claude Code usage

## Changes
- **claude-code-review.yml**: Updated action version, replaced `direct_prompt` with `prompt`, converted tool allowlist to `claude_args` format
- **claude.yml**: Updated action version, replaced `custom_instructions` with `--system-prompt`, replaced `timeout_minutes` with `--max-turns`

## Test plan
- [x] Verify workflow syntax is correct
- [ ] Test PR review functionality with the new action version
- [ ] Test general Claude Code functionality with the new parameters

🤖 Generated with [Claude Code](https://claude.ai/code)