### PR TITLE
ブログ記事の訂正: Baseline対応状況の修正

### DIFF
--- a/core/src/app/blog/(articles)/highlight/page.mdx
+++ b/core/src/app/blog/(articles)/highlight/page.mdx
@@ -2,7 +2,7 @@
 title: CSS Custom Highlight APIで任意の範囲のテキストをハイライトする
 description: Firefox 140でCSS Custom Highlight APIがサポートされ、DOMを変更せずに任意のテキスト範囲をハイライトできるようになりました。JavaScriptでRangeオブジェクトを定義し、Highlightオブジェクトとして登録後、CSSの::highlight擬似要素でスタイリングしてハイライトを作ります。
 createdAt: 2025-06-29 00:00:00.000000+09
-updatedAt: 2025-09-15 00:09:00.000000+09
+updatedAt: 2025-09-15 09:00:00.000000+09
 ---
 
 import { Alert } from '@k8o/arte-odyssey/alert';

--- a/core/src/app/blog/(articles)/highlight/page.mdx
+++ b/core/src/app/blog/(articles)/highlight/page.mdx
@@ -2,9 +2,10 @@
 title: CSS Custom Highlight APIで任意の範囲のテキストをハイライトする
 description: Firefox 140でCSS Custom Highlight APIがサポートされ、DOMを変更せずに任意のテキスト範囲をハイライトできるようになりました。JavaScriptでRangeオブジェクトを定義し、Highlightオブジェクトとして登録後、CSSの::highlight擬似要素でスタイリングしてハイライトを作ります。
 createdAt: 2025-06-29 00:00:00.000000+09
-updatedAt: 2025-06-29 00:00:00.000000+09
+updatedAt: 2025-09-15 00:00:00.000000+09
 ---
 
+import { Alert } from '@k8o/arte-odyssey/alert';
 import { BaselineStatus } from '@k8o/arte-odyssey/baseline-status';
 import { HighlightBasicDemo as Example1 } from '@/app/_components/playgrounds/highlight';
 import { HighlightPriorityDemo as Example2 } from '@/app/_components/playgrounds/highlight';
@@ -16,6 +17,11 @@ import { Playground } from '@/app/_components/playgrounds';
 <BaselineStatus featureId="highlight" />
 
 ## はじめに
+
+<Alert
+  status="warning"
+  message="【訂正】この記事で紹介する機能がFirefox 140のリリースによってBaseline入りしたような記述をしていますが、実際には一部の機能が導入されておらずBaseline 2025にはなっていませんでした。"
+/>
 
 Firefox 140がリリースされ、`CSS Custom Highlight API`がサポートされました。この新機能により、JavaScriptで定義した任意のテキスト範囲をCSSでスタイリングできるようになります。
 

--- a/core/src/app/blog/(articles)/highlight/page.mdx
+++ b/core/src/app/blog/(articles)/highlight/page.mdx
@@ -2,7 +2,7 @@
 title: CSS Custom Highlight APIで任意の範囲のテキストをハイライトする
 description: Firefox 140でCSS Custom Highlight APIがサポートされ、DOMを変更せずに任意のテキスト範囲をハイライトできるようになりました。JavaScriptでRangeオブジェクトを定義し、Highlightオブジェクトとして登録後、CSSの::highlight擬似要素でスタイリングしてハイライトを作ります。
 createdAt: 2025-06-29 00:00:00.000000+09
-updatedAt: 2025-09-15 00:00:00.000000+09
+updatedAt: 2025-09-15 00:09:00.000000+09
 ---
 
 import { Alert } from '@k8o/arte-odyssey/alert';

--- a/core/src/app/blog/(articles)/spelling-grammar-error/page.mdx
+++ b/core/src/app/blog/(articles)/spelling-grammar-error/page.mdx
@@ -2,9 +2,10 @@
 title: スペルミス・文法エラーに対してスタイルを設定する::spelling-errorと::grammar-error
 description:
 createdAt: 2025-06-29 00:00:00.000000+09
-updatedAt: 2025-06-29 00:00:00.000000+09
+updatedAt: 2025-09-15 00:00:00.000000+09
 ---
 
+import { Alert } from '@k8o/arte-odyssey/alert';
 import { BaselineStatus } from '@k8o/arte-odyssey/baseline-status';
 import { SpellingGrammarErrorDemo as Example1 } from '@/app/_components/playgrounds/spelling-grammar-error';
 import { Playground } from '@/app/_components/playgrounds';
@@ -15,7 +16,11 @@ import { Playground } from '@/app/_components/playgrounds';
 
 ## はじめに
 
-Firefox 140で`::spelling-error`と`::grammar-error`のCSS擬似要素がサポートされました。これにより、全てのコアブラウザでこれらの擬似要素が利用可能になりました。
+<Alert
+  status="warning"
+  message="【連絡】この記事では以前、紹介する機能がFirefox 140のリリースによってBaseline入りしたと記述していましたが、実際には導入されていませんでしたのでその部分を修正しています。"
+/>
+
 これらの擬似要素は、スペルミスや文法エラーとしてフラグ付けされたテキストに対するスタイルを定義するために使用されます。
 
 ## ::spelling-error

--- a/core/src/app/blog/(articles)/spelling-grammar-error/page.mdx
+++ b/core/src/app/blog/(articles)/spelling-grammar-error/page.mdx
@@ -2,7 +2,7 @@
 title: スペルミス・文法エラーに対してスタイルを設定する::spelling-errorと::grammar-error
 description:
 createdAt: 2025-06-29 00:00:00.000000+09
-updatedAt: 2025-09-15 00:00:00.000000+09
+updatedAt: 2025-09-15 09:00:00.000000+09
 ---
 
 import { Alert } from '@k8o/arte-odyssey/alert';
@@ -21,7 +21,7 @@ import { Playground } from '@/app/_components/playgrounds';
   message="【連絡】この記事では以前、紹介する機能がFirefox 140のリリースによってBaseline入りしたと記述していましたが、実際には導入されていませんでしたのでその部分を修正しています。"
 />
 
-これらの擬似要素は、スペルミスや文法エラーとしてフラグ付けされたテキストに対するスタイルを定義するために使用されます。
+擬似要素である`::spelling-error`と`::grammar-error`は、スペルミスや文法エラーとしてフラグ付けされたテキストに対するスタイルを定義するために使用されます。
 
 ## ::spelling-error
 


### PR DESCRIPTION
## Summary
- highlight記事とspelling-grammar-error記事にアラートを追加
- Firefox 140でBaseline入りしたという誤った記述を訂正
- 実際にはまだBaseline 2025に含まれていないことを明記

## Test plan
- [x] 記事の内容を確認
- [x] アラートコンポーネントが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)