### PR TITLE
fix: ブログ記事の進捗検出を改善してスクロール時の100%表示を確実にする

### DIFF
--- a/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -100,16 +100,17 @@ export const BlogLayout: FC<{
             <Separator />
           </div>
           {children}
-          <div aria-hidden="true" className="sr-only" id={END_OF_CONTENT_ID} />
         </article>
-        <ErrorBoundary fallback={null}>
-          <section className="w-full rounded-md bg-bg-base/90 px-3 pt-8 pb-14 sm:px-10">
-            <Feedback slug={slug} />
-          </section>
-        </ErrorBoundary>
-        <ErrorBoundary fallback={null}>
-          <Recommend slug={slug} />
-        </ErrorBoundary>
+        <div id={END_OF_CONTENT_ID}>
+          <ErrorBoundary fallback={null}>
+            <section className="w-full rounded-md bg-bg-base/90 px-3 pt-8 pb-14 sm:px-10">
+              <Feedback slug={slug} />
+            </section>
+          </ErrorBoundary>
+          <ErrorBoundary fallback={null}>
+            <Recommend slug={slug} />
+          </ErrorBoundary>
+        </div>
       </div>
       <ErrorBoundary fallback={null}>
         <TableOfContext headingTree={headingTree} />


### PR DESCRIPTION
## Summary
- END_OF_CONTENT_IDの配置位置を変更して、高速スクロール時の進捗検出を改善
- 従来: `<article>`内の最後（高さ0のdiv要素）
- 変更後: FeedbackとRecommendを囲むdiv要素

## Problem
高速スクロール時、高さがほぼ0の`END_OF_CONTENT_ID`要素を`IntersectionObserver`が検出できず、目次の進捗バーが100%にならない問題がありました。

## Solution
FeedbackとRecommendセクション全体を囲むdivに`END_OF_CONTENT_ID`を配置することで、監視領域を拡大し、高速スクロールでも確実に検出されるようにしました。

## Test plan
- [ ] ブログページにアクセス
- [ ] 高速スクロールでページ最下部まで移動
- [ ] 目次の進捗バーが100%になり、「さいごまで よみました」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)