### PR TITLE
fix(ci): Claude Code ReviewがPRにコメントできるよう権限を修正

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
       id-token: write
 
@@ -29,7 +29,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           claude_args: |
-            --allowedTools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
+            --allowedTools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*)"
             --system-prompt "日本語で応答してください。"
           prompt: |
             REPO: ${{ github.repository }}


### PR DESCRIPTION
## Summary
Claude Code Review GitHub Actionがレビューコメントを投稿できない問題を修正。

## What Changed
- `pull-requests: read` → `write` に変更
- `allowedTools`に`gh pr review`を追加

## Why
PRへのレビューコメント投稿には書き込み権限が必要だった。

🤖 Generated with [Claude Code](https://claude.ai/code)