### PR TITLE
Refine Playground container and require titles

### DIFF
--- a/apps/main/src/app/_components/playgrounds/abs-sign/css-math-functions-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/abs-sign/css-math-functions-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { CssMathFunctionsDemo } from './css-math-functions-demo';
 
+const playgroundTitle = CssMathFunctionsDemo.name;
+
 const meta: Meta<typeof CssMathFunctionsDemo> = {
   title: 'playgrounds/abs-sign/CssMathFunctionsDemo',
   component: CssMathFunctionsDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/active-view-transition/active-view-transition-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/active-view-transition/active-view-transition-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { ActiveViewTransitionDemo } from './active-view-transition-demo';
 
+const playgroundTitle = ActiveViewTransitionDemo.name;
+
 const meta: Meta<typeof ActiveViewTransitionDemo> = {
   title: 'playgrounds/active-view-transition/ActiveViewTransitionDemo',
   component: ActiveViewTransitionDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/async-clipboard/clipboard-image-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/async-clipboard/clipboard-image-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { ClipboardImageDemo } from './clipboard-image-demo';
 
+const playgroundTitle = ClipboardImageDemo.name;
+
 const meta: Meta<typeof ClipboardImageDemo> = {
   title: 'playgrounds/async-clipboard/ClipboardImageDemo',
   component: ClipboardImageDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/async-clipboard/clipboard-text-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/async-clipboard/clipboard-text-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { ClipboardTextDemo } from './clipboard-text-demo';
 
+const playgroundTitle = ClipboardTextDemo.name;
+
 const meta: Meta<typeof ClipboardTextDemo> = {
   title: 'playgrounds/async-clipboard/ClipboardTextDemo',
   component: ClipboardTextDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/caret-position-from-point/caret-position-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/caret-position-from-point/caret-position-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { CaretPositionDemo } from './caret-position-demo';
 
+const playgroundTitle = CaretPositionDemo.name;
+
 const meta: Meta<typeof CaretPositionDemo> = {
   title: 'playgrounds/caret-position-from-point/CaretPositionDemo',
   component: CaretPositionDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/caret-position-from-point/drag-drop-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/caret-position-from-point/drag-drop-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { DragDropDemo } from './drag-drop-demo';
 
+const playgroundTitle = DragDropDemo.name;
+
 const meta: Meta<typeof DragDropDemo> = {
   title: 'playgrounds/caret-position-from-point/DragDropDemo',
   component: DragDropDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/composed-ranges/get-composed-ranges.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/composed-ranges/get-composed-ranges.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { GetComposedRanges } from './get-composed-ranges';
 
+const playgroundTitle = GetComposedRanges.name;
+
 const meta: Meta<typeof GetComposedRanges> = {
   title: 'playgrounds/composed-ranges/GetComposedRanges',
   component: GetComposedRanges,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/composed-ranges/selection-methods.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/composed-ranges/selection-methods.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { SelectionMethods } from './selection-methods';
 
+const playgroundTitle = SelectionMethods.name;
+
 const meta: Meta<typeof SelectionMethods> = {
   title: 'playgrounds/composed-ranges/SelectionMethods',
   component: SelectionMethods,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/composed-ranges/selection-properties.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/composed-ranges/selection-properties.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { SelectionProperties } from './selection-properties';
 
+const playgroundTitle = SelectionProperties.name;
+
 const meta: Meta<typeof SelectionProperties> = {
   title: 'playgrounds/composed-ranges/SelectionProperties',
   component: SelectionProperties,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/content-visibility/content-visibility-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/content-visibility/content-visibility-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { ContentVisibilityDemo } from './content-visibility-demo';
 
+const playgroundTitle = ContentVisibilityDemo.name;
+
 const meta: Meta<typeof ContentVisibilityDemo> = {
   title: 'playgrounds/content-visibility/ContentVisibilityDemo',
   component: ContentVisibilityDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/details-content/details-animation-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/details-content/details-animation-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { DetailsAnimationDemo } from './details-animation-demo';
 
+const playgroundTitle = DetailsAnimationDemo.name;
+
 const meta: Meta<typeof DetailsAnimationDemo> = {
   title: 'playgrounds/details-content/DetailsAnimationDemo',
   component: DetailsAnimationDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/details-content/details-content-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/details-content/details-content-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { DetailsContentDemo } from './details-content-demo';
 
+const playgroundTitle = DetailsContentDemo.name;
+
 const meta: Meta<typeof DetailsContentDemo> = {
   title: 'playgrounds/details-content/DetailsContentDemo',
   component: DetailsContentDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/event-timing/event-timing-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/event-timing/event-timing-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { EventTimingDemo } from './event-timing-demo';
 
+const playgroundTitle = EventTimingDemo.name;
+
 const meta: Meta<typeof EventTimingDemo> = {
   title: 'playgrounds/event-timing/EventTimingDemo',
   component: EventTimingDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/font-family-math/font-family-math-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/font-family-math/font-family-math-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { FontFamilyMathDemo } from './font-family-math-demo';
 
+const playgroundTitle = FontFamilyMathDemo.name;
+
 const meta: Meta<typeof FontFamilyMathDemo> = {
   title: 'playgrounds/font-family-math/FontFamilyMathDemo',
   component: FontFamilyMathDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/highlight/highlight-basic-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/highlight/highlight-basic-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { HighlightBasicDemo } from './highlight-basic-demo';
 
+const playgroundTitle = HighlightBasicDemo.name;
+
 const meta: Meta<typeof HighlightBasicDemo> = {
   title: 'playgrounds/highlight/HighlightBasicDemo',
   component: HighlightBasicDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/highlight/highlight-priority-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/highlight/highlight-priority-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { HighlightPriorityDemo } from './highlight-priority-demo';
 
+const playgroundTitle = HighlightPriorityDemo.name;
+
 const meta: Meta<typeof HighlightPriorityDemo> = {
   title: 'playgrounds/highlight/HighlightPriorityDemo',
   component: HighlightPriorityDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/highlight/highlight-spelling-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/highlight/highlight-spelling-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { HighlightSpellingDemo } from './highlight-spelling-demo';
 
+const playgroundTitle = HighlightSpellingDemo.name;
+
 const meta: Meta<typeof HighlightSpellingDemo> = {
   title: 'playgrounds/highlight/HighlightSpellingDemo',
   component: HighlightSpellingDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/input-file-webkitdirectory/webkit-relative-path-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/input-file-webkitdirectory/webkit-relative-path-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { WebkitRelativePathDemo } from './webkit-relative-path-demo';
 
+const playgroundTitle = WebkitRelativePathDemo.name;
+
 const meta = {
   title: 'playgrounds/input-file-webkitdirectory/WebkitRelativePathDemo',
   component: WebkitRelativePathDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/largest-contentful-paint/lcp-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/largest-contentful-paint/lcp-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { LCPDemo } from './lcp-demo';
 
+const playgroundTitle = LCPDemo.name;
+
 const meta: Meta<typeof LCPDemo> = {
   title: 'playgrounds/largest-contentful-paint/LCPDemo',
   component: LCPDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/playground.tsx
+++ b/apps/main/src/app/_components/playgrounds/playground.tsx
@@ -1,18 +1,24 @@
+import { Separator } from '@k8o/arte-odyssey/separator';
 import type { FC, PropsWithChildren } from 'react';
 
 export const Playground: FC<
   PropsWithChildren<{
-    title?: string;
+    title: string;
   }>
-> = ({ title = 'Playground', children }) => {
+> = ({ title, children }) => {
   return (
-    <div className="my-8 text-xs sm:text-md">
-      <p className="rounded-t-sm border-border-base border-x border-t bg-bg-mute p-4 font-bold">
-        {title}
-      </p>
-      <div className="rounded-b-sm border border-border-base bg-bg-base p-4">
-        {children}
+    <section className="my-8 sm:my-10">
+      <div className="rounded-md border border-border-base bg-bg-base p-7 sm:p-10">
+        <div className="flex flex-col gap-6 sm:gap-8">
+          <header className="flex flex-col gap-2 sm:gap-3">
+            <h3 className="font-bold text-fg-base text-sm sm:text-lg">
+              {title}
+            </h3>
+            <Separator />
+          </header>
+          <div>{children}</div>
+        </div>
       </div>
-    </div>
+    </section>
   );
 };

--- a/apps/main/src/app/_components/playgrounds/popover/popover-api-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/popover/popover-api-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { PopoverApiDemo } from './popover-api-demo';
 
+const playgroundTitle = PopoverApiDemo.name;
+
 const meta: Meta<typeof PopoverApiDemo> = {
   title: 'playgrounds/popover/PopoverApiDemo',
   component: PopoverApiDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/popover/tooltip-dropdown-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/popover/tooltip-dropdown-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { TooltipDropdownDemo } from './tooltip-dropdown-demo';
 
+const playgroundTitle = TooltipDropdownDemo.name;
+
 const meta: Meta<typeof TooltipDropdownDemo> = {
   title: 'playgrounds/popover/TooltipDropdownDemo',
   component: TooltipDropdownDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/print-color-adjust/print-color-adjust-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/print-color-adjust/print-color-adjust-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { PrintColorAdjustDemo } from './print-color-adjust-demo';
 
+const playgroundTitle = PrintColorAdjustDemo.name;
+
 const meta: Meta<typeof PrintColorAdjustDemo> = {
   title: 'playgrounds/print-color-adjust/PrintColorAdjustDemo',
   component: PrintColorAdjustDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/requestclose/dialog-requestclose-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/requestclose/dialog-requestclose-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { DialogRequestCloseDemo } from './dialog-requestclose-demo';
 
+const playgroundTitle = DialogRequestCloseDemo.name;
+
 const meta: Meta<typeof DialogRequestCloseDemo> = {
   title: 'playgrounds/requestclose/DialogRequestCloseDemo',
   component: DialogRequestCloseDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/root-font-units/root-comparison-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/root-font-units/root-comparison-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { RootComparisonDemo } from './root-comparison-demo';
 
+const playgroundTitle = RootComparisonDemo.name;
+
 const meta: Meta<typeof RootComparisonDemo> = {
   title: 'playgrounds/root-font-units/RootComparisonDemo',
   component: RootComparisonDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/root-font-units/unit-comparison-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/root-font-units/unit-comparison-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { UnitComparisonDemo } from './unit-comparison-demo';
 
+const playgroundTitle = UnitComparisonDemo.name;
+
 const meta: Meta<typeof UnitComparisonDemo> = {
   title: 'playgrounds/root-font-units/UnitComparisonDemo',
   component: UnitComparisonDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/scope/donut-scope-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/scope/donut-scope-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { DonutScopeDemo } from './donut-scope-demo';
 
+const playgroundTitle = DonutScopeDemo.name;
+
 const meta: Meta<typeof DonutScopeDemo> = {
   title: 'playgrounds/scope/DonutScopeDemo',
   component: DonutScopeDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/scope/scope-limit-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/scope/scope-limit-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { ScopeLimitDemo } from './scope-limit-demo';
 
+const playgroundTitle = ScopeLimitDemo.name;
+
 const meta: Meta<typeof ScopeLimitDemo> = {
   title: 'playgrounds/scope/ScopeLimitDemo',
   component: ScopeLimitDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/scope/scope-proximity-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/scope/scope-proximity-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { ScopeProximityDemo } from './scope-proximity-demo';
 
+const playgroundTitle = ScopeProximityDemo.name;
+
 const meta: Meta<typeof ScopeProximityDemo> = {
   title: 'playgrounds/scope/ScopeProximityDemo',
   component: ScopeProximityDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/screen-wake-lock/wake-lock-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/screen-wake-lock/wake-lock-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { WakeLockDemo } from './wake-lock-demo';
 
+const playgroundTitle = WakeLockDemo.name;
+
 const meta: Meta<typeof WakeLockDemo> = {
   title: 'playgrounds/screen-wake-lock/WakeLockDemo',
   component: WakeLockDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/scrollbar-color/scrollbar-color-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/scrollbar-color/scrollbar-color-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { ScrollbarColorDemo } from './scrollbar-color-demo';
 
+const playgroundTitle = ScrollbarColorDemo.name;
+
 const meta: Meta<typeof ScrollbarColorDemo> = {
   title: 'playgrounds/scrollbar-color/ScrollbarColorDemo',
   component: ScrollbarColorDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/scrollend/scrollend-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/scrollend/scrollend-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { ScrollendDemo } from './scrollend-demo';
 
+const playgroundTitle = ScrollendDemo.name;
+
 const meta: Meta<typeof ScrollendDemo> = {
   title: 'playgrounds/scrollend/ScrollendDemo',
   component: ScrollendDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/scrollend/scrollend-trigger-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/scrollend/scrollend-trigger-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { ScrollendTriggerDemo } from './scrollend-trigger-demo';
 
+const playgroundTitle = ScrollendTriggerDemo.name;
+
 const meta: Meta<typeof ScrollendTriggerDemo> = {
   title: 'playgrounds/scrollend/ScrollendTriggerDemo',
   component: ScrollendTriggerDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/spelling-grammar-error/spelling-grammar-error-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/spelling-grammar-error/spelling-grammar-error-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { SpellingGrammarErrorDemo } from './spelling-grammar-error-demo';
 
+const playgroundTitle = SpellingGrammarErrorDemo.name;
+
 const meta: Meta<typeof SpellingGrammarErrorDemo> = {
   title: 'playgrounds/spelling-grammar-error/SpellingGrammarErrorDemo',
   component: SpellingGrammarErrorDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/suspense-list/suspense-list-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/suspense-list/suspense-list-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { SuspenseListDemo } from './suspense-list-demo';
 
+const playgroundTitle = SuspenseListDemo.name;
+
 const meta: Meta<typeof SuspenseListDemo> = {
   title: 'playgrounds/suspense-list/SuspenseListDemo',
   component: SuspenseListDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/_components/playgrounds/view-transitions/view-transition-basic-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/view-transitions/view-transition-basic-demo.stories.tsx
@@ -2,12 +2,14 @@ import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { Playground } from '../playground';
 import { ViewTransitionBasicDemo } from './view-transition-basic-demo';
 
+const playgroundTitle = ViewTransitionBasicDemo.name;
+
 const meta: Meta<typeof ViewTransitionBasicDemo> = {
   title: 'playgrounds/view-transitions/ViewTransitionBasicDemo',
   component: ViewTransitionBasicDemo,
   decorators: [
     (Story) => (
-      <Playground>
+      <Playground title={playgroundTitle}>
         <Story />
       </Playground>
     ),

--- a/apps/main/src/app/blog/(articles)/details-content/page.mdx
+++ b/apps/main/src/app/blog/(articles)/details-content/page.mdx
@@ -49,7 +49,7 @@ import detailsSlot from './_images/details-slot.png';
 
 `::details-content`擬似要素は、この`slot`要素に対してスタイルを付与できます。
 
-<Playground>
+<Playground title="details-contentの適用範囲">
   <Example1 />
 </Playground>
 

--- a/apps/main/src/app/blog/(articles)/document-caretpositionfrompoint/page.mdx
+++ b/apps/main/src/app/blog/(articles)/document-caretpositionfrompoint/page.mdx
@@ -83,7 +83,7 @@ document.addEventListener('click', (event) => {
 });
 ```
 
-<Playground>
+<Playground title="キャレット位置の取得">
   <CaretPositionDemo />
 </Playground>
 
@@ -115,7 +115,7 @@ dropZone.addEventListener('drop', (event) => {
 });
 ```
 
-<Playground>
+<Playground title="ドラッグ&ドロップの挿入">
   <DragDropDemo />
 </Playground>
 

--- a/apps/main/src/app/blog/(articles)/event-timing/page.mdx
+++ b/apps/main/src/app/blog/(articles)/event-timing/page.mdx
@@ -143,7 +143,7 @@ for (const entry of interactionMap.values()) {
 }
 ```
 
-<Playground>
+<Playground title="Event Timingの計測デモ">
   <EventTimingDemo />
 </Playground>
 

--- a/apps/main/src/app/blog/(articles)/font-family-math/page.mdx
+++ b/apps/main/src/app/blog/(articles)/font-family-math/page.mdx
@@ -91,7 +91,7 @@ Windowsには`Cambria Math`、macOS（Ventura以降）には`STIX Two Math`が�
 
 ## デモ
 
-<Playground>
+<Playground title="font-family: mathのデモ">
   <FontFamilyMathDemo />
 </Playground>
 

--- a/apps/main/src/app/blog/(articles)/invoker-commands/page.mdx
+++ b/apps/main/src/app/blog/(articles)/invoker-commands/page.mdx
@@ -64,7 +64,7 @@ Invoker Commands APIは`commandfor`と`command`の2つの属性で構成され�
 </dialog>
 ```
 
-<Playground>
+<Playground title="Dialogの操作">
   <DialogDemo />
 </Playground>
 
@@ -88,7 +88,7 @@ Invoker Commands APIは`commandfor`と`command`の2つの属性で構成され�
 </div>
 ```
 
-<Playground>
+<Playground title="Popoverの操作">
   <PopoverDemo />
 </Playground>
 
@@ -124,7 +124,7 @@ image.addEventListener('command', (event) => {
 
 `command`に応じた自由な動作を実装できます。`command`に`--`ではじまらない名前を渡した場合は`event.command`に値がセットされないので注意してください。
 
-<Playground>
+<Playground title="カスタムコマンド">
   <CustomCommandDemo />
 </Playground>
 

--- a/apps/main/src/app/blog/(articles)/largest-contentful-paint/page.mdx
+++ b/apps/main/src/app/blog/(articles)/largest-contentful-paint/page.mdx
@@ -97,7 +97,7 @@ const observer = new PerformanceObserver((list) => {
 observer.observe({ type: 'largest-contentful-paint', buffered: true });
 ```
 
-<Playground>
+<Playground title="LCP計測デモ">
   <LCPDemo />
 </Playground>
 

--- a/apps/main/src/app/blog/(articles)/scope/page.mdx
+++ b/apps/main/src/app/blog/(articles)/scope/page.mdx
@@ -92,7 +92,7 @@ HTMLの`<style>`要素内で使用する場合、親要素が自動的にスコ�
 </div>
 ```
 
-<Playground>
+<Playground title="ドーナツスコープの例">
   <DonutScopeDemo />
 </Playground>
 
@@ -152,7 +152,7 @@ HTMLの`<style>`要素内で使用する場合、親要素が自動的にスコ�
 ```
 上記のHTMLは、`.article`内の最初の`.nested-content`内の`<img>`にはスタイルが適用されませんが、2番目の`.nested-content`内の`<img>`にはスタイルが適用されます。
 
-<Playground>
+<Playground title="スコープ境界の例">
   <ScopeLimitDemo />
 </Playground>
 
@@ -194,7 +194,7 @@ HTMLの`<style>`要素内で使用する場合、親要素が自動的にスコ�
 
 `@scope`がない場合、同じ詳細度のスタイルが競合したときは、後に定義された`.warning-box`のスタイルが優先されます。
 
-<Playground>
+<Playground title="近接性の優先">
   <ScopeProximityDemo />
 </Playground>
 

--- a/apps/main/src/app/blog/(articles)/scrollbar-color/page.mdx
+++ b/apps/main/src/app/blog/(articles)/scrollbar-color/page.mdx
@@ -43,7 +43,7 @@ Safari 26.2のリリースによって、`scrollbar-color`プロパティが主�
 
 最初の値がつまみの色、2番目の値がトラックの色です。
 
-<Playground>
+<Playground title="scrollbar-colorのデモ">
   <ScrollbarColorDemo />
 </Playground>
 

--- a/apps/main/src/app/blog/(articles)/scrollend/page.mdx
+++ b/apps/main/src/app/blog/(articles)/scrollend/page.mdx
@@ -57,7 +57,7 @@ element.addEventListener('scrollend', () => {
 
 タイムアウト値を気にする必要がなく、シンプルに記述できます。
 
-<Playground>
+<Playground title="scrollendイベントの基本">
   <ScrollendDemo />
 </Playground>
 
@@ -67,7 +67,7 @@ element.addEventListener('scrollend', () => {
 
 一方で、スクロール位置が変化しなかった場合は発火しません。
 
-<Playground>
+<Playground title="発火条件のデモ">
   <ScrollendTriggerDemo />
 </Playground>
 

--- a/apps/main/src/app/playgrounds/page.tsx
+++ b/apps/main/src/app/playgrounds/page.tsx
@@ -12,7 +12,7 @@ export default function PlaygroundsPage() {
         <Heading type="h1">Playgrounds</Heading>
         <p className="mt-2 text-fg-mute">
           インタラクティブなWeb技術のデモ集。最新のWeb
-          API、CSS機能、React技術を実際に体験できます。
+          API、CSS、Reactを用いた機能を実際に体験できます。
         </p>
       </div>
 


### PR DESCRIPTION
## Summary\n- refine Playground container layout and separator usage\n- make Playground title required and update storybook usages\n- add missing Playground titles in blog MDX\n\n## Testing\n- not run (hooks ran: check, ls-lint)