### PR TITLE
refactor: react-emailのための不要なreact-dom aliasを削除

### DIFF
--- a/apps/main/vitest.config.ts
+++ b/apps/main/vitest.config.ts
@@ -35,11 +35,6 @@ export default defineConfig({
         publicDir: fileURLToPath(
           new URL('./.storybook/public', import.meta.url),
         ),
-        resolve: {
-          alias: {
-            'react-dom/server.browser': 'react-dom/server',
-          },
-        },
         test: {
           name: { label: 'storybook', color: 'magenta' },
           browser: {


### PR DESCRIPTION
## Summary
- vitest.configからreact-dom/server.browserのaliasを削除
- このaliasはreact-email開発時の互換性のために追加されていたが、現在は不要

## Changes
- `apps/main/vitest.config.ts`の`resolve.alias`セクションを削除
  - `react-dom/server.browser` → `react-dom/server` のaliasが不要に

## Test plan
- [ ] `pnpm run test`でテストが通ることを確認
- [ ] `pnpm run -F main email`でReact Email開発サーバーが正常起動することを確認
- [ ] `pnpm run -F main storybook`でStorybookが正常起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)