### PR TITLE
refactor: llms.txtの重複コンテンツを共有定数から生成するように変更

### DIFF
--- a/apps/main/src/app/llms.txt/route.ts
+++ b/apps/main/src/app/llms.txt/route.ts
@@ -28,13 +28,11 @@ const assistItems = [
   textDiffMetadata,
 ];
 
-type MetadataLike = {
-  title?: unknown;
-  description?: unknown;
-};
-
-function _formatMetadataSection(metadata: MetadataLike): string {
-  return `### ${String(metadata.title ?? '')}\n${String(metadata.description ?? '')}`;
+function _formatMetadataSection(metadata: {
+  title?: string | null;
+  description?: string | null;
+}): string {
+  return `### ${metadata.title ?? ''}\n${metadata.description ?? ''}`;
 }
 
 async function _generateLlmContent() {
@@ -57,7 +55,7 @@ async function _generateLlmContent() {
 
   // metadata とサブコンテンツを直接紐付け
   const forgeItems: {
-    metadata: MetadataLike;
+    metadata: { title?: string | null; description?: string | null };
     subContent?: string;
   }[] = [
     { metadata: blogMetadata, subContent: blogContent },

--- a/apps/main/src/app/playgrounds/layout.tsx
+++ b/apps/main/src/app/playgrounds/layout.tsx
@@ -1,6 +1,4 @@
-import type { Metadata } from 'next';
-
-export const metadata: Metadata = {
+export const metadata = {
   title: 'Playgrounds',
   description: 'ブログの記事や興味のある技術を試した試作品を集めた場所。',
   openGraph: {


### PR DESCRIPTION
ホームページ(page.tsx)とllms.txt/route.tsで二重管理されていた
コンテンツ定義を_constants/content.tsに集約。
- プロフィール、Forge/Assistセクション、全ツールのtitle/descriptionを一元化
- Talksデータをデータベースから動的に取得するように改善

https://claude.ai/code/session_01AjYZue9BdvPRHgLGj2dy9y