### PR TITLE
feat: add font-family: math blog article

### DIFF
--- a/apps/main/src/app/_components/playgrounds/font-family-math/font-family-math-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/font-family-math/font-family-math-demo.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { Playground } from '../playground';
+import { FontFamilyMathDemo } from './font-family-math-demo';
+
+const meta: Meta<typeof FontFamilyMathDemo> = {
+  title: 'playgrounds/font-family-math/FontFamilyMathDemo',
+  component: FontFamilyMathDemo,
+  decorators: [
+    (Story) => (
+      <Playground>
+        <Story />
+      </Playground>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FontFamilyMathDemo>;
+
+export const Default: Story = {};

--- a/apps/main/src/app/_components/playgrounds/font-family-math/font-family-math-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/font-family-math/font-family-math-demo.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Checkbox } from '@k8o/arte-odyssey/form/checkbox';
+import { useState } from 'react';
+
+/**
+ * font-family: mathプロパティのデモ
+ * 通常のフォントとmathフォントの違いを比較できる
+ */
+export function FontFamilyMathDemo() {
+  const [useMathFont, setUseMathFont] = useState(true);
+
+  const fontFamily = useMathFont ? 'math' : 'sans-serif';
+
+  return (
+    <div className="space-y-6">
+      <Checkbox
+        label="mathフォントを適用する"
+        onChange={(e) => setUseMathFont(e.target.checked)}
+        value={useMathFont}
+      />
+
+      <div className="space-y-4 rounded-lg border border-border-base bg-bg-base p-6">
+        <div>
+          <p className="mb-2 text-fg-mute text-sm">
+            ピタゴラスの定理（上付き文字）
+          </p>
+          <p className="text-2xl" style={{ fontFamily }}>
+            x² + y² = z²
+          </p>
+        </div>
+
+        <div>
+          <p className="mb-2 text-fg-mute text-sm">
+            等差数列（上付き・下付き文字）
+          </p>
+          <p className="text-2xl" style={{ fontFamily }}>
+            aₙ = a₁ + (n−1)d
+          </p>
+        </div>
+
+        <div>
+          <p className="mb-2 text-fg-mute text-sm">
+            数の集合（Blackboard bold）
+          </p>
+          <p className="text-2xl" style={{ fontFamily }}>
+            ℕ ⊂ ℤ ⊂ ℚ ⊂ ℝ ⊂ ℂ
+          </p>
+        </div>
+
+        <div>
+          <p className="mb-2 text-fg-mute text-sm">積分記号</p>
+          <p className="text-2xl" style={{ fontFamily }}>
+            ∫₀^∞ e⁻ˣ dx = 1
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/app/_components/playgrounds/font-family-math/index.ts
+++ b/apps/main/src/app/_components/playgrounds/font-family-math/index.ts
@@ -1,0 +1,19 @@
+import type { PlaygroundSection } from '../types';
+import { FontFamilyMathDemo } from './font-family-math-demo';
+
+export { FontFamilyMathDemo } from './font-family-math-demo';
+
+export const fontFamilyMathSection: PlaygroundSection = {
+  id: 'font-family-math',
+  title: 'font-family: math',
+  description:
+    '数学的表現に特化したgeneric font familyで、数式を適切に表示します。',
+  type: 'blog',
+  slug: 'font-family-math',
+  demos: [
+    {
+      component: FontFamilyMathDemo,
+      title: 'font-family: mathプロパティ',
+    },
+  ],
+};

--- a/apps/main/src/app/_components/playgrounds/index.ts
+++ b/apps/main/src/app/_components/playgrounds/index.ts
@@ -5,6 +5,7 @@ export * from './composed-ranges';
 export * from './content-visibility';
 export * from './details-content';
 export * from './event-timing';
+export * from './font-family-math';
 export * from './highlight';
 export * from './input-file-webkitdirectory';
 export * from './largest-contentful-paint';
@@ -28,6 +29,7 @@ import { composedRangesSection } from './composed-ranges';
 import { contentVisibilitySection } from './content-visibility';
 import { detailsContentSection } from './details-content';
 import { eventTimingSection } from './event-timing';
+import { fontFamilyMathSection } from './font-family-math';
 import { highlightSection } from './highlight';
 import { inputFileWebkitdirectorySection } from './input-file-webkitdirectory';
 import { lcpSection } from './largest-contentful-paint';
@@ -50,6 +52,7 @@ export const playgroundSections: PlaygroundSection[] = [
   contentVisibilitySection,
   detailsContentSection,
   eventTimingSection,
+  fontFamilyMathSection,
   inputFileWebkitdirectorySection,
   lcpSection,
   popoverSection,

--- a/apps/main/src/app/blog/(articles)/font-family-math/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/font-family-math/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import { getBlogContent } from '@/app/blog/_api';
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+
+const slug = 'font-family-math';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt.toString(),
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/font-family-math'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/font-family-math/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/font-family-math/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getBlogContent } from '@/app/blog/_api';
+
+export const alt = 'font-family: mathで数式に適切なフォントを適用する';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const blog = await getBlogContent('font-family-math');
+
+  return await OgImage({
+    category: 'Blog',
+    title: blog.title,
+  });
+}

--- a/apps/main/src/app/blog/(articles)/font-family-math/page.mdx
+++ b/apps/main/src/app/blog/(articles)/font-family-math/page.mdx
@@ -1,0 +1,104 @@
+---
+title: 'font-family: mathで数式に適切なフォントを適用する'
+description: 'font-family: mathは数学的表現に特化した一般フォントファミリーです。上付き・下付き文字、複数行にまたがる括弧、数式の入れ子構造などを適切に表示できます。Baseline 2025で主要ブラウザすべてで利用可能になりました。'
+createdAt: 2026-01-12
+updatedAt: 2026-01-12
+---
+
+import { BaselineStatus } from '@k8o/arte-odyssey/baseline-status';
+import { FontFamilyMathDemo } from '@/app/_components/playgrounds/font-family-math';
+import { Playground } from '@/app/_components/playgrounds';
+
+# font-family: mathで数式に適切なフォントを適用する
+
+<BaselineStatus featureId="font-family-math"></BaselineStatus>
+
+## はじめに
+
+Webページで数式を表示する際、適切なフォントがないと正しく表示されないことがあります。
+上付き文字（$x^2$）や下付き文字（$a_n$）、分数（$\frac{a}{b}$）、積分記号（$\int$）など、数学特有の表現には専用のグリフが必要です。
+
+CSSではBaseline 2025より、`font-family`プロパティとして`math`を指定することで数式を適切に表示できるようになりました。
+
+## font-family: mathとは
+
+`math`は数学的表現に特化した一般フォントファミリーです。以下のような表現に対応しています。
+
+- 上付き文字・下付き文字: $x^2$や$a_n$などの指数や添字
+- 複数行にまたがる括弧: $$\left( \frac{a}{b} \right)$$
+- 数式の入れ子構造: $$\frac{\frac{a}{b}}{c}$$
+- Blackboard bold: $\mathbb{N}$、$\mathbb{Z}$、$\mathbb{R}$など
+
+一般フォントファミリーとは、特定のフォント名ではなくフォントの種類を指定するキーワードです。
+`serif`（明朝体）、`sans-serif`（ゴシック体）、`monospace`（等幅）などがあり、`math`はその数式版として追加されました。
+
+## 使い方
+
+一般フォントファミリーなので、フォントの読み込み指定は不要で、以下のように指定するだけで使用できます。
+
+```css
+.math-expression {
+  font-family: math;
+}
+```
+
+`<math>`要素はUAスタイルシートで`font-family: math`が指定することになっています。
+
+<math display="block">
+  <mrow>
+    <msubsup>
+      <mo>∫</mo>
+      <mn>0</mn>
+      <mn>1</mn>
+    </msubsup>
+    <msup><mi>x</mi><mn>2</mn></msup>
+    <mi>dx</mi>
+  </mrow>
+  <mo>=</mo>
+  <mfrac>
+    <mn>1</mn>
+    <mn>3</mn>
+  </mfrac>
+</math>
+
+```html
+<!-- 上記の数式を表示するHTML -->
+<math display="block">
+  <mrow>
+    <msubsup>
+      <mo>∫</mo>
+      <mn>0</mn>
+      <mn>1</mn>
+    </msubsup>
+    <msup><mi>x</mi><mn>2</mn></msup>
+    <mi>dx</mi>
+  </mrow>
+  <mo>=</mo>
+  <mfrac>
+    <mn>1</mn>
+    <mn>3</mn>
+  </mfrac>
+</math>
+```
+
+## 使われるフォント
+
+`font-family: math`を指定すると、ブラウザが数式表示に適したフォントを自動的に選択します。
+`serif`を指定したときに明朝体が選ばれるのと同じ仕組みです（実際に選ばれるフォントは環境によって異なります）。
+
+どのフォントが選ばれるかはブラウザとOSの組み合わせによって異なります。
+Windowsには`Cambria Math`、macOS（Ventura以降）には`STIX Two Math`がプリインストールされているため、多くの環境では追加のインストールなしこれらが利用されます。
+
+## デモ
+
+<Playground>
+  <FontFamilyMathDemo />
+</Playground>
+
+## おわりに
+
+`font-family: math`を紹介しました。
+
+`font-family`を`math`にするだけで、数式に適切なフォントが適用され、見やすく美しい表示が可能になる便利な機能です。
+
+数式を簡単に表示する際はぜひ活用してみてください。

--- a/packages/database/migrations/0009_careless_storm.sql
+++ b/packages/database/migrations/0009_careless_storm.sql
@@ -1,0 +1,6 @@
+INSERT INTO tags (id, name) VALUES (94, 'font-family: math');--> statement-breakpoint
+INSERT INTO blogs (id, slug, published, created_at) VALUES (44, 'font-family-math', 1, '2026-01-12T00:00:00.000Z');--> statement-breakpoint
+INSERT INTO blog_views (blog_id, views) VALUES (44, 0);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (44, 30);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (44, 11);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (44, 94);

--- a/packages/database/migrations/meta/0009_snapshot.json
+++ b/packages/database/migrations/meta/0009_snapshot.json
@@ -1,0 +1,1009 @@
+{
+  "id": "7ed295d7-69fd-49d5-93bc-73de6bff6284",
+  "prevId": "de6401e2-603e-4194-b3b8-0ebf5eae4fa0",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_id_idx": {
+          "name": "comments_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_answers": {
+      "name": "quiz_answers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "answer": {
+          "name": "answer",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quiz_answers_quiz_id_idx": {
+          "name": "quiz_answers_quiz_id_idx",
+          "columns": [
+            "quiz_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "quiz_answers_quiz_id_quizzes_id_fk": {
+          "name": "quiz_answers_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_answers",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "tableTo": "quizzes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_questions": {
+      "name": "quiz_questions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "quiz_id": {
+          "name": "quiz_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "highlight": {
+          "name": "highlight",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "question": {
+          "name": "question",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quiz_questions_quiz_id_idx": {
+          "name": "quiz_questions_quiz_id_idx",
+          "columns": [
+            "quiz_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "quiz_questions_quiz_id_quizzes_id_fk": {
+          "name": "quiz_questions_quiz_id_quizzes_id_fk",
+          "tableFrom": "quiz_questions",
+          "columnsFrom": [
+            "quiz_id"
+          ],
+          "tableTo": "quizzes",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quiz_type": {
+      "name": "quiz_type",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quiz_type_name_idx": {
+          "name": "quiz_type_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "quizzes": {
+      "name": "quizzes",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "quizzes_type_idx": {
+          "name": "quizzes_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "quizzes_type_quiz_type_id_fk": {
+          "name": "quizzes_type_quiz_type_id_fk",
+          "tableFrom": "quizzes",
+          "columnsFrom": [
+            "type"
+          ],
+          "tableTo": "quiz_type",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_tag": {
+      "name": "service_tag",
+      "columns": {
+        "service_id": {
+          "name": "service_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "service_tag_service_id_idx": {
+          "name": "service_tag_service_id_idx",
+          "columns": [
+            "service_id"
+          ],
+          "isUnique": false
+        },
+        "service_tag_tag_id_idx": {
+          "name": "service_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "service_tag_unique_idx": {
+          "name": "service_tag_unique_idx",
+          "columns": [
+            "service_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "service_tag_service_id_services_id_fk": {
+          "name": "service_tag_service_id_services_id_fk",
+          "tableFrom": "service_tag",
+          "columnsFrom": [
+            "service_id"
+          ],
+          "tableTo": "services",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "service_tag_tag_id_tags_id_fk": {
+          "name": "service_tag_tag_id_tags_id_fk",
+          "tableFrom": "service_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "service_type": {
+      "name": "service_type",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "service_type_name_idx": {
+          "name": "service_type_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "services": {
+      "name": "services",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "services_slug_idx": {
+          "name": "services_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "services_id_idx": {
+          "name": "services_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "services_type_idx": {
+          "name": "services_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "services_type_service_type_id_fk": {
+          "name": "services_type_service_type_id_fk",
+          "tableFrom": "services",
+          "columnsFrom": [
+            "type"
+          ],
+          "tableTo": "service_type",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "subscribers": {
+      "name": "subscribers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "token_expires_at": {
+          "name": "token_expires_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "subscribers_id_idx": {
+          "name": "subscribers_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "subscribers_email_idx": {
+          "name": "subscribers_email_idx",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_id_idx": {
+          "name": "talks_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1767075601899,
       "tag": "0008_ancient_punisher",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1768021782501,
+      "tag": "0009_careless_storm",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
closed: https://github.com/k35o/k8o/issues/1344

## Summary

- Baseline 2025で追加された`font-family: math`についてのブログ記事を追加
- インタラクティブなPlaygroundデモを実装（チェックボックスでmathフォントの切り替え）
- MathMLを使った積分の例を追加
- データベースマイグレーションでブログエントリとタグを追加

## Test plan

- [ ] 開発サーバーで記事が正しく表示されることを確認
- [ ] Playgroundデモでフォント切り替えが動作することを確認
- [ ] MathML数式が正しくレンダリングされることを確認
- [ ] Storybookでコンポーネントが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)