### PR TITLE
fix: ブログのview数カウントでサブパスを除外

### DIFF
--- a/apps/main/src/proxy.ts
+++ b/apps/main/src/proxy.ts
@@ -3,8 +3,9 @@ import { after, type NextRequest, NextResponse } from 'next/server';
 export function proxy(request: NextRequest) {
   // blog
   if (request.nextUrl.pathname.startsWith('/blog')) {
-    const slug = request.nextUrl.pathname.split('/')[2];
-    if (slug && slug !== 'feed') {
+    const paths = request.nextUrl.pathname.split('/');
+    const slug = paths[2];
+    if (slug && slug !== 'feed' && paths.length === 3) {
       after(() => {
         void fetch(`${request.nextUrl.origin}/api/blog/views`, {
           method: 'POST',


### PR DESCRIPTION
## Summary
`/blog/[slug]/opengraph-image`などのサブパスへのリクエストでもviewがカウントされていた問題を修正。

`paths.length === 3`の条件を追加し、`/blog/[slug]`の直接アクセスのみカウントするようにした。