### PR TITLE
chore: frontend-designスキルにライセンス表記を追加

### DIFF
--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -95,6 +95,10 @@ description: 独自性のある本番品質のフロントエンドインター�
 [frontend-design (0075614)](https://github.com/anthropics/skills/tree/0075614/skills/frontend-design)
 をベースに作成されています。
 
-原作は Apache License 2.0 でライセンスされています。
-変更点: 日本語に翻訳し、k8oプロジェクト固有の設定（ArteOdyssey UIライブラリ、
-TailwindCSSカスタムトークン等）を追加しました。
+Copyright 2025 Anthropic, PBC
+
+原作は [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0) でライセンスされています。
+
+**MODIFIED**: このファイルは原作から以下の変更を加えています：
+- 日本語に翻訳
+- k8oプロジェクト固有の設定を追加（ArteOdyssey UIライブラリ、TailwindCSSカスタムトークン等）


### PR DESCRIPTION
anthropics/skillsリポジトリのfrontend-designスキルをベースに
作成したため、Apache License 2.0の帰属表示要件に従い
ライセンス情報を追加しました。