### PR TITLE
chore: remove @types/dompurify package

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -93,7 +93,6 @@
     "@storybook/addon-docs": "9.1.10",
     "@storybook/addon-vitest": "9.1.10",
     "@storybook/nextjs-vite": "9.1.10",
-    "@types/dompurify": "3.2.0",
     "@types/mdx": "2.0.13",
     "@types/react": "19.2.1",
     "@types/react-dom": "19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,9 +178,6 @@ importers:
       '@storybook/nextjs-vite':
         specifier: 9.1.10
         version: 9.1.10(@babel/core@7.28.3)(next@15.5.4(@babel/core@7.28.3)(@playwright/test@1.56.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.46.2)(storybook@9.1.10(@testing-library/dom@10.4.1)(msw@2.11.3(@types/node@22.18.8)(typescript@5.9.3))(prettier@3.6.2)(vite@7.1.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.2(@types/node@22.18.8)(jiti@2.6.1)(lightningcss@1.30.1)(tsx@4.20.4)(yaml@2.8.1))
-      '@types/dompurify':
-        specifier: 3.2.0
-        version: 3.2.0
       '@types/mdx':
         specifier: 2.0.13
         version: 2.0.13
@@ -1903,10 +1900,6 @@ packages:
 
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
-
-  '@types/dompurify@3.2.0':
-    resolution: {integrity: sha512-Fgg31wv9QbLDA0SpTOXO3MaxySc4DKGLi8sna4/Utjo4r3ZRPdCt4UQee8BWr+Q5z21yifghREPJGYaEOEIACg==}
-    deprecated: This is a stub types definition. dompurify provides its own type definitions, so you do not need this installed.
 
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
@@ -6071,7 +6064,7 @@ snapshots:
       commander: 13.1.0
       glob: 11.0.3
       ink: 6.0.1(@types/react@19.2.1)(react@19.1.1)
-      ink-gradient: 3.0.0(ink@6.0.1(@types/react@19.2.1)(react@19.2.0))
+      ink-gradient: 3.0.0(ink@6.0.1(@types/react@19.2.1)(react@19.1.1))
       inquirer: 12.6.3(@types/node@22.18.8)
       neverthrow: 8.2.0
       react: 19.1.1
@@ -6861,10 +6854,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
-
-  '@types/dompurify@3.2.0':
-    dependencies:
-      dompurify: 3.2.7
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -8211,7 +8200,7 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ink-gradient@3.0.0(ink@6.0.1(@types/react@19.2.1)(react@19.2.0)):
+  ink-gradient@3.0.0(ink@6.0.1(@types/react@19.2.1)(react@19.1.1)):
     dependencies:
       '@types/gradient-string': 1.1.6
       gradient-string: 2.0.2


### PR DESCRIPTION
## Summary
- Remove `@types/dompurify` package from dependencies

## Reason
`@types/dompurify` is a deprecated stub package. The `dompurify` package provides its own type definitions, making this additional types package unnecessary and redundant.

## Changes
- Removed `@types/dompurify` from `core/package.json`
- Updated `pnpm-lock.yaml` accordingly

🤖 Generated with [Claude Code](https://claude.com/claude-code)