### PR TITLE
feat: Storybook MCP addonの統合

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -11,6 +11,10 @@
     "chrome": {
       "command": "pnpm",
       "args": ["mcp-chrome"]
+    },
+    "storybook-mcp": {
+      "url": "http://localhost:6006/mcp",
+      "type": "http"
     }
   }
 }

--- a/core/.storybook/main.ts
+++ b/core/.storybook/main.ts
@@ -6,6 +6,7 @@ const config: StorybookConfig = {
     '@storybook/addon-a11y',
     '@storybook/addon-vitest',
     '@storybook/addon-docs',
+    '@storybook/addon-mcp',
     'storybook-addon-mock-date',
   ],
   framework: {

--- a/core/package.json
+++ b/core/package.json
@@ -60,6 +60,7 @@
     "@playwright/test": "1.56.1",
     "@storybook/addon-a11y": "10.0.1",
     "@storybook/addon-docs": "10.0.1",
+    "@storybook/addon-mcp": "0.1.3",
     "@storybook/addon-vitest": "10.0.1",
     "@storybook/nextjs-vite": "10.0.1",
     "@types/mdx": "2.0.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,9 @@ importers:
       '@storybook/addon-docs':
         specifier: 10.0.1
         version: 10.0.1(@types/react@19.2.2)(esbuild@0.25.11)(rollup@4.52.5)(storybook@10.0.1(@testing-library/dom@10.4.1)(msw@2.11.6(@types/node@22.18.12)(typescript@5.9.3))(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.11(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)))(vite@7.1.11(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1))
+      '@storybook/addon-mcp':
+        specifier: 0.1.3
+        version: 0.1.3(storybook@10.0.1(@testing-library/dom@10.4.1)(msw@2.11.6(@types/node@22.18.12)(typescript@5.9.3))(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.11(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)))(typescript@5.9.3)
       '@storybook/addon-vitest':
         specifier: 10.0.1
         version: 10.0.1(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(msw@2.11.6(@types/node@22.18.12)(typescript@5.9.3))(vite@7.1.11(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.1(@testing-library/dom@10.4.1)(msw@2.11.6(@types/node@22.18.12)(typescript@5.9.3))(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.11(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)))(vitest@4.0.6)
@@ -1720,6 +1723,11 @@ packages:
     peerDependencies:
       storybook: ^10.0.1
 
+  '@storybook/addon-mcp@0.1.3':
+    resolution: {integrity: sha512-7lPSFkK0RmVIVlq+yNBg65m8GAih8IsOx61DeUQaKUSSSQlLFOFmtLHms/A1Noz2oMZ0wm/d3p5z2U/gYi+9dg==}
+    peerDependencies:
+      storybook: ^9.1.16 || ^10.0.0
+
   '@storybook/addon-vitest@10.0.1':
     resolution: {integrity: sha512-QtAAzSYAVMyr6yHzFFm37JqrS3wnF4XhXxy4YwcIJsfOzCPDkxJr27ZrhLqyAjkGtvvLmVOqAq6QI917xS0BmQ==}
     peerDependencies:
@@ -1771,6 +1779,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
+
+  '@storybook/mcp@0.0.6':
+    resolution: {integrity: sha512-sCLU9jvCjCDFHOTSOa/3jUZ/HKTQQ5UrBC52mpBFEfgs6jUcspUC5DZSwsFqrcNi6jB4pi6MARLNlsimeGPsJg==}
 
   '@storybook/nextjs-vite@10.0.1':
     resolution: {integrity: sha512-rGySjWELAwVb9RpirmkdUGoy7fI4/K4o5SotWLSX9bmvIRbD2lQQTam8IXnB+DiiawjyYVkXAs/amre00CiG2Q==}
@@ -1999,6 +2010,26 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@tmcp/adapter-valibot@0.1.4':
+    resolution: {integrity: sha512-/fGCUz/L5RLCYC4L0Mo6s9Z9cSIIPztuHfIkhyo3WjMPTjQWUkFulA47sZSWRTaz5eKQxm5fV1qcfT7zHSuY3Q==}
+    peerDependencies:
+      tmcp: ^1.10.2
+      valibot: ^1.1.0
+
+  '@tmcp/session-manager@0.2.0':
+    resolution: {integrity: sha512-/MjEFFvnvrV3DbnwEAXMBKhIFmm7z81EgazBtPhKP9i5pe37/iDkYHOa+SD6aaqT3V7gACQ1nmqoJH3MdrC7gQ==}
+    peerDependencies:
+      tmcp: ^1.16.0
+
+  '@tmcp/transport-http@0.8.0':
+    resolution: {integrity: sha512-XkIFDIDr8zzQhJiwI+6He0pIGmEg0SAwHdsv914UtL0zqKuUfFvFLLARkryB95Rhp1ib4nVWAgLcV1FtdWGzIw==}
+    peerDependencies:
+      '@tmcp/auth': ^0.3.3
+      tmcp: ^1.16.0
+    peerDependenciesMeta:
+      '@tmcp/auth':
+        optional: true
+
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
@@ -2155,6 +2186,11 @@ packages:
 
   '@upstash/redis@1.35.6':
     resolution: {integrity: sha512-aSEIGJgJ7XUfTYvhQcQbq835re7e/BXjs8Janq6Pvr6LlmTZnyqwT97RziZLO/8AVUL037RLXqqiQC6kCt+5pA==}
+
+  '@valibot/to-json-schema@1.3.0':
+    resolution: {integrity: sha512-82Vv6x7sOYhv5YmTRgSppSqj1nn2pMCk5BqCMGWYp0V/fq+qirrbGncqZAtZ09/lrO40ne/7z8ejwE728aVreg==}
+    peerDependencies:
+      valibot: ^1.1.0
 
   '@vercel/analytics@1.5.0':
     resolution: {integrity: sha512-MYsBzfPki4gthY5HnYN7jgInhAZ7Ac1cYDoRWFomwGHWEX7odTEzbtg9kf/QSo7XEsEAqlQugA6gJ2WS2DEa3g==}
@@ -2860,6 +2896,9 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  esm-env@1.2.2:
+    resolution: {integrity: sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==}
+
   esprima@4.0.1:
     resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
     engines: {node: '>=4'}
@@ -3232,6 +3271,9 @@ packages:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
     engines: {node: '>=6'}
     hasBin: true
+
+  json-rpc-2.0@1.7.1:
+    resolution: {integrity: sha512-JqZjhjAanbpkXIzFE7u8mE/iFblawwlXtONaCvRqI+pyABVz7B4M1EUNpyVW+dZjqgQ2L5HFmZCmOCgUKm00hg==}
 
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
@@ -4332,6 +4374,9 @@ packages:
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
 
+  sqids@0.3.0:
+    resolution: {integrity: sha512-lOQK1ucVg+W6n3FhRwwSeUijxe93b51Bfz5PMRMihVf1iVkl82ePQG7V5vwrhzB11v0NtsR25PSZRGiSomJaJw==}
+
   stack-utils@2.0.6:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
@@ -4487,6 +4532,9 @@ packages:
     resolution: {integrity: sha512-Y1KQBgDd/NUc+LfOtKS6mNsC9CCaH+m2P1RoIZy7RAPo3C3/t8X45+zgut31cRZtZ3xKPjfn3TkGTrctC2TQIQ==}
     hasBin: true
 
+  tmcp@1.16.2:
+    resolution: {integrity: sha512-4Q/aenWdWR0CWnmKjAR4Q5H+8+i/UvU5Q4wHRJQ6AfE6Ta0pBTpRn722hAfHYYLKmTV12sGgXfLju8FEjJzagQ==}
+
   to-vfile@8.0.0:
     resolution: {integrity: sha512-IcmH1xB5576MJc9qcfEC/m/nQCFt3fzMHz45sSlgJyTWjRbKW1HAkJpuf3DgE57YzIlZcwcBZA5ENQbBo4aLkg==}
 
@@ -4636,6 +4684,9 @@ packages:
 
   uqr@0.1.2:
     resolution: {integrity: sha512-MJu7ypHq6QasgF5YRTjqscSzQp/W11zoUk6kvmlH+fmWEs63Y0Eib13hYFwAzagRJcVY8WVnlV+eBDUGMJ5IbA==}
+
+  uri-template-matcher@1.1.2:
+    resolution: {integrity: sha512-uZc1h12jdO3m/R77SfTEOuo6VbMhgWznaawKpBjRGSJb7i91x5PgI37NQJtG+Cerxkk0yr1pylBY2qG1kQ+aEQ==}
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
@@ -5596,7 +5647,7 @@ snapshots:
       commander: 13.1.0
       glob: 11.0.3
       ink: 6.0.1(@types/react@19.2.2)(react@19.1.1)
-      ink-gradient: 3.0.0(ink@6.0.1(@types/react@19.2.2)(react@19.1.1))
+      ink-gradient: 3.0.0(ink@6.0.1(@types/react@19.2.2)(react@19.2.0))
       inquirer: 12.6.3(@types/node@22.18.12)
       neverthrow: 8.2.0
       react: 19.1.1
@@ -6086,6 +6137,18 @@ snapshots:
       - vite
       - webpack
 
+  '@storybook/addon-mcp@0.1.3(storybook@10.0.1(@testing-library/dom@10.4.1)(msw@2.11.6(@types/node@22.18.12)(typescript@5.9.3))(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.11(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)))(typescript@5.9.3)':
+    dependencies:
+      '@storybook/mcp': 0.0.6(typescript@5.9.3)
+      '@tmcp/adapter-valibot': 0.1.4(tmcp@1.16.2(typescript@5.9.3))(valibot@1.1.0(typescript@5.9.3))
+      '@tmcp/transport-http': 0.8.0(tmcp@1.16.2(typescript@5.9.3))
+      storybook: 10.0.1(@testing-library/dom@10.4.1)(msw@2.11.6(@types/node@22.18.12)(typescript@5.9.3))(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.11(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1))
+      tmcp: 1.16.2(typescript@5.9.3)
+      valibot: 1.1.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@tmcp/auth'
+      - typescript
+
   '@storybook/addon-vitest@10.0.1(@vitest/browser-playwright@4.0.6)(@vitest/browser@4.0.6(msw@2.11.6(@types/node@22.18.12)(typescript@5.9.3))(vite@7.1.11(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1))(vitest@4.0.6))(@vitest/runner@4.0.6)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@10.0.1(@testing-library/dom@10.4.1)(msw@2.11.6(@types/node@22.18.12)(typescript@5.9.3))(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.11(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)))(vitest@4.0.6)':
     dependencies:
       '@storybook/global': 5.0.0
@@ -6128,6 +6191,16 @@ snapshots:
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
+
+  '@storybook/mcp@0.0.6(typescript@5.9.3)':
+    dependencies:
+      '@tmcp/adapter-valibot': 0.1.4(tmcp@1.16.2(typescript@5.9.3))(valibot@1.1.0(typescript@5.9.3))
+      '@tmcp/transport-http': 0.8.0(tmcp@1.16.2(typescript@5.9.3))
+      tmcp: 1.16.2(typescript@5.9.3)
+      valibot: 1.1.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - '@tmcp/auth'
+      - typescript
 
   '@storybook/nextjs-vite@10.0.1(@babel/core@7.28.4)(esbuild@0.25.11)(next@16.0.1(@babel/core@7.28.4)(@playwright/test@1.56.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@10.0.1(@testing-library/dom@10.4.1)(msw@2.11.6(@types/node@22.18.12)(typescript@5.9.3))(prettier@3.6.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(vite@7.1.11(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1)))(typescript@5.9.3)(vite@7.1.11(@types/node@22.18.12)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.20.6)(yaml@2.8.1))':
     dependencies:
@@ -6338,6 +6411,23 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@tmcp/adapter-valibot@0.1.4(tmcp@1.16.2(typescript@5.9.3))(valibot@1.1.0(typescript@5.9.3))':
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      '@valibot/to-json-schema': 1.3.0(valibot@1.1.0(typescript@5.9.3))
+      tmcp: 1.16.2(typescript@5.9.3)
+      valibot: 1.1.0(typescript@5.9.3)
+
+  '@tmcp/session-manager@0.2.0(tmcp@1.16.2(typescript@5.9.3))':
+    dependencies:
+      tmcp: 1.16.2(typescript@5.9.3)
+
+  '@tmcp/transport-http@0.8.0(tmcp@1.16.2(typescript@5.9.3))':
+    dependencies:
+      '@tmcp/session-manager': 0.2.0(tmcp@1.16.2(typescript@5.9.3))
+      esm-env: 1.2.2
+      tmcp: 1.16.2(typescript@5.9.3)
+
   '@types/aria-query@5.0.4': {}
 
   '@types/babel__core@7.20.5':
@@ -6493,6 +6583,10 @@ snapshots:
   '@upstash/redis@1.35.6':
     dependencies:
       uncrypto: 0.1.3
+
+  '@valibot/to-json-schema@1.3.0(valibot@1.1.0(typescript@5.9.3))':
+    dependencies:
+      valibot: 1.1.0(typescript@5.9.3)
 
   '@vercel/analytics@1.5.0(next@16.0.1(@babel/core@7.28.4)(@playwright/test@1.56.1)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     optionalDependencies:
@@ -7120,6 +7214,8 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  esm-env@1.2.2: {}
+
   esprima@4.0.1: {}
 
   estree-util-attach-comments@3.0.0:
@@ -7415,7 +7511,7 @@ snapshots:
 
   indent-string@5.0.0: {}
 
-  ink-gradient@3.0.0(ink@6.0.1(@types/react@19.2.2)(react@19.1.1)):
+  ink-gradient@3.0.0(ink@6.0.1(@types/react@19.2.2)(react@19.2.0)):
     dependencies:
       '@types/gradient-string': 1.1.6
       gradient-string: 2.0.2
@@ -7565,6 +7661,8 @@ snapshots:
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
+
+  json-rpc-2.0@1.7.1: {}
 
   json5@2.2.3: {}
 
@@ -8875,6 +8973,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  sqids@0.3.0: {}
+
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
@@ -9026,6 +9126,16 @@ snapshots:
     dependencies:
       tldts-core: 7.0.17
 
+  tmcp@1.16.2(typescript@5.9.3):
+    dependencies:
+      '@standard-schema/spec': 1.0.0
+      json-rpc-2.0: 1.7.1
+      sqids: 0.3.0
+      uri-template-matcher: 1.1.2
+      valibot: 1.1.0(typescript@5.9.3)
+    transitivePeerDependencies:
+      - typescript
+
   to-vfile@8.0.0:
     dependencies:
       vfile: 6.0.3
@@ -9171,6 +9281,8 @@ snapshots:
       picocolors: 1.1.1
 
   uqr@0.1.2: {}
+
+  uri-template-matcher@1.1.2: {}
 
   url-parse@1.5.10:
     dependencies:


### PR DESCRIPTION
## Summary
- Storybook MCP addonを統合し、Claude CodeからStorybookコンポーネントへのアクセスを可能にしました

## 変更内容
- `@storybook/addon-mcp@0.1.3`をdevDependenciesに追加
- `.storybook/main.ts`でaddonを有効化
- `.mcp.json`にstorybook-mcpサーバー設定を追加（`http://localhost:6006/mcp`）

## 期待される効果
- Storybook起動中（`pnpm run -F core storybook`）にClaude Codeがコンポーネント情報にアクセス可能になります
- コンポーネント開発時にClaude CodeがStorybookのストーリー情報を参照できるようになります

## Test plan
- [ ] `pnpm install`で依存関係をインストール
- [ ] `pnpm run -F core storybook`でStorybookが正常に起動すること
- [ ] `.mcp.json`の設定が正しく読み込まれること
- [ ] Claude Code起動時にstorybook-mcpサーバーに接続できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)