### PR TITLE
ブログレイアウトでタグセクションの位置を調整

### DIFF
--- a/packages/core/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/packages/core/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -82,21 +82,21 @@ export const BlogLayout: FC<{
                 </Suspense>
               </ErrorBoundary>
             </div>
+            <ViewTransition name={`tags-${slug}`}>
+              {blog.tags.length > 0 && (
+                <div className="mb-4 flex flex-wrap items-center gap-2">
+                  <TagIcon size="sm" />
+                  {blog.tags.map((tag) => {
+                    return (
+                      <Link href={`/tags/${tag.id.toString()}`} key={tag.id}>
+                        <TextTag clickable key={tag.id} text={tag.name} />
+                      </Link>
+                    );
+                  })}
+                </div>
+              )}
+            </ViewTransition>
           </div>
-          <ViewTransition name={`tags-${slug}`}>
-            {blog.tags.length > 0 && (
-              <div className="mb-4 flex flex-wrap items-center gap-2">
-                <TagIcon size="sm" />
-                {blog.tags.map((tag) => {
-                  return (
-                    <Link href={`/tags/${tag.id.toString()}`} key={tag.id}>
-                      <TextTag clickable key={tag.id} text={tag.name} />
-                    </Link>
-                  );
-                })}
-              </div>
-            )}
-          </ViewTransition>
           <div className="m-2 sm:mt-4">
             <Separator />
           </div>


### PR DESCRIPTION
## Summary
- ブログレイアウトでタグセクションの位置を調整しました
- より適切なDOM階層構造になるように変更

## Test plan
- [ ] ブログページでタグが正しく表示されることを確認
- [ ] レイアウトが崩れていないことを確認
- [ ] ViewTransitionが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)