### PR TITLE
refactor: Biome linterルールの修正

### DIFF
--- a/apps/main/src/app/_components/global-layout/background/background.tsx
+++ b/apps/main/src/app/_components/global-layout/background/background.tsx
@@ -4,10 +4,10 @@ export const Background: FC = () => {
   return (
     <div
       aria-hidden="true"
-      className="-z-10 fixed top-0 left-0 h-full w-full overflow-hidden bg-linear-65 from-(--cyan-100) to-(--blue-100) dark:from-(--cyan-950) dark:to-(--blue-950)"
+      className="fixed top-0 left-0 -z-10 h-full w-full overflow-hidden bg-linear-65 from-(--cyan-100) to-(--blue-100) dark:from-(--cyan-950) dark:to-(--blue-950)"
     >
-      <div className="-top-24 -left-24 absolute h-96 w-96 bg-linear-65 from-(--cyan-400) to-(--teal-300) opacity-40 blur-3xl dark:from-(--cyan-700) dark:to-(--teal-600) dark:opacity-30" />
-      <div className="-bottom-24 -right-24 absolute h-96 w-96 bg-linear-65 from-(--blue-400) to-(--teal-400) opacity-40 blur-3xl dark:from-(--blue-700) dark:to-(--teal-700) dark:opacity-30" />
+      <div className="absolute -top-24 -left-24 h-96 w-96 bg-linear-65 from-(--cyan-400) to-(--teal-300) opacity-40 blur-3xl dark:from-(--cyan-700) dark:to-(--teal-600) dark:opacity-30" />
+      <div className="absolute -right-24 -bottom-24 h-96 w-96 bg-linear-65 from-(--blue-400) to-(--teal-400) opacity-40 blur-3xl dark:from-(--blue-700) dark:to-(--teal-700) dark:opacity-30" />
     </div>
   );
 };

--- a/apps/main/src/app/_components/global-layout/navigation-menu/navigation-menu.tsx
+++ b/apps/main/src/app/_components/global-layout/navigation-menu/navigation-menu.tsx
@@ -44,13 +44,11 @@ export const NavigationMenu: FC = () => {
             </div>
             <nav className="mt-8">
               <ul className="flex w-full flex-col gap-4 p-4">
-                {/** biome-ignore lint/a11y/useKeyWithClickEvents: propagation */}
-                <li onClick={onClose}>
-                  <TagsLink />
+                <li>
+                  <TagsLink onNavigate={onClose} />
                 </li>
-                {/** biome-ignore lint/a11y/useKeyWithClickEvents: propagation */}
-                <li onClick={onClose}>
-                  <NewsLink />
+                <li>
+                  <NewsLink onNavigate={onClose} />
                 </li>
                 <li>
                   <Suspense fallback={null}>

--- a/apps/main/src/app/_components/global-layout/news-link/news-link.tsx
+++ b/apps/main/src/app/_components/global-layout/news-link/news-link.tsx
@@ -6,13 +6,15 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { FC } from 'react';
 
-export const NewsLink: FC = () => {
+export const NewsLink: FC<{
+  onNavigate?: () => void;
+}> = (props) => {
   const pathname = usePathname();
   return (
     <LinkButton
       active={pathname.startsWith('/news')}
       href="/news"
-      renderAnchor={(props) => <Link {...props} />}
+      renderAnchor={(anchorProps) => <Link {...anchorProps} {...props} />}
       startIcon={<NewsIcon />}
       variant="skeleton"
     >

--- a/apps/main/src/app/_components/global-layout/tags-link/tags-link.tsx
+++ b/apps/main/src/app/_components/global-layout/tags-link/tags-link.tsx
@@ -6,13 +6,15 @@ import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { FC } from 'react';
 
-export const TagsLink: FC = () => {
+export const TagsLink: FC<{
+  onNavigate?: () => void;
+}> = (props) => {
   const pathname = usePathname();
   return (
     <LinkButton
       active={pathname.startsWith('/tags')}
       href="/tags"
-      renderAnchor={(props) => <Link {...props} />}
+      renderAnchor={(anchorProps) => <Link {...anchorProps} {...props} />}
       startIcon={<TagIcon />}
       variant="skeleton"
     >

--- a/apps/main/src/app/_components/playgrounds/details-content/details-animation-demo.module.css
+++ b/apps/main/src/app/_components/playgrounds/details-content/details-animation-demo.module.css
@@ -1,6 +1,8 @@
 .detailsAnimation::details-content {
   interpolate-size: allow-keywords;
-  transition: height 0.5s ease, content-visibility 0.5s ease allow-discrete;
+  transition:
+    height 0.5s ease,
+    content-visibility 0.5s ease allow-discrete;
   height: 0;
   overflow: clip;
 }

--- a/apps/main/src/app/_styles/globals.css
+++ b/apps/main/src/app/_styles/globals.css
@@ -21,6 +21,7 @@
   ::view-transition-group(*),
   ::view-transition-old(*),
   ::view-transition-new(*) {
+    /* biome-ignore lint/complexity/noImportantStyles: ユーザーの設定を強制するため */
     animation: none !important;
   }
 }

--- a/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -28,7 +28,7 @@ export const BlogLayout: FC<{
   const headingTree = await getBlogToc(slug);
 
   return (
-    <div className="xl:has-[>:nth-child(2)]:-mx-36 gap-4 xl:flex">
+    <div className="gap-4 xl:flex xl:has-[>:nth-child(2)]:-mx-36">
       <div className="m-auto flex flex-col gap-8 xl:max-w-5xl">
         <article className="rounded-md bg-bg-base/90 px-3 pt-8 pb-14 sm:px-10">
           <div className="flex flex-col gap-3">

--- a/apps/main/src/app/blog/_components/blog-layout/table-of-context/progress-bar.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/table-of-context/progress-bar.tsx
@@ -23,7 +23,7 @@ export const ProgressBar: FC<{
     <div className="relative h-8 w-8 shrink-0">
       <svg
         aria-hidden="true"
-        className="-rotate-90 h-full w-full"
+        className="h-full w-full -rotate-90"
         viewBox="0 0 32 32"
       >
         {/* 背景の円 */}

--- a/apps/main/src/app/blog/_components/blog-layout/table-of-context/table-of-context.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/table-of-context/table-of-context.tsx
@@ -72,9 +72,9 @@ export const TableOfContext: FC<{
 
     // すべての見出し要素を監視
     const headings = document.querySelectorAll('h2[id], h3[id], h4[id]');
-    headings.forEach((heading) => {
+    for (const heading of headings) {
       observer.observe(heading);
-    });
+    }
     const eocElement = document.getElementById(END_OF_CONTENT_ID);
     if (eocElement) {
       observer.observe(eocElement);

--- a/apps/main/src/app/blog/feed/route.ts
+++ b/apps/main/src/app/blog/feed/route.ts
@@ -18,7 +18,7 @@ async function generateRssFeed() {
 
   const blogs = await getBlogContents();
 
-  blogs.forEach((blog) => {
+  for (const blog of blogs) {
     feed.item({
       title: blog.title,
       description: blog.description ?? '',
@@ -26,7 +26,7 @@ async function generateRssFeed() {
       date: blog.updatedAt,
       categories: blog.tags.map((tag) => tag),
     });
-  });
+  }
 
   return feed.xml();
 }

--- a/apps/main/src/mdx-components.tsx
+++ b/apps/main/src/mdx-components.tsx
@@ -38,10 +38,10 @@ const LinkHeading: FC<
           <span
             className={cn(
               'absolute top-1 box-content text-fg-mute opacity-0 transition-opacity duration-500 sm:group-hover:opacity-100',
-              type === 'h2' && '-left-7 top-1.5 pr-2',
+              type === 'h2' && 'top-1.5 -left-7 pr-2',
               type === 'h3' && '-left-7 pr-2',
-              type === 'h4' && '-left-5 top-2 pr-2',
-              type === 'h5' && '-left-5 top-1.5 pr-2',
+              type === 'h4' && 'top-2 -left-5 pr-2',
+              type === 'h5' && 'top-1.5 -left-5 pr-2',
               type === 'h6' && '-left-5 pr-2',
             )}
           >

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -16,45 +16,66 @@
   "linter": {
     "enabled": true,
     "domains": {
-      "test": "all"
+      "test": "all",
+      "turborepo": "all"
     },
     "rules": {
       "recommended": true,
       "a11y": {
+        "noNoninteractiveElementInteractions": "error",
         "noSvgWithoutTitle": "off"
       },
       "complexity": {
         "noExcessiveNestedTestSuites": "error",
+        "noForEach": "error",
         "noUselessStringConcat": "error",
         "useSimplifiedLogicExpression": "error",
-        "useIndexOf": "error",
         "useLiteralKeys": "off"
       },
       "correctness": {
-        "noRenderReturnValue": "error",
-        "useExhaustiveDependencies": "error",
-        "useHookAtTopLevel": "error",
-        "useJsxKeyInIterable": "error",
-        "useJsonImportAttributes": "error",
+        "noNestedComponentDefinitions": "error",
         "noReactPropAssignments": "error",
-        "useUniqueElementIds": "off",
-        "useImageSize": "error"
+        "useJsonImportAttributes": "error",
+        "useUniqueElementIds": "off"
       },
       "nursery": {
+        "noDeprecatedImports": "error",
+        "noForIn": "error",
+        "noFloatingPromises": "error",
+        "noImportCycles": "error",
+        "noMisusedPromises": "error",
+        "noMultiStr": "error",
+        "noNextAsyncClientComponent": "error",
+        "noParametersOnlyUsedInRecursion": "error",
+        "noProto": "error",
+        "noReactForwardRef": "error",
+        "noScriptUrl": "error",
+        "noSyncScripts": "error",
+        "noUndeclaredEnvVars": "error",
+        "noUnknownAttribute": "error",
+        "noUnusedExpressions": "error",
+        "noUselessCatchBinding": "error",
+        "noUselessUndefined": "error",
+        "useArraySortCompare": "error",
         "useExhaustiveSwitchCases": "error",
-        "useSortedClasses": "error"
+        "useFind": "error",
+        "useRegexpExec": "error",
+        "useSortedClasses": "error",
+        "useSpread": "error",
+        "noEmptySource": "error",
+        "noDuplicateDependencies": "error",
+        "useRequiredScripts": "error"
       },
       "performance": {
+        "noAwaitInLoops": "error",
         "noDelete": "error",
-        "noDynamicNamespaceImportAccess": "error",
-        "noImgElement": "error",
         "noAccumulatingSpread": "off"
       },
       "style": {
         "noCommonJs": "error",
+        "noDoneCallback": "error",
         "noEnum": "error",
         "noExportedImports": "error",
-        "noHeadElement": "error",
         "noNamespace": "error",
         "noNegationElse": "error",
         "noParameterAssign": "error",
@@ -114,13 +135,17 @@
   },
   "css": {
     "linter": {
-      "enabled": false
+      "enabled": true
     },
     "assist": {
-      "enabled": false
+      "enabled": true
     },
     "formatter": {
-      "enabled": false
+      "enabled": true
+    },
+    "parser": {
+      "cssModules": true,
+      "tailwindDirectives": true
     }
   },
   "assist": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "server-only": "0.0.1"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.3.8",
+    "@biomejs/biome": "2.3.10",
     "@ls-lint/ls-lint": "2.3.1",
     "@repo/typescript-config": "workspace:*",
     "@types/node": "24.10.3",

--- a/packages/database/biome.json
+++ b/packages/database/biome.json
@@ -1,0 +1,11 @@
+{
+  "root": false,
+  "extends": "//",
+  "linter": {
+    "rules": {
+      "nursery": {
+        "noImportCycles": "off"
+      }
+    }
+  }
+}

--- a/packages/helpers/src/color/extract-color.ts
+++ b/packages/helpers/src/color/extract-color.ts
@@ -279,10 +279,10 @@ if (import.meta.vitest) {
           'violet',
         ];
 
-        namedColors.forEach((color) => {
+        for (const color of namedColors) {
           const result = extractColor(color);
           expect(result).toBe(color);
-        });
+        }
       });
     });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,8 +43,8 @@ importers:
         version: 0.0.1
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.3.8
-        version: 2.3.8
+        specifier: 2.3.10
+        version: 2.3.10
       '@ls-lint/ls-lint':
         specifier: 2.3.1
         version: 2.3.1
@@ -378,59 +378,59 @@ packages:
     resolution: {integrity: sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.3.8':
-    resolution: {integrity: sha512-Qjsgoe6FEBxWAUzwFGFrB+1+M8y/y5kwmg5CHac+GSVOdmOIqsAiXM5QMVGZJ1eCUCLlPZtq4aFAQ0eawEUuUA==}
+  '@biomejs/biome@2.3.10':
+    resolution: {integrity: sha512-/uWSUd1MHX2fjqNLHNL6zLYWBbrJeG412/8H7ESuK8ewoRoMPUgHDebqKrPTx/5n6f17Xzqc9hdg3MEqA5hXnQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.3.8':
-    resolution: {integrity: sha512-HM4Zg9CGQ3txTPflxD19n8MFPrmUAjaC7PQdLkugeeC0cQ+PiVrd7i09gaBS/11QKsTDBJhVg85CEIK9f50Qww==}
+  '@biomejs/cli-darwin-arm64@2.3.10':
+    resolution: {integrity: sha512-M6xUjtCVnNGFfK7HMNKa593nb7fwNm43fq1Mt71kpLpb+4mE7odO8W/oWVDyBVO4ackhresy1ZYO7OJcVo/B7w==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.3.8':
-    resolution: {integrity: sha512-lUDQ03D7y/qEao7RgdjWVGCu+BLYadhKTm40HkpJIi6kn8LSv5PAwRlew/DmwP4YZ9ke9XXoTIQDO1vAnbRZlA==}
+  '@biomejs/cli-darwin-x64@2.3.10':
+    resolution: {integrity: sha512-Vae7+V6t/Avr8tVbFNjnFSTKZogZHFYl7MMH62P/J1kZtr0tyRQ9Fe0onjqjS2Ek9lmNLmZc/VR5uSekh+p1fg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.3.8':
-    resolution: {integrity: sha512-PShR4mM0sjksUMyxbyPNMxoKFPVF48fU8Qe8Sfx6w6F42verbwRLbz+QiKNiDPRJwUoMG1nPM50OBL3aOnTevA==}
+  '@biomejs/cli-linux-arm64-musl@2.3.10':
+    resolution: {integrity: sha512-B9DszIHkuKtOH2IFeeVkQmSMVUjss9KtHaNXquYYWCjH8IstNgXgx5B0aSBQNr6mn4RcKKRQZXn9Zu1rM3O0/A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.3.8':
-    resolution: {integrity: sha512-Uo1OJnIkJgSgF+USx970fsM/drtPcQ39I+JO+Fjsaa9ZdCN1oysQmy6oAGbyESlouz+rzEckLTF6DS7cWse95g==}
+  '@biomejs/cli-linux-arm64@2.3.10':
+    resolution: {integrity: sha512-hhPw2V3/EpHKsileVOFynuWiKRgFEV48cLe0eA+G2wO4SzlwEhLEB9LhlSrVeu2mtSn205W283LkX7Fh48CaxA==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.3.8':
-    resolution: {integrity: sha512-YGLkqU91r1276uwSjiUD/xaVikdxgV1QpsicT0bIA1TaieM6E5ibMZeSyjQ/izBn4tKQthUSsVZacmoJfa3pDA==}
+  '@biomejs/cli-linux-x64-musl@2.3.10':
+    resolution: {integrity: sha512-QTfHZQh62SDFdYc2nfmZFuTm5yYb4eO1zwfB+90YxUumRCR171tS1GoTX5OD0wrv4UsziMPmrePMtkTnNyYG3g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.3.8':
-    resolution: {integrity: sha512-QDPMD5bQz6qOVb3kiBui0zKZXASLo0NIQ9JVJio5RveBEFgDgsvJFUvZIbMbUZT3T00M/1wdzwWXk4GIh0KaAw==}
+  '@biomejs/cli-linux-x64@2.3.10':
+    resolution: {integrity: sha512-wwAkWD1MR95u+J4LkWP74/vGz+tRrIQvr8kfMMJY8KOQ8+HMVleREOcPYsQX82S7uueco60L58Wc6M1I9WA9Dw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.3.8':
-    resolution: {integrity: sha512-H4IoCHvL1fXKDrTALeTKMiE7GGWFAraDwBYFquE/L/5r1927Te0mYIGseXi4F+lrrwhSWbSGt5qPFswNoBaCxg==}
+  '@biomejs/cli-win32-arm64@2.3.10':
+    resolution: {integrity: sha512-o7lYc9n+CfRbHvkjPhm8s9FgbKdYZu5HCcGVMItLjz93EhgJ8AM44W+QckDqLA9MKDNFrR8nPbO4b73VC5kGGQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.3.8':
-    resolution: {integrity: sha512-RguzimPoZWtBapfKhKjcWXBVI91tiSprqdBYu7tWhgN8pKRZhw24rFeNZTNf6UiBfjCYCi9eFQs/JzJZIhuK4w==}
+  '@biomejs/cli-win32-x64@2.3.10':
+    resolution: {integrity: sha512-pHEFgq7dUEsKnqG9mx9bXihxGI49X+ar+UBrEIj3Wqj3UCZp1rNgV+OoyjFgcXsjCWpuEAF4VJdkZr3TrWdCbQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -5514,39 +5514,39 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@biomejs/biome@2.3.8':
+  '@biomejs/biome@2.3.10':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.3.8
-      '@biomejs/cli-darwin-x64': 2.3.8
-      '@biomejs/cli-linux-arm64': 2.3.8
-      '@biomejs/cli-linux-arm64-musl': 2.3.8
-      '@biomejs/cli-linux-x64': 2.3.8
-      '@biomejs/cli-linux-x64-musl': 2.3.8
-      '@biomejs/cli-win32-arm64': 2.3.8
-      '@biomejs/cli-win32-x64': 2.3.8
+      '@biomejs/cli-darwin-arm64': 2.3.10
+      '@biomejs/cli-darwin-x64': 2.3.10
+      '@biomejs/cli-linux-arm64': 2.3.10
+      '@biomejs/cli-linux-arm64-musl': 2.3.10
+      '@biomejs/cli-linux-x64': 2.3.10
+      '@biomejs/cli-linux-x64-musl': 2.3.10
+      '@biomejs/cli-win32-arm64': 2.3.10
+      '@biomejs/cli-win32-x64': 2.3.10
 
-  '@biomejs/cli-darwin-arm64@2.3.8':
+  '@biomejs/cli-darwin-arm64@2.3.10':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.3.8':
+  '@biomejs/cli-darwin-x64@2.3.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.3.8':
+  '@biomejs/cli-linux-arm64-musl@2.3.10':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.3.8':
+  '@biomejs/cli-linux-arm64@2.3.10':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.3.8':
+  '@biomejs/cli-linux-x64-musl@2.3.10':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.3.8':
+  '@biomejs/cli-linux-x64@2.3.10':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.3.8':
+  '@biomejs/cli-win32-arm64@2.3.10':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.3.8':
+  '@biomejs/cli-win32-x64@2.3.10':
     optional: true
 
   '@clack/core@0.3.5':


### PR DESCRIPTION
## Summary
- `noForEach`ルール対応: `forEach`を`for...of`に変換
- `noAwaitInLoops`ルール対応: ループ内の`await`を`Promise.all`に変更
- `noImportCycles`ルール対応: データベーススキーマファイルの循環インポートを許可

## Changes
### forEachの削除
- `table-of-context.tsx`: 見出し要素の監視ループ
- `blog/feed/route.ts`: RSSフィードのアイテム追加ループ
- `extract-color.ts`: テストコード内のループ

### ループ内awaitの修正
- `clipboard-image-demo.tsx`: PNG画像取得を並列処理に変更

### 設定変更
- `packages/database/biome.json`: 新規作成し`noImportCycles`をオフに設定
- Drizzle ORMのrelations定義で必要な循環インポートを許可

## Test plan
- [ ] `pnpm run check`が成功すること
- [ ] 既存の機能が正常に動作すること
- [ ] ビルドが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)