### PR TITLE
fix(database): ERDビルドをDrizzle形式に変更

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -19,7 +19,7 @@
     "generate:custom": "drizzle-kit generate --custom",
     "migrate": "drizzle-kit migrate",
     "export:schema": "drizzle-kit export > ./schema.sql",
-    "build:erd": "liam erd build --input ./schema.sql --format sqlite",
+    "build:erd": "liam erd build --input './src/schema/*.ts' --format drizzle",
     "preview:erd": "pnpm run build:erd && pnpm dlx http-server dist"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- liamのERDツールがSQLite形式をサポートしていないため、Drizzle形式に変更
- `--format sqlite` → `--format drizzle`
- 入力を`./schema.sql`から`'./src/schema/*.ts'`に変更

## Test plan
- [x] ローカルで`pnpm -F @repo/database run build:erd`が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)