### PR TITLE
chore: update Claude workflow permissions and tools

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,7 +29,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           claude_args: |
-            --allowedTools mcp__github__create_pending_pull_request_review,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__get_pull_request_comments
+            --allowedTools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
             --system-prompt "日本語で応答してください。"
           prompt: |
             REPO: ${{ github.repository }}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,8 +19,8 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      pull-requests: read
       issues: read
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
@@ -34,6 +34,8 @@ jobs:
         id: claude
         uses: anthropics/claude-code-action@7e4b782d5f10609fdd6147c146d8195605d881c5
         with:
+          additional_permissions: |
+            actions: read
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           claude_args: |
             --system-prompt "日本語で応答してください。"


### PR DESCRIPTION
## Summary
- Change `claude.yml` permissions from write to read for contents and pull-requests
- Add `actions: read` to `additional_permissions` in `claude.yml`
- Update `claude-code-review.yml` to use Bash-based GitHub CLI tools instead of MCP tools

## Test plan
- [ ] Verify workflow runs successfully
- [ ] Confirm Claude Code action works with new permissions
- [ ] Test code review functionality with new allowed tools

🤖 Generated with [Claude Code](https://claude.ai/code)