### PR TITLE
refactor: metadata定数にsatisfies Metadataを適用

### DIFF
--- a/apps/main/src/app/base-converter/layout.tsx
+++ b/apps/main/src/app/base-converter/layout.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
+import type { Metadata } from 'next';
 
 export const metadata = {
   title: '基数チェンジャー',
@@ -16,7 +17,7 @@ export const metadata = {
     card: 'summary',
     description: '2進数・8進数・10進数・16進数を相互に変換します。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({ children }: LayoutProps<'/base-converter'>) {
   return (

--- a/apps/main/src/app/blog/layout.tsx
+++ b/apps/main/src/app/blog/layout.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 import { ExternalBlog } from './_components/external-blog';
 
@@ -18,7 +19,7 @@ export const metadata = {
     card: 'summary',
     description: 'Webフロントエンドの話題を中心に、日々のことも書くブログ。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({ children }: LayoutProps<'/blog'>) {
   return (

--- a/apps/main/src/app/color-converter/layout.tsx
+++ b/apps/main/src/app/color-converter/layout.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
+import type { Metadata } from 'next';
 
 export const metadata = {
   title: 'カラーコード職人',
@@ -16,7 +17,7 @@ export const metadata = {
     card: 'summary',
     description: 'HEX・RGB・HSLの色表現を相互に変換します。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({ children }: LayoutProps<'/color-converter'>) {
   return (

--- a/apps/main/src/app/contrast-checker/layout.tsx
+++ b/apps/main/src/app/contrast-checker/layout.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
+import type { Metadata } from 'next';
 
 export const metadata = {
   title: 'コントラストチェッカー',
@@ -16,7 +17,7 @@ export const metadata = {
     card: 'summary',
     description: '2色のコントラスト比を計算し、WCAGの基準で評価します。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({ children }: LayoutProps<'/contrast-checker'>) {
   return (

--- a/apps/main/src/app/japanese-text-fixer/layout.tsx
+++ b/apps/main/src/app/japanese-text-fixer/layout.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
+import type { Metadata } from 'next';
 import { ProofreadProvider } from './_state/provider';
 
 export const metadata = {
@@ -17,7 +18,7 @@ export const metadata = {
     card: 'summary',
     description: '日本語の文章を解析し、誤字脱字や文法ミスを指摘します。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({
   children,

--- a/apps/main/src/app/layout.tsx
+++ b/apps/main/src/app/layout.tsx
@@ -9,7 +9,7 @@ import { mPlus2, notoSansJp } from './_styles/font';
 import '@/libs/zod';
 import type { Metadata } from 'next';
 
-export const metadata: Metadata = {
+export const metadata = {
   metadataBase: new URL('https://k8o.me'),
   title: 'k8o',
   description: 'k8oの活動や制作物をまとめた個人サイト',
@@ -38,7 +38,7 @@ export const metadata: Metadata = {
     card: 'summary',
     description: 'k8oの活動や制作物をまとめた個人サイト',
   },
-};
+} satisfies Metadata;
 
 export default function RootLayout({ children }: LayoutProps<'/'>) {
   return (

--- a/apps/main/src/app/moji-count/layout.tsx
+++ b/apps/main/src/app/moji-count/layout.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
+import type { Metadata } from 'next';
 
 export const metadata = {
   title: 'もじカウント',
@@ -16,7 +17,7 @@ export const metadata = {
     card: 'summary',
     description: 'テキストの文字数をリアルタイムに数えます。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({ children }: LayoutProps<'/moji-count'>) {
   return (

--- a/apps/main/src/app/playgrounds/layout.tsx
+++ b/apps/main/src/app/playgrounds/layout.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next';
+
 export const metadata = {
   title: 'Playgrounds',
   description: 'ブログの記事や興味のある技術を試した試作品を集めた場所。',
@@ -11,7 +13,7 @@ export const metadata = {
     title: 'Playgrounds',
     description: 'ブログの記事や興味のある技術を試した試作品を集めた場所。',
   },
-};
+} satisfies Metadata;
 
 export default function PlaygroundsLayout({
   children,

--- a/apps/main/src/app/qr-generator/layout.tsx
+++ b/apps/main/src/app/qr-generator/layout.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
+import type { Metadata } from 'next';
 
 export const metadata = {
   title: 'QRキット',
@@ -16,7 +17,7 @@ export const metadata = {
     card: 'summary',
     description: 'テキストやURLからQRコードを生成してダウンロードできます。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({ children }: LayoutProps<'/qr-generator'>) {
   return (

--- a/apps/main/src/app/quizzes/fish-kanji/layout.tsx
+++ b/apps/main/src/app/quizzes/fish-kanji/layout.tsx
@@ -1,3 +1,5 @@
+import type { Metadata } from 'next';
+
 export const metadata = {
   title: 'うおへんクイズ',
   description: 'うおへんを持つ漢字の問題を出します',
@@ -14,7 +16,7 @@ export const metadata = {
     card: 'summary',
     description: 'うおへんを持つ漢字の問題を出します',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({
   children,

--- a/apps/main/src/app/quizzes/layout.tsx
+++ b/apps/main/src/app/quizzes/layout.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { QuizBreadcrumb } from './_components/quiz-breadcrumb';
 
 export const metadata = {
@@ -16,7 +17,7 @@ export const metadata = {
     card: 'summary',
     description: 'いろいろなジャンルの知識をクイズで試せます。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({ children }: LayoutProps<'/quizzes'>) {
   return (

--- a/apps/main/src/app/radius-maker/layout.tsx
+++ b/apps/main/src/app/radius-maker/layout.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
+import type { Metadata } from 'next';
 
 export const metadata = {
   title: 'かどまるラボ',
@@ -16,7 +17,7 @@ export const metadata = {
     card: 'summary',
     description: 'border-radiusを視覚的に操作してCSSを生成します。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({ children }: LayoutProps<'/radius-maker'>) {
   return (

--- a/apps/main/src/app/sql-table-builder/layout.tsx
+++ b/apps/main/src/app/sql-table-builder/layout.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
+import type { Metadata } from 'next';
 import { Suspense } from 'react';
 
 export const metadata = {
@@ -16,7 +17,7 @@ export const metadata = {
     description:
       'テーブル名・カラム・制約を入力してCREATE TABLE文を生成します。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({
   children,

--- a/apps/main/src/app/tags/layout.tsx
+++ b/apps/main/src/app/tags/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
 import { TagIcon } from '@k8o/arte-odyssey/icons';
+import type { Metadata } from 'next';
 import Link from 'next/link';
 
 export const metadata = {
@@ -21,7 +22,7 @@ export const metadata = {
     description:
       'k8oで提供するサービスやブログのタグ一覧をまとめたページです。各タグの関連するコンテンツへのリンクを掲載しています。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({ children }: LayoutProps<'/tags'>) {
   return (

--- a/apps/main/src/app/talks/layout.tsx
+++ b/apps/main/src/app/talks/layout.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
+import type { Metadata } from 'next';
 
 export const metadata = {
   title: 'Talks',
@@ -19,7 +20,7 @@ export const metadata = {
     description:
       '過去の登壇内容をまとめたページです。講演のテーマや資料へのリンクを掲載しています。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({ children }: LayoutProps<'/talks'>) {
   return (

--- a/apps/main/src/app/text-diff/layout.tsx
+++ b/apps/main/src/app/text-diff/layout.tsx
@@ -1,4 +1,5 @@
 import { Heading } from '@k8o/arte-odyssey/heading';
+import type { Metadata } from 'next';
 
 export const metadata = {
   title: 'テキスト差分チェッカー',
@@ -16,7 +17,7 @@ export const metadata = {
     card: 'summary',
     description: '2つのテキストを文字単位で比較して差分を表示します。',
   },
-};
+} satisfies Metadata;
 
 export default function Layout({ children }: LayoutProps<'/text-diff'>) {
   return (


### PR DESCRIPTION
全layoutファイルのexport const metadataに対してsatisfies Metadata
を追加し、型安全性を確保しつつリテラル型を保持するようにした。
root layoutは`: Metadata`から`satisfies Metadata`に変更。

https://claude.ai/code/session_01QhegyjWgp6ig1u5WBrhKZa