### PR TITLE
chore: フッターのコピーライト年を2026年に更新

### DIFF
--- a/apps/main/src/app/_components/global-layout/global-layout.tsx
+++ b/apps/main/src/app/_components/global-layout/global-layout.tsx
@@ -49,7 +49,7 @@ export const GlobalLayout: FC<{ children: ReactNode }> = ({ children }) => {
           <footer className="flex items-center justify-center p-4">
             <div className="max-w-5xl">
               <p className="text-fg-mute md:text-lg">
-                ©︎ 2024〜2025 k8o. All Rights Reserved.
+                ©︎ 2024〜2026 k8o. All Rights Reserved.
               </p>
             </div>
           </footer>


### PR DESCRIPTION
フッターのコピーライト表記を `©︎ 2024〜2025` から `©︎ 2024〜2026` に更新しました。