### PR TITLE
chore: pnpm workspace設定の更新

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2674,6 +2674,41 @@ packages:
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251201.1':
+    resolution: {integrity: sha512-PY0BrlRF3YCZEMxzuk79IFSgpGqUErkdrW7Aq+/mF8DEET5uaDypTMb8Vz4CLYJ7Xvvxz8eZsLimPbv6hYDIvA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20251201.1':
+    resolution: {integrity: sha512-YeDrjnsvXwm/MNG8aURT3J+cmHQIhpiElBKOVOy/H6ky4S2Ro9ufG+Bj9CqS3etbTCLhV5btk+QNh86DZ4VDkQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20251201.1':
+    resolution: {integrity: sha512-HbEn+SBTDZEtwN/VUxA2To+6vEr7x++SCRc6yGp5y4onpBL2xnH17UoxWiqN9J4Bu1DbQ9jZv3D5CzwBlofPQA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20251201.1':
+    resolution: {integrity: sha512-gr2EQYK888YdGROMc7l3N3MeKY1V3QVImKIQZNgqprV+N2rXaFnxGAZ+gql3LqZgRGel4a12vCUJeP7Pjl2gww==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20251201.1':
+    resolution: {integrity: sha512-q94K/LZ3Ab/SbUBMBsf37VdsumeZ1dZmymJYlhGBqk/fdXBayL0diLR3RdzyeQWbCXAxWL5KFKLIiIc3cI/fcA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20251201.1':
+    resolution: {integrity: sha512-/AFwpsX/G05bBsfVURfg4+/JC6gfvqj9jfFe/7oe1Y1J42koN5C8TH+eSmMOOEcPYpFjR1e+NWckqBJKaCXJ4A==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20251201.1':
+    resolution: {integrity: sha512-vTUCDEuSP4ifLHqb8aljuj44v6+M1HDKo1WLnboTDpwU7IIrTux/0jzkPfEHd9xd5FU4EhSA8ZrYDwKI0BcRcg==}
+    cpu: [x64]
+    os: [win32]
+
   '@typescript/native-preview@7.0.0-dev.20251201.1':
     resolution: {integrity: sha512-EiPEgGwNa2uHyyKgeoWTL6wWHKUBmF3xsfZ3OHofk7TxUuxb2mpLG5igEuaBe8iUwkCUl9uZgJvOu6o0wE5NSA==}
     hasBin: true
@@ -9517,7 +9552,36 @@ snapshots:
     dependencies:
       '@types/node': 22.19.0
 
-  '@typescript/native-preview@7.0.0-dev.20251201.1': {}
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20251201.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20251201.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20251201.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20251201.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20251201.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20251201.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20251201.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20251201.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20251201.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20251201.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20251201.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20251201.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20251201.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20251201.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20251201.1
 
   '@ungap/structured-clone@1.3.0': {}
 


### PR DESCRIPTION
## Summary
- `minimumReleaseAgeExclude`を配列形式に変更し、React/Next.js関連パッケージを除外対象に追加
- `ignoredBuiltDependencies`に`@parcel/watcher`を追加

## 変更内容
- `pnpm-workspace.yaml`の`minimumReleaseAgeExclude`を文字列からリスト形式に変更
- React、React DOM、Next.js、および@Next関連パッケージを`minimumReleaseAge`の対象から除外
- `@parcel/watcher`を`ignoredBuiltDependencies`に追加してビルド依存関係をスキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)