### PR TITLE
fix: link-cardのCORSプロキシ依存を削除

### DIFF
--- a/apps/main/src/app/_components/link-card/metadata.ts
+++ b/apps/main/src/app/_components/link-card/metadata.ts
@@ -1,8 +1,7 @@
 export async function getMetadata(href: string) {
   'use cache';
 
-  const proxyUrl = `https://corsproxy.io/?url=${encodeURIComponent(href)}`;
-  const res = await fetch(proxyUrl);
+  const res = await fetch(href);
   const html = (await res.text()).trim();
   const title = /<title>(.*?)<\/title>/i.exec(html)?.[1];
   const ogTitle = /<meta\s+property="og:title"\s+content="(.*?)"/i.exec(


### PR DESCRIPTION
## Summary
- `getMetadata`はサーバーサイド（`'use cache'`）で実行されるため、CORSの制約を受けない
- 不要な`corsproxy.io`経由のfetchを直接fetchに置き換え
- corsproxy.ioのサーバーサイド有料化によりlink-cardが表示できなくなった問題を修正

## Test plan
- [ ] link-cardが正常にOGメタデータを取得・表示できること
- [ ] `pnpm run build` が通ること