### PR TITLE
fix: Vercelでのpostinstallエラーを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,13 @@
   "engines": {
     "node": "24.12.0"
   },
+  "devEngines": {
+    "runtime": {
+      "name": "node",
+      "version": "^24.4.0",
+      "onFail": "download"
+    }
+  },
   "packageManager": "pnpm@10.26.1",
   "scripts": {
     "dev": "turbo dev",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       next-devtools-mcp:
         specifier: 0.3.7
         version: 0.3.7
+      node:
+        specifier: runtime:^24.4.0
+        version: runtime:24.12.0
       playwright:
         specifier: 1.57.0
         version: 1.57.0
@@ -4215,6 +4218,96 @@ packages:
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  node@runtime:24.12.0:
+    resolution:
+      type: variations
+      variants:
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-MfPQZbuE8GnlIuVdDTA1vTZMul2KIiM/9oAF0oHou3g=
+            type: binary
+            url: https://nodejs.org/download/release/v24.12.0/node-v24.12.0-aix-ppc64.tar.gz
+          targets:
+            - cpu: ppc64
+              os: aix
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-MZ8iGtxeRP8O1X6KRBsihPArjcb8h7jrkqapNkP9gIA=
+            type: binary
+            url: https://nodejs.org/download/release/v24.12.0/node-v24.12.0-darwin-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-uC6kxi/QjiUMq1nWJeddd8xbCj1gxmmOvuRUXIihacU=
+            type: binary
+            url: https://nodejs.org/download/release/v24.12.0/node-v24.12.0-darwin-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: darwin
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-myou65io6zc2EiTiodBgMArS3RQ69Y39sW3nhd8PEig=
+            type: binary
+            url: https://nodejs.org/download/release/v24.12.0/node-v24.12.0-linux-arm64.tar.gz
+          targets:
+            - cpu: arm64
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-Zux5tNZPQQmu34IhCHFdC2CXEY35FZwvYyFHfaTqF6o=
+            type: binary
+            url: https://nodejs.org/download/release/v24.12.0/node-v24.12.0-linux-ppc64le.tar.gz
+          targets:
+            - cpu: ppc64le
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-jclgolVdsap3/RMcJb5XG594RLyLJ454cyufWA/n1YA=
+            type: binary
+            url: https://nodejs.org/download/release/v24.12.0/node-v24.12.0-linux-s390x.tar.gz
+          targets:
+            - cpu: s390x
+              os: linux
+        - resolution:
+            archive: tarball
+            bin: bin/node
+            integrity: sha256-YVkifgr318PGuy+pAEUrBKbLiEGnAqeazGEyCdcLBNA=
+            type: binary
+            url: https://nodejs.org/download/release/v24.12.0/node-v24.12.0-linux-x64.tar.gz
+          targets:
+            - cpu: x64
+              os: linux
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-sF5+Bm+BPTWtPNnCTu2u4HTAEqx+AAcSl2CP3S6UiuM=
+            prefix: node-v24.12.0-win-arm64
+            type: binary
+            url: https://nodejs.org/download/release/v24.12.0/node-v24.12.0-win-arm64.zip
+          targets:
+            - cpu: arm64
+              os: win32
+        - resolution:
+            archive: zip
+            bin: node.exe
+            integrity: sha256-nBJfYa6Ue1LneQlYMPnKwmeEagQ+9xkhg8hAFqqtKBI=
+            prefix: node-v24.12.0-win-x64
+            type: binary
+            url: https://nodejs.org/download/release/v24.12.0/node-v24.12.0-win-x64.zip
+          targets:
+            - cpu: x64
+              os: win32
+    version: 24.12.0
+    hasBin: true
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -9160,6 +9253,8 @@ snapshots:
       - babel-plugin-macros
 
   node-releases@2.0.27: {}
+
+  node@runtime:24.12.0: {}
 
   normalize-path@3.0.0: {}
 


### PR DESCRIPTION
## Summary
- Vercelでのpnpm installでlefthookとmswのpostinstallスクリプトが失敗する問題を修正
- `devEngines`設定でNodeランタイムをpnpmに管理させることで、postinstallスクリプトが正しくnodeバイナリを見つけられるようにする

## 問題
```
.../node_modules/lefthook postinstall$ node postinstall.js
.../node_modules/msw postinstall: /vercel/path0/node_modules/.bin/node: line 17: /vercel/path0/node_modules/.bin/../node/bin/node: No such file or directory
```

## 解決策
`devEngines.runtime`でpnpmにNodeランタイムをダウンロード・管理させることで、`node_modules/.bin/node`が正しいパスを指すようにする。

## Test plan
- [ ] Vercelでのデプロイが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)