### PR TITLE
chore: package.jsonから不要なスクリプトを削除

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -9,8 +9,6 @@
     "build": "next build",
     "start": "next start",
     "analyze": "next experimental-analyze",
-    "check": "biome check",
-    "check:write": "biome check --write --unsafe",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui --coverage",
@@ -18,8 +16,7 @@
     "email": "email dev --dir src/emails --port 3333",
     "type-check": "next typegen && tsgo --noEmit",
     "storybook": "storybook dev -p 6006 --no-open",
-    "build-storybook": "storybook build",
-    "preview:dist": "pnpm dlx http-server dist"
+    "build-storybook": "storybook build"
   },
   "dependencies": {
     "@k8o/arte-odyssey": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "packageManager": "pnpm@10.28.0",
   "scripts": {
     "dev": "turbo dev",
-    "dev:db": "turso dev --db-file local.db",
     "build": "turbo build",
     "check": "biome check",
     "check:write": "biome check --write --unsafe",


### PR DESCRIPTION
## Summary
- `apps/main/package.json`から重複・未使用スクリプトを削除
  - `check`, `check:write`: ルートで実行するため重複
  - `preview:dist`: 未使用
- ルート`package.json`から`dev:db`スクリプト削除: 未使用

## Test plan
- [ ] `pnpm run check:write`がルートで正常動作することを確認
- [ ] `pnpm run dev`が正常に起動することを確認
- [ ] ビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)