### PR TITLE
feat: HomeのActivityセクションに最近のブログを追加

### DIFF
--- a/apps/main/src/app/_components/recent-blogs/blog-card.stories.tsx
+++ b/apps/main/src/app/_components/recent-blogs/blog-card.stories.tsx
@@ -1,0 +1,107 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+import { BlogCard } from './blog-card';
+
+const meta: Meta<typeof BlogCard> = {
+  title: 'app/globals/recent-blogs/blog-card',
+  component: BlogCard,
+};
+
+export default meta;
+type Story = StoryObj<typeof BlogCard>;
+
+export const Primary: Story = {
+  args: {
+    slug: 'example-post',
+    title: 'サンプル記事のタイトル',
+    description:
+      'これはサンプル記事の説明文です。記事の概要を簡潔に説明します。',
+    tags: ['React', 'TypeScript'],
+    createdAt: new Date('2024/01/15'),
+  },
+};
+
+export const DisplaysTitle: Story = {
+  args: {
+    slug: 'test-slug',
+    title: 'テスト記事のタイトル',
+    description: 'テスト説明文',
+    tags: ['React'],
+    createdAt: new Date('2024/01/15'),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByRole('heading', { name: 'テスト記事のタイトル' }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const DisplaysTags: Story = {
+  args: {
+    slug: 'test-slug',
+    title: 'テスト記事',
+    description: null,
+    tags: ['React', 'TypeScript', 'Next.js'],
+    createdAt: new Date('2024/01/15'),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('React')).toBeInTheDocument();
+    await expect(canvas.getByText('TypeScript')).toBeInTheDocument();
+    await expect(canvas.getByText('Next.js')).toBeInTheDocument();
+  },
+};
+
+export const DisplaysDate: Story = {
+  args: {
+    slug: 'test-slug',
+    title: 'テスト記事',
+    description: null,
+    tags: [],
+    createdAt: new Date('2024/01/15'),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('2024年1月15日')).toBeInTheDocument();
+  },
+};
+
+export const HasLinkToBlog: Story = {
+  args: {
+    slug: 'my-blog-post',
+    title: 'ブログ記事リンクテスト',
+    description: null,
+    tags: ['React'],
+    createdAt: new Date('2024/01/15'),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const link = canvas.getByRole('link');
+    await expect(link).toHaveAttribute('href', '/blog/my-blog-post');
+  },
+};
+
+export const WithoutDescription: Story = {
+  args: {
+    slug: 'no-description',
+    title: '説明なしの記事',
+    description: null,
+    tags: ['TypeScript'],
+    createdAt: new Date('2024/02/20'),
+  },
+};
+
+export const WithoutTags: Story = {
+  args: {
+    slug: 'no-tags',
+    title: 'タグなしの記事',
+    description: '説明文あり',
+    tags: [],
+    createdAt: new Date('2024/02/20'),
+  },
+};

--- a/apps/main/src/app/_components/recent-blogs/blog-card.tsx
+++ b/apps/main/src/app/_components/recent-blogs/blog-card.tsx
@@ -1,0 +1,55 @@
+import { InteractiveCard } from '@k8o/arte-odyssey/card';
+import { Heading } from '@k8o/arte-odyssey/heading';
+import { PublishDateIcon, TagIcon } from '@k8o/arte-odyssey/icons';
+import { TextTag } from '@k8o/arte-odyssey/text-tag';
+import { formatDate } from '@repo/helpers/date/format';
+import type { Route } from 'next';
+import Link from 'next/link';
+import type { FC } from 'react';
+
+type BlogCardProps = {
+  slug: string;
+  title: string;
+  description: string | null;
+  tags: string[];
+  createdAt: Date;
+};
+
+export const BlogCard: FC<BlogCardProps> = ({
+  slug,
+  title,
+  description,
+  tags,
+  createdAt,
+}) => {
+  return (
+    <InteractiveCard>
+      <Link className="group block h-full" href={`/blog/${slug}` as Route}>
+        <div className="flex h-full flex-col justify-between gap-4 p-4">
+          <div className="flex flex-col gap-1 group-hover:text-primary-fg">
+            <Heading lineClamp={2} type="h3">
+              {title}
+            </Heading>
+            {description && (
+              <p className="line-clamp-2 text-fg-mute text-sm">{description}</p>
+            )}
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            {tags.length > 0 && (
+              <div className="flex flex-wrap items-center gap-2">
+                <TagIcon size="sm" />
+                {tags.map((tag) => (
+                  <TextTag key={tag} size="sm" text={tag} />
+                ))}
+              </div>
+            )}
+            <div className="ml-auto flex items-center gap-1 text-fg-mute text-xs">
+              <PublishDateIcon size="sm" />
+              <span>{formatDate(createdAt, 'yyyy年M月d日')}</span>
+            </div>
+          </div>
+        </div>
+      </Link>
+    </InteractiveCard>
+  );
+};

--- a/apps/main/src/app/_components/recent-blogs/index.ts
+++ b/apps/main/src/app/_components/recent-blogs/index.ts
@@ -1,0 +1,1 @@
+export { RecentBlogs } from './recent-blogs';

--- a/apps/main/src/app/_components/recent-blogs/recent-blogs.tsx
+++ b/apps/main/src/app/_components/recent-blogs/recent-blogs.tsx
@@ -1,0 +1,48 @@
+import { Card } from '@k8o/arte-odyssey/card';
+import { cacheLife } from 'next/cache';
+import { Suspense } from 'react';
+import { getBlogContents } from '@/app/blog/_api';
+import { BlogCard } from './blog-card';
+
+const Skeleton = () => (
+  <div className="flex flex-col gap-4">
+    {[1, 2, 3].map((i) => (
+      <Card key={i}>
+        <div className="flex flex-col gap-4 p-4">
+          <div className="flex flex-col gap-2">
+            <div className="h-6 w-3/4 animate-pulse rounded bg-bg-mute" />
+            <div className="h-4 w-full animate-pulse rounded bg-bg-mute" />
+          </div>
+          <div className="h-4 w-24 animate-pulse rounded bg-bg-mute" />
+        </div>
+      </Card>
+    ))}
+  </div>
+);
+
+/**
+ * 最近のブログ記事コンポーネント（Server Component）
+ */
+export const RecentBlogs = () => {
+  return (
+    <Suspense fallback={<Skeleton />}>
+      <RecentBlogsContent />
+    </Suspense>
+  );
+};
+
+const RecentBlogsContent = async () => {
+  'use cache';
+  cacheLife('days');
+
+  const blogs = await getBlogContents();
+  const recentBlogs = blogs.slice(0, 3);
+
+  return (
+    <div className="flex flex-col gap-4">
+      {recentBlogs.map((blog) => (
+        <BlogCard key={blog.id} {...blog} />
+      ))}
+    </div>
+  );
+};

--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -12,6 +12,7 @@ import Image from 'next/image';
 import { AppCard } from './_components/app-card';
 import { EmailTooltip } from './_components/email-tooltip';
 import { GitHubContributionGraph } from './_components/github-contribution-graph';
+import { RecentBlogs } from './_components/recent-blogs';
 import arteodyssey from './_images/arteodyssey.png';
 import k8o from './_images/k8o.jpg';
 import { RoundedIcon } from './radius-maker/_components/rounded-icon';
@@ -78,8 +79,13 @@ export default function Home() {
         <div>
           <Heading type="h2">Activity</Heading>
         </div>
-        <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
-          <GitHubContributionGraph />
+        <div className="grid items-start gap-8 md:grid-cols-2 lg:grid-cols-3">
+          <div className="lg:sticky lg:top-4">
+            <GitHubContributionGraph />
+          </div>
+          <div className="md:col-span-2">
+            <RecentBlogs />
+          </div>
         </div>
       </div>
       <div className="flex flex-col gap-6">


### PR DESCRIPTION
## Summary
- HomeページのActivityセクションに最近のブログ3件を表示
- 専用のBlogCardコンポーネントを作成（タイトル、説明、タグ、公開日を表示）
- GitHubContributionGraphをlg以上でstickyに設定し、スクロール時も追従

## Test plan
- [ ] Homeページで最近のブログ3件が表示されることを確認
- [ ] BlogCardのStorybookテストが通ることを確認
- [ ] レスポンシブデザインの確認（sm/md/lg）
- [ ] GitHubContributionGraphがlg以上でstickyになることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)