### PR TITLE
CSS Custom Highlight APIブログ記事の訂正文改善とタイポ修正

### DIFF
--- a/core/src/app/blog/(articles)/highlight/page.mdx
+++ b/core/src/app/blog/(articles)/highlight/page.mdx
@@ -20,7 +20,7 @@ import { Playground } from '@/app/_components/playgrounds';
 
 <Alert
   status="warning"
-  message="【訂正】この記事で紹介する機能がFirefox 140のリリースによってBaseline入りしたような記述をしていますが、実際には一部の機能が導入されておらずBaseline 2025にはなっていませんでした。"
+  message="【訂正】この記事では、Firefox 140のリリースによってCSS Custom Highlight APIがBaseline入りしたと記述していますが、実際にはまだBaseline 2025の対象にはなっていませんでした（MDNではBaseline入りしているように見えます）。"
 />
 
 Firefox 140がリリースされ、`CSS Custom Highlight API`がサポートされました。この新機能により、JavaScriptで定義した任意のテキスト範囲をCSSでスタイリングできるようになります。
@@ -174,7 +174,7 @@ spellErrorHighlight.type = 'spelling-error';
 
 `highlight`には特別な意味がありません。`spelling-error`はスペルミス、`grammar-error`は文法エラーを意味します。
 
-<Playground title="grammer-errorでハイライトした例">
+<Playground title="grammar-errorでハイライトした例">
   <Example3 />
 </Playground>
 


### PR DESCRIPTION
## 概要
- 訂正文をより具体的で正確な内容に改善（Firefoxのブラウザサポート状況とMDNドキュメントの食い違いについて明記）
- タイポ修正: "grammer-error" → "grammar-error" 

## テストプラン
- [ ] ブログ記事で訂正メッセージが正しく表示されることを確認
- [ ] プレイグラウンドのタイトルで正しいスペルが表示されることを確認  
- [ ] この変更でGitHub Actionsのレビュー機能が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)