### PR TITLE
refactor: simplify GitHubContributionGraph component

### DIFF
--- a/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.tsx
@@ -1,6 +1,4 @@
 import { cacheLife } from 'next/cache';
-import { Suspense } from 'react';
-import type { ContributionWeek } from '@/services/github/contributions';
 import { fetchK8oRepositoryContributions } from '@/services/github/contributions';
 import { Presenter } from './presenter';
 
@@ -9,26 +7,10 @@ const OWNER = 'k35o';
 const REPO = 'k8o';
 
 /**
- * 空のコントリビューションデータ（10週間分の空データ）
- * プリレンダリング時にnew Date()を使用しないよう、静的な空配列を使用
- */
-const EMPTY_WEEKS: ContributionWeek[] = Array.from({ length: 10 }, () => ({
-  days: Array.from({ length: 5 }, () => ({
-    date: '2000-01-01',
-    count: 0,
-    level: 0,
-  })),
-}));
-
-/**
  * GitHub Contributionグラフコンポーネント（Server Component）
  */
 export const GitHubContributionGraph = () => {
-  return (
-    <Suspense fallback={<Presenter weeks={EMPTY_WEEKS} />}>
-      <RepositoryContributionsContent />
-    </Suspense>
-  );
+  return <RepositoryContributionsContent />;
 };
 
 /**


### PR DESCRIPTION
## Summary

- Suspenseラッパーと空のフォールバックデータを削除
- コンポーネントを直接`RepositoryContributionsContent`をレンダリングするようにシンプル化

## Test plan

- [ ] トップページでGitHub Contributionグラフが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)