### PR TITLE
chore: remove Zenn link from external blog component

### DIFF
--- a/apps/main/src/app/blog/_components/external-blog/external-blog.tsx
+++ b/apps/main/src/app/blog/_components/external-blog/external-blog.tsx
@@ -1,5 +1,5 @@
 import { IconLink } from '@k8o/arte-odyssey/icon-link';
-import { QiitaIcon, RSSIcon, ZennIcon } from '@k8o/arte-odyssey/icons';
+import { QiitaIcon, RSSIcon } from '@k8o/arte-odyssey/icons';
 import type { FC } from 'react';
 
 export const ExternalBlog: FC = () => {
@@ -11,13 +11,6 @@ export const ExternalBlog: FC = () => {
         label="Qiitaのアカウント"
       >
         <QiitaIcon />
-      </IconLink>
-      <IconLink
-        bg="base"
-        href="https://zenn.dev/kokisakano"
-        label="Zennのアカウント"
-      >
-        <ZennIcon />
       </IconLink>
       <IconLink bg="base" href="/blog/feed" label="RSSフィード" openInNewTab>
         <RSSIcon />

--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -1,12 +1,7 @@
 import { Card } from '@k8o/arte-odyssey/card';
 import { Heading } from '@k8o/arte-odyssey/heading';
 import { IconLink } from '@k8o/arte-odyssey/icon-link';
-import {
-  GitHubIcon,
-  QiitaIcon,
-  TwitterIcon,
-  ZennIcon,
-} from '@k8o/arte-odyssey/icons';
+import { GitHubIcon, QiitaIcon, TwitterIcon } from '@k8o/arte-odyssey/icons';
 import { TextTag } from '@k8o/arte-odyssey/text-tag';
 import Image from 'next/image';
 import { AppCard } from './_components/app-card';
@@ -50,12 +45,6 @@ export default function Home() {
                     label="Qiitaのアカウント"
                   >
                     <QiitaIcon />
-                  </IconLink>
-                  <IconLink
-                    href="https://zenn.dev/kokisakano"
-                    label="Zennのアカウント"
-                  >
-                    <ZennIcon />
                   </IconLink>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Zennへのリンクをブログページから削除
- QiitaとRSSフィードのリンクは維持

## Test plan
- [ ] ブログページでZennリンクが表示されないことを確認
- [ ] QiitaとRSSのリンクが正常に機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)