### PR TITLE
feat: migrate from zod to zod/mini for bundle size optimization

### DIFF
--- a/apps/main/src/app/_api/contact-to-me.ts
+++ b/apps/main/src/app/_api/contact-to-me.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { db } from '@repo/database';
-import { z } from 'zod/mini';
+import * as z from 'zod/mini';
 import '@/libs/zod';
 
 const contactSchema = z.object({

--- a/apps/main/src/app/api/blog/views/route.ts
+++ b/apps/main/src/app/api/blog/views/route.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/mini';
+import * as z from 'zod/mini';
 import { getBlogContent } from '@/app/blog/_api';
 import { incrementBlogView } from '@/services/blogs/view';
 

--- a/apps/main/src/app/sql-table-builder/_utils/statement.ts
+++ b/apps/main/src/app/sql-table-builder/_utils/statement.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod/mini';
+import * as z from 'zod/mini';
 import type { Column, InvalidColumns } from '../_types/column';
 import type { InvalidRestrictions, Restriction } from '../_types/restriction';
 import type { InvalidTable, Table } from '../_types/table';

--- a/apps/main/src/libs/zod.ts
+++ b/apps/main/src/libs/zod.ts
@@ -1,3 +1,3 @@
-import { z } from 'zod/mini';
+import * as z from 'zod/mini';
 
 z.config(z.locales.ja());

--- a/apps/main/src/services/subscriptions/subscribe.ts
+++ b/apps/main/src/services/subscriptions/subscribe.ts
@@ -1,5 +1,5 @@
 import { db } from '@repo/database';
-import { z } from 'zod/mini';
+import * as z from 'zod/mini';
 import { sendVerificationEmail } from '@/services/subscriptions/verify';
 import type { Result } from '../type';
 

--- a/apps/main/src/services/subscriptions/verify.ts
+++ b/apps/main/src/services/subscriptions/verify.ts
@@ -1,7 +1,7 @@
 import { db } from '@repo/database';
 import { compareDate } from '@repo/helpers/date/compare';
 import { eq } from 'drizzle-orm';
-import { z } from 'zod/mini';
+import * as z from 'zod/mini';
 import VerifyEmail from '@/emails/verify-email';
 import { resend } from '@/services/email';
 import type { Result } from '../type';


### PR DESCRIPTION
## Summary

zodからzod/miniに移行してバンドルサイズを削減しました。

## Changes

### 1. zod → zod/mini移行 (eb7cf07a)
- `import { z } from 'zod'` → `import * as z from 'zod/mini'`
- メソッドチェーンAPIから関数型APIに変更
  - `z.string().min().max()` → `z.string().check(z.minLength(), z.maxLength())`
  - `z.array().min()` → `z.array().check(z.minLength())`
- `z.email()`は引数なしで動作することを確認
- 日本語ロケール`z.locales.ja()`も引き続き利用可能

### 2. namespace importに統一 (2d157c4d)
- `import { z }` → `import * as z`に変更
- 公式ドキュメント推奨のスタイルに統一

## Benefits

- **バンドルサイズを64%削減**（公式ドキュメントより）
- ツリーシェイキングにより未使用の関数を自動削除
- 既存機能はすべて維持（型チェック・テスト通過確認済み）

## Test plan

- [x] 型チェック成功
- [x] 全テスト通過
- [x] pre-commitフック通過
- [ ] ビルドサイズの実測確認（本番環境での影響確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)