### PR TITLE
chore: playwrightのインストール対象をchromiumのみに限定

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "test": "turbo run test",
     "test:watch": "turbo run test:watch",
     "turbo:devtools": "turbo devtools",
-    "install-playwright": "playwright install --with-deps",
+    "install-playwright": "playwright install --with-deps chromium",
     "mcp-next": "next-devtools-mcp",
     "knip": "knip"
   },


### PR DESCRIPTION
## Summary

- `playwright install --with-deps` から `playwright install --with-deps chromium` に変更
- vitest.config.ts で使用しているブラウザは `chromium` のみのため、不要なブラウザ（firefox, webkit）のインストールを省略

🤖 Generated with [Claude Code](https://claude.com/claude-code)