### PR TITLE
input要素でディレクトリを扱うwebkitdirectory属性

### DIFF
--- a/core/migrations/0053_vengeful_mongoose.sql
+++ b/core/migrations/0053_vengeful_mongoose.sql
@@ -1,0 +1,7 @@
+INSERT INTO tags (id, name) VALUES (84, 'input-file-webkitdirectory');
+
+INSERT INTO blogs (id, slug, published) VALUES (36, 'input-file-webkitdirectory', true);
+INSERT INTO blog_views (blog_id, views) VALUES (36, 0);
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (36, 15);
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (36, 11);
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (36, 84);

--- a/core/migrations/meta/0053_snapshot.json
+++ b/core/migrations/meta/0053_snapshot.json
@@ -1,0 +1,1255 @@
+{
+  "id": "c0c1ba39-0ec9-4538-a7d6-1a8b054d4ab3",
+  "prevId": "4ca9de51-7562-481c-85a0-54d33bc9c36a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.blog_comment": {
+      "name": "blog_comment",
+      "schema": "",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "commend_id": {
+          "name": "commend_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_index": {
+          "name": "blog_comment_blog_id_index",
+          "columns": [
+            {
+              "expression": "blog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "blog_comment_commend_id_index": {
+          "name": "blog_comment_commend_id_index",
+          "columns": [
+            {
+              "expression": "commend_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_commend_id_comments_id_fk": {
+          "name": "blog_comment_commend_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "commend_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blog_tag": {
+      "name": "blog_tag",
+      "schema": "",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_index": {
+          "name": "blog_tag_blog_id_index",
+          "columns": [
+            {
+              "expression": "blog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "blog_tag_tag_id_index": {
+          "name": "blog_tag_tag_id_index",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "blog_tag_blog_id_tag_id_index": {
+          "name": "blog_tag_blog_id_tag_id_index",
+          "columns": [
+            {
+              "expression": "blog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blog_views": {
+      "name": "blog_views",
+      "schema": "",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "blog_views_blog_id_index": {
+          "name": "blog_views_blog_id_index",
+          "columns": [
+            {
+              "expression": "blog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blogs": {
+      "name": "blogs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published": {
+          "name": "published",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blogs_slug_index": {
+          "name": "blogs_slug_index",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "comments_id_index": {
+          "name": "comments_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "comments_feedback_id_index": {
+          "name": "comments_feedback_id_index",
+          "columns": [
+            {
+              "expression": "feedback_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedbacks": {
+      "name": "feedbacks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_answers": {
+      "name": "quiz_answers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "quiz_answers_quiz_id_index": {
+          "name": "quiz_answers_quiz_id_index",
+          "columns": [
+            {
+              "expression": "quiz_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "quiz_answers_quiz_id_quizzes_id_fk": {
+          "name": "quiz_answers_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_answers",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "tableTo": "quizzes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_questions": {
+      "name": "quiz_questions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "highlight": {
+          "name": "highlight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "quiz_questions_quiz_id_index": {
+          "name": "quiz_questions_quiz_id_index",
+          "columns": [
+            {
+              "expression": "quiz_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "quiz_questions_quiz_id_quizzes_id_fk": {
+          "name": "quiz_questions_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_questions",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "tableTo": "quizzes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quiz_type": {
+      "name": "quiz_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "quiz_type_name_index": {
+          "name": "quiz_type_name_index",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.quizzes": {
+      "name": "quizzes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "quizzes_type_index": {
+          "name": "quizzes_type_index",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "quizzes_type_quiz_type_id_fk": {
+          "name": "quizzes_type_quiz_type_id_fk",
+          "tableFrom": "quizzes",
+          "columnsFrom": [
+            "type"
+          ],
+          "tableTo": "quiz_type",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_tag": {
+      "name": "service_tag",
+      "schema": "",
+      "columns": {
+        "service_id": {
+          "name": "service_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "service_tag_service_id_index": {
+          "name": "service_tag_service_id_index",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "service_tag_tag_id_index": {
+          "name": "service_tag_tag_id_index",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "service_tag_service_id_tag_id_index": {
+          "name": "service_tag_service_id_tag_id_index",
+          "columns": [
+            {
+              "expression": "service_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "service_tag_service_id_services_id_fk": {
+          "name": "service_tag_service_id_services_id_fk",
+          "tableFrom": "service_tag",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "tableTo": "services",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "service_tag_tag_id_tags_id_fk": {
+          "name": "service_tag_tag_id_tags_id_fk",
+          "tableFrom": "service_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.service_type": {
+      "name": "service_type",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "service_type_name_index": {
+          "name": "service_type_name_index",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.services": {
+      "name": "services",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "services_slug_index": {
+          "name": "services_slug_index",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "services_id_index": {
+          "name": "services_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "services_type_index": {
+          "name": "services_type_index",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "services_type_service_type_id_fk": {
+          "name": "services_type_service_type_id_fk",
+          "tableFrom": "services",
+          "columnsFrom": [
+            "type"
+          ],
+          "tableTo": "service_type",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.subscribers": {
+      "name": "subscribers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "subscribers_id_index": {
+          "name": "subscribers_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "email": {
+          "name": "email",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tags": {
+      "name": "tags",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "tags_name_index": {
+          "name": "tags_name_index",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.talk_tag": {
+      "name": "talk_tag",
+      "schema": "",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_index": {
+          "name": "talk_tag_talk_id_index",
+          "columns": [
+            {
+              "expression": "talk_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "talk_tag_tag_id_index": {
+          "name": "talk_tag_tag_id_index",
+          "columns": [
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "talk_tag_talk_id_tag_id_index": {
+          "name": "talk_tag_talk_id_tag_id_index",
+          "columns": [
+            {
+              "expression": "talk_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tag_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.talks": {
+      "name": "talks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "talks_id_index": {
+          "name": "talks_id_index",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "talks_blog_id_index": {
+          "name": "talks_blog_id_index",
+          "columns": [
+            {
+              "expression": "blog_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/core/migrations/meta/_journal.json
+++ b/core/migrations/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1762153210670,
       "tag": "0052_military_rictor",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1762589924474,
+      "tag": "0053_vengeful_mongoose",
+      "breakpoints": true
     }
   ]
 }

--- a/core/src/app/_components/playgrounds/index.ts
+++ b/core/src/app/_components/playgrounds/index.ts
@@ -2,6 +2,7 @@ export * from './abs-sign';
 export * from './async-clipboard';
 export * from './details-content';
 export * from './highlight';
+export * from './input-file-webkitdirectory';
 export { Playground } from './playground';
 export * from './popover';
 export * from './print-color-adjust';
@@ -17,6 +18,7 @@ import { asyncClipboardSection } from './async-clipboard';
 import { composedRangesSection } from './composed-ranges';
 import { detailsContentSection } from './details-content';
 import { highlightSection } from './highlight';
+import { inputFileWebkitdirectorySection } from './input-file-webkitdirectory';
 import { popoverSection } from './popover';
 import { printColorAdjustSection } from './print-color-adjust';
 import { requestCloseSection } from './requestclose';
@@ -30,6 +32,7 @@ export const playgroundSections: PlaygroundSection[] = [
   asyncClipboardSection,
   composedRangesSection,
   detailsContentSection,
+  inputFileWebkitdirectorySection,
   popoverSection,
   requestCloseSection,
   printColorAdjustSection,

--- a/core/src/app/_components/playgrounds/input-file-webkitdirectory/index.ts
+++ b/core/src/app/_components/playgrounds/input-file-webkitdirectory/index.ts
@@ -1,0 +1,18 @@
+import type { PlaygroundSection } from '../types';
+import { WebkitRelativePathDemo } from './webkit-relative-path-demo';
+
+export { WebkitRelativePathDemo } from './webkit-relative-path-demo';
+
+export const inputFileWebkitdirectorySection: PlaygroundSection = {
+  id: 'input-file-webkitdirectory',
+  title: 'input要素のwebkitdirectory属性',
+  description: 'ディレクトリ選択を可能にするwebkitdirectory属性の使用例です。',
+  type: 'blog',
+  slug: 'input-file-webkitdirectory',
+  demos: [
+    {
+      component: WebkitRelativePathDemo,
+      title: 'webkitRelativePathの例',
+    },
+  ],
+};

--- a/core/src/app/_components/playgrounds/input-file-webkitdirectory/webkit-relative-path-demo.stories.tsx
+++ b/core/src/app/_components/playgrounds/input-file-webkitdirectory/webkit-relative-path-demo.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { WebkitRelativePathDemo } from './webkit-relative-path-demo';
+
+const meta = {
+  title: 'playgrounds/input-file-webkitdirectory/WebkitRelativePathDemo',
+  component: WebkitRelativePathDemo,
+  tags: ['autodocs'],
+} satisfies Meta<typeof WebkitRelativePathDemo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/core/src/app/_components/playgrounds/input-file-webkitdirectory/webkit-relative-path-demo.tsx
+++ b/core/src/app/_components/playgrounds/input-file-webkitdirectory/webkit-relative-path-demo.tsx
@@ -1,0 +1,61 @@
+'use client';
+
+import { Button } from '@k8o/arte-odyssey/button';
+import { FormControl } from '@k8o/arte-odyssey/form/form-control';
+import { type ChangeEvent, useRef, useState } from 'react';
+
+export const WebkitRelativePathDemo = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [files, setFiles] = useState<FileList | null>(null);
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    setFiles(files);
+  };
+  const handleClear = () => {
+    if (inputRef.current) {
+      inputRef.current.value = '';
+    }
+    setFiles(null);
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex flex-wrap justify-between gap-2">
+        <div>
+          <FormControl
+            label="ディレクトリ選択"
+            renderInput={({ id, describedbyId }) => (
+              <input
+                aria-describedby={describedbyId}
+                className="max-w-80 cursor-pointer rounded-lg bg-primary-bg px-4 py-2 text-center font-bold text-fg text-md hover:bg-primary-bg/90 focus-visible:border-transparent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-info active:bg-primary-bg/80"
+                id={id}
+                onChange={handleChange}
+                ref={inputRef}
+                type="file"
+                // @ts-expect-error
+                webkitdirectory="true"
+              />
+            )}
+          />
+        </div>
+        <div>
+          <Button color="gray" onClick={handleClear} size="md">
+            選択を初期化
+          </Button>
+        </div>
+      </div>
+      <div className="rounded-b-sm p-4">
+        <p className="font-bold">選択されたファイル一覧:</p>
+        {files && files.length > 0 ? (
+          <ul className="flex list-inside list-disc flex-col gap-1">
+            {Array.from(files).map((file) => (
+              <li key={file.webkitRelativePath}>{file.webkitRelativePath}</li>
+            ))}
+          </ul>
+        ) : (
+          <p>ファイルが選択されていません。</p>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/core/src/app/blog/(articles)/input-file-webkitdirectory/layout.tsx
+++ b/core/src/app/blog/(articles)/input-file-webkitdirectory/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import { getBlogContent } from '@/app/blog/_api';
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+
+const slug = 'input-file-webkitdirectory';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt.toString(),
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/input-file-webkitdirectory'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/core/src/app/blog/(articles)/input-file-webkitdirectory/opengraph-image.tsx
+++ b/core/src/app/blog/(articles)/input-file-webkitdirectory/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getBlogContent } from '@/app/blog/_api';
+
+export const alt =
+  'ファイルを受け入れるinput要素でディレクトリを扱うwebkitdirectory属性';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const blog = await getBlogContent('input-file-webkitdirectory');
+
+  return OgImage({
+    title: blog.title,
+  });
+}

--- a/core/src/app/blog/(articles)/input-file-webkitdirectory/page.mdx
+++ b/core/src/app/blog/(articles)/input-file-webkitdirectory/page.mdx
@@ -1,0 +1,130 @@
+---
+title: input要素でディレクトリを扱うwebkitdirectory属性
+description: input要素のwebkitdirectory属性がBaseline 2025に追加されました。webkitdirectory属性を利用することで、input要素のtype="file"でディレクトリを選択できるようになります。
+createdAt: 2025-11-08
+updatedAt: 2025-11-08
+---
+
+import { FormControl } from '@k8o/arte-odyssey/form/form-control';
+import { BaselineStatus } from '@k8o/arte-odyssey/baseline-status';
+import { Playground } from '@/app/_components/playgrounds';
+import {
+  WebkitRelativePathDemo,
+} from '@/app/_components/playgrounds/input-file-webkitdirectory';
+import { LinkCard } from '@/app/_components/link-card';
+
+# input要素でディレクトリを扱うwebkitdirectory属性
+
+<BaselineStatus featureId="input-file-webkitdirectory" />
+
+## はじめに
+`<input>`要素に`type="file"`を付与すると、ファイルを入力するための要素になります。
+
+```html
+<!-- 単一ファイル選択 -->
+<input type="file" />
+
+<!-- 複数ファイル選択 -->
+<input type="file" multiple />
+```
+
+<div className="flex flex-col gap-4">
+  <FormControl
+    label="単一ファイル選択"
+    renderInput={({ id, describedbyId }) => (
+      <input
+        type="file"
+        className="max-w-80 cursor-pointer rounded-lg text-center font-bold bg-primary-bg text-fg hover:bg-primary-bg/90 active:bg-primary-bg/80 focus-visible:border-transparent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-info px-4 py-2 text-md"
+        aria-describedby={describedbyId}
+        id={id}
+      />
+    )}
+  />
+
+  <FormControl
+    label="複数ファイル選択"
+    renderInput={({ id, describedbyId }) => (
+      <input
+        type="file"
+        multiple
+        className="max-w-80 cursor-pointer rounded-lg text-center font-bold bg-primary-bg text-fg hover:bg-primary-bg/90 active:bg-primary-bg/80 focus-visible:border-transparent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-info px-4 py-2 text-md"
+        aria-describedby={describedbyId}
+        id={id}
+      />
+    )}
+  />
+</div>
+
+この機能に加えて、ディレクトリごと選択させる`webkitdirectory`属性が、Firefox Androidの対応によってBaseline 2025に追加されました。
+
+```html
+<!-- ディレクトリ選択 -->
+<input type="file" webkitdirectory />
+```
+
+<FormControl
+  label="ディレクトリ選択"
+  renderInput={({ id, describedbyId }) => (
+    <input
+      type="file"
+      webkitdirectory="true"
+      className="max-w-80 cursor-pointer rounded-lg text-center font-bold bg-primary-bg text-fg hover:bg-primary-bg/90 active:bg-primary-bg/80 focus-visible:border-transparent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-info px-4 py-2 text-md"
+      aria-describedby={describedbyId}
+      id={id}
+    />
+  )}
+/>
+
+## webkitdirectory属性
+`webkitdirectory`属性にはユーザーにディレクトリの選択をさせるときに`true`、ファイルを選択するときは`false`を渡します。
+デフォルトは挙動からもわかる通り`false`です。
+
+### ファイルの取得
+`webkitdirectory`属性を付与した`<input>`要素で選択したファイルを取得は、`multiple`属性を指定した時の取得方法と同じように`files`プロパティから取得します。
+
+`files`プロパティは`FileList`オブジェクトまたは`null`を返します。
+
+`FileList`オブジェクトは`File`オブジェクトの集合体で、`File`は添え字からのアクセスと`item()`メソッドでアクセスできます。また、イテレーターとしての機能も持っています。
+
+```ts
+const files = inputElement.files;
+
+// 選択されたファイル数
+console.log(files?.length);
+// 添え字でのアクセス
+console.log(files?.[0]);
+// item()メソッドでのアクセス なければnullを返す
+console.log(files?.item(0));
+// イテレーターでのアクセス
+for (const file of files ?? []) {
+  console.log(file);
+}
+```
+
+`webkitdirectory`属性を付与した`<input>`要素から入力された`File`は書き換え不可な`webkitRelativePath`プロパティを持ちます。
+このプロパティには、選択されたファイルの相対パスが格納されます。
+
+```ts
+const files = inputElement.files;
+
+for (const file of files ?? []) {
+  console.log(file.webkitRelativePath);
+}
+```
+
+<Playground title="webkitRelativePathの例">
+  <WebkitRelativePathDemo />
+</Playground>
+
+`webkitEntries`プロパティからの取得はいくつかのブラウザでは、`webkitdirectory`属性と併用できないようなので気をつけてください。
+
+> INTEROP: In Chrome, if webkitdirectory is specified on a HTMLInputElement, webkitEntries is not populated; the files collection and webkitRelativePath properties must be used instead to reconstruct the directory structure. Should we fix this so it is always populated?
+
+> AIによる翻訳: Chromeにおいて、HTMLInputElementにwebkitdirectoryが指定されている場合、webkitEntriesは設定されません。代わりに、filesコレクションとwebkitRelativePathプロパティを使用してディレクトリ構造を再構築する必要があります。これを常に設定されるように修正すべきでしょうか？
+
+<LinkCard href="https://wicg.github.io/entries-api/#html-forms" />
+
+## おわりに
+`webkitRelativePath`属性を利用することで、ディレクトリごとファイルを受け取れるため、より高度なファイル操作が可能になりました。
+
+`webkitdirectory`属性のような`webkit`prefixがついている機能は利用を躊躇いますが、Baseline 2025に追加されたことで安心して利用できるようになり嬉しいです。


### PR DESCRIPTION
closed: https://github.com/k35o/k8o/issues/1184

## Summary
- 新しいブログ記事「input要素でディレクトリを扱うwebkitdirectory属性」を追加
- `webkitdirectory`属性がBaseline 2025に追加されたことに関する記事
- input要素でディレクトリを選択できる機能の解説

## 主な内容
- `<input type="file" webkitdirectory>`の使い方
- `webkitRelativePath`プロパティによるファイルパスの取得
- `FileList`と`File`オブジェクトの扱い方
- デモコンポーネント付きの実践的な説明

## データベースマイグレーション
- タグ「input-file-webkitdirectory」を追加
- ブログエントリとタグの関連付け
- 初期ビュー数のセットアップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)