### PR TITLE
Renovateで.github/actionsの依存関係を検出可能に

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,6 +9,9 @@
     "monorepo:vitest"
   ],
   "prConcurrentLimit": 10,
+  "github-actions": {
+    "fileMatch": ["^\\.github/actions/[^/]+/action\\.ya?ml$"]
+  },
   "packageRules": [
     {
       "matchPackageNames": ["/^next$/", "/^@next/"],


### PR DESCRIPTION
`.github/actions/`内のカスタムcomposite actionsの依存関係をRenovateが検出できるように`fileMatch`を追加。

デフォルトでは`.github/workflows/`のみスキャンされるため、`.github/actions/setup-pnpm/action.yml`内の`pnpm/action-setup`や`actions/setup-node`が更新対象から漏れていた。

🤖 Generated with [Claude Code](https://claude.com/claude-code)