### PR TITLE
feat(main): ArteOdysseyカードのリンク先を外部サイトに変更

### DIFF
--- a/apps/main/src/app/_components/app-card/app-card.tsx
+++ b/apps/main/src/app/_components/app-card/app-card.tsx
@@ -10,24 +10,41 @@ export const AppCard = ({
   title,
   description,
 }: {
-  link: Route;
+  link: Route | `https://${string}`;
   symbol: ReactNode;
   title: string;
   description: string;
 }) => {
+  const isExternal = typeof link === 'string' && link.startsWith('https://');
+
+  const content = (
+    <div className="flex h-full flex-col items-center gap-4 p-4 group-hover:text-primary-fg">
+      <div className="flex size-24 shrink-0 items-center justify-center rounded-full bg-bg-mute text-emphasize group-hover:bg-primary-bg-mute">
+        {symbol}
+      </div>
+      <div className="flex flex-col items-center gap-1">
+        <Heading type="h3">{title}</Heading>
+        <p className="line-clamp-3 text-fg-mute text-sm">{description}</p>
+      </div>
+    </div>
+  );
+
   return (
     <InteractiveCard>
-      <Link className="group" href={link}>
-        <div className="flex h-full flex-col items-center gap-4 p-4 group-hover:text-primary-fg">
-          <div className="flex size-24 shrink-0 items-center justify-center rounded-full bg-bg-mute text-emphasize group-hover:bg-primary-bg-mute">
-            {symbol}
-          </div>
-          <div className="flex flex-col items-center gap-1">
-            <Heading type="h3">{title}</Heading>
-            <p className="line-clamp-3 text-fg-mute text-sm">{description}</p>
-          </div>
-        </div>
-      </Link>
+      {isExternal ? (
+        <a
+          className="group"
+          href={link}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
+          {content}
+        </a>
+      ) : (
+        <Link className="group" href={link}>
+          {content}
+        </Link>
+      )}
     </InteractiveCard>
   );
 };

--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -114,7 +114,7 @@ export default function Home() {
           />
           <AppCard
             description="k8o.meで利用しているデザインシステムを紹介します。コンポーネントやデザイントークンを確認できます。"
-            link="/design-system"
+            link="https://arte-odyssey.k8o.me"
             symbol={
               <Image
                 alt=""


### PR DESCRIPTION
## Summary
- AppCardコンポーネントの`link`プロパティを外部URL（`https://`）にも対応させた
- ArteOdysseyカードのリンク先を`/design-system`から`https://arte-odyssey.k8o.me`に変更
- 外部リンクの場合は`<a>`タグ（`target="_blank"` + `rel="noopener noreferrer"`）を使用

## Test plan
- [ ] 型チェック・lintが通ることを確認 → 確認済み
- [ ] ArteOdysseyカードをクリックして`arte-odyssey.k8o.me`が新しいタブで開くことを確認
- [ ] 他のAppCardが従来通り内部リンクとして動作することを確認