### PR TITLE
feat: improve renovate grouping configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,20 +10,32 @@
   "prConcurrentLimit": 10,
   "packageRules": [
     {
-      "matchUpdateTypes": ["minor", "patch"],
-      "matchPackageNames": [
-        "!/^(pnpm|node)$/",
-        "!/^@storybook/",
-        "!/storybook$/",
-        "!/react$/",
-        "!/react-dom$/",
-        "!/next$/",
-        "!/^@next/",
-        "!/vitest$/",
-        "!/@vitest/",
-        "!/^@typescript/native-preview$/"
-      ],
-      "groupName": "minor and patch dependencies"
+      "matchPackageNames": ["/next$/", "/^@next/"],
+      "groupName": "next dependencies"
+    },
+    {
+      "matchPackageNames": ["/^@storybook/", "/storybook$/"],
+      "groupName": "storybook dependencies"
+    },
+    {
+      "matchPackageNames": ["/vitest$/", "/@vitest/"],
+      "groupName": "vitest dependencies"
+    },
+    {
+      "matchPackageNames": ["/^@typescript/native-preview$/"],
+      "groupName": "tsgo dependencies"
+    },
+    {
+      "matchPackageNames": ["/react$/", "/react-dom$/"],
+      "groupName": "react dependencies"
+    },
+    {
+      "matchPackageNames": ["/^pnpm$/"],
+      "groupName": "pnpm dependencies"
+    },
+    {
+      "matchPackageNames": ["/node$/"],
+      "groupName": "node dependencies"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Replace single catchall group with specific dependency groups for better organization
- Create dedicated groups for Next.js, Storybook, Vitest, React, TypeScript native preview, pnpm, and Node.js dependencies
- Improve dependency update organization and reduce PR noise

## Test plan
- [ ] Verify renovate configuration is valid
- [ ] Monitor future dependency update PRs for proper grouping

🤖 Generated with [Claude Code](https://claude.ai/code)