### PR TITLE
chore: add knip report workflow

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -27,13 +27,13 @@ jobs:
           exit_code=$?
           set -e
           # exit code 2以上は実行エラーとして失敗させる
-          if [ $exit_code -ge 2 ]; then
-            echo "$output"
-            exit $exit_code
+          if [[ "${exit_code}" -ge 2 ]]; then
+            echo "${output}"
+            exit "${exit_code}"
           fi
-          echo "output<<KNIP_REPORT_EOF" >> "$GITHUB_OUTPUT"
-          echo "$output" >> "$GITHUB_OUTPUT"
-          echo "KNIP_REPORT_EOF" >> "$GITHUB_OUTPUT"
+          echo "output<<KNIP_REPORT_EOF" >> "${GITHUB_OUTPUT}"
+          echo "${output}" >> "${GITHUB_OUTPUT}"
+          echo "KNIP_REPORT_EOF" >> "${GITHUB_OUTPUT}"
 
       - name: Update or create issue
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea


### PR DESCRIPTION
## Summary

- 週次（毎週月曜 9:00 JST）でknipを自動実行するGitHub Actionsワークフローを追加
- 実行結果を `knip-report` ラベルのIssueに蓄積（既存Issueがあればコメント追加、なければ新規作成）
- `workflow_dispatch` で手動実行も可能

## Test plan

- [ ] ActionsタブからRun workflowで手動実行して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)