### PR TITLE
fix: correct description of commandfor behavior

### DIFF
--- a/apps/main/src/app/blog/(articles)/invoker-commands/page.mdx
+++ b/apps/main/src/app/blog/(articles)/invoker-commands/page.mdx
@@ -51,7 +51,7 @@ Invoker Commands APIは`commandfor`と`command`の2つの属性で構成され�
 
 `command`は現在カスタム値を除いて、Dialogの`show-modal`・`close`・`request-close`、Popoverの`show-popover`・`hide-popover`・`toggle-popover`が使えます。
 
-`commandfor`で指定した要素をクリックすると、JavaScriptでは`showModal()`・`close()`・`requestClose()`、`showPopover()`・`hidePopover()`・`togglePopover()`メソッド相当の動作が実行されます。
+ボタンをクリックすると、`commandfor`で指定した要素に対してJavaScriptの`showModal()`・`close()`・`requestClose()`、`showPopover()`・`hidePopover()`・`togglePopover()`メソッド相当の動作が実行されます。
 
 ### Dialogの操作
 


### PR DESCRIPTION
## Summary
- `commandfor`で指定した要素をクリック → ボタンをクリックすると、`commandfor`で指定した要素に対して

記事の説明が間違っていたので修正。

🤖 Generated with [Claude Code](https://claude.com/claude-code)