### PR TITLE
fix: 画面リサイズ時にナビゲーションメニューを自動的に閉じる

### DIFF
--- a/core/src/app/_components/global-layout/navigation-menu/navigation-menu.tsx
+++ b/core/src/app/_components/global-layout/navigation-menu/navigation-menu.tsx
@@ -4,7 +4,7 @@ import { IconButton } from '@k8o/arte-odyssey/icon-button';
 import { CloseIcon, NavigationMenuIcon } from '@k8o/arte-odyssey/icons';
 import { Modal } from '@k8o/arte-odyssey/modal';
 import { PortalRootProvider } from '@k8o/arte-odyssey/providers';
-import { type FC, useCallback, useRef, useState } from 'react';
+import { type FC, useCallback, useEffect, useRef, useState } from 'react';
 import { ColorFilters } from '../../color-filters';
 import { ContactToMe } from '../../contact-to-me';
 import { ToggleTheme } from '../../toggle-theme';
@@ -19,6 +19,20 @@ export const NavigationMenu: FC = () => {
   const onClose = useCallback(() => {
     setOpen(false);
   }, []);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (open) {
+        onClose();
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, [open, onClose]);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- 画面の横幅が変更された際に、開いているナビゲーションメニューが自動的に閉じるように修正

## Changes
- `useEffect`フックを使用して`resize`イベントリスナーを追加
- メニューが開いている状態でリサイズイベントが発生した場合、`onClose`を呼び出してメニューを閉じる処理を実装
- コンポーネントのアンマウント時にイベントリスナーを適切にクリーンアップ

## Test plan
- [x] メニューを開く
- [x] 画面サイズを変更する
- [x] メニューが自動的に閉じることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)