### PR TITLE
refactor: knip workflowをpatrol-boardに置き換え

### DIFF
--- a/.github/workflows/knip.yml
+++ b/.github/workflows/knip.yml
@@ -18,84 +18,11 @@ jobs:
         uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - name: Setup
         uses: ./.github/actions/setup
-
-      - name: Run knip
-        id: knip
-        run: |
-          set +e
-          output=$(pnpm run knip 2>&1)
-          exit_code=$?
-          set -e
-          # exit code 2以上は実行エラーとして失敗させる
-          if [[ "${exit_code}" -ge 2 ]]; then
-            echo "${output}"
-            exit "${exit_code}"
-          fi
-          echo "output<<KNIP_REPORT_EOF" >> "${GITHUB_OUTPUT}"
-          echo "${output}" >> "${GITHUB_OUTPUT}"
-          echo "KNIP_REPORT_EOF" >> "${GITHUB_OUTPUT}"
-
-      - name: Update or create issue
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
-        env:
-          KNIP_OUTPUT: ${{ steps.knip.outputs.output }}
+      - name: Run knip report
+        uses: k35o/patrol-board@v1
         with:
-          script: |
-            const label = 'knip-report';
-            const title = 'Knip 定期レポート';
-            const output = process.env.KNIP_OUTPUT;
-            const date = new Date().toLocaleDateString('ja-JP', {
-              timeZone: 'Asia/Tokyo',
-              year: 'numeric',
-              month: '2-digit',
-              day: '2-digit',
-            });
-            const body = `## ${date} のKnipレポート\n\n\`\`\`\n${output || '問題なし'}\n\`\`\`\n\n[ワークフロー実行](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})`;
-
-            // ラベルが存在しない場合は作成
-            try {
-              await github.rest.issues.getLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: label,
-              });
-            } catch {
-              await github.rest.issues.createLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: label,
-                color: 'e4e669',
-                description: 'Knip による未使用コード・依存関係のレポート',
-              });
-            }
-
-            // 既存のIssueを検索
-            const issues = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: label,
-              state: 'open',
-              per_page: 1,
-            });
-
-            if (issues.data.length > 0) {
-              // 既存Issueにコメントを追加
-              const issue = issues.data[0];
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: issue.number,
-                body,
-              });
-              console.log(`Issue #${issue.number} にコメントを追加しました`);
-            } else {
-              // 新規Issueを作成
-              const newIssue = await github.rest.issues.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title,
-                body,
-                labels: [label],
-              });
-              console.log(`Issue #${newIssue.data.number} を作成しました`);
-            }
+          script: './scripts/knip-report.sh'
+          issue-title: 'Knip 定期レポート'
+          issue-label: 'knip-report'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/scripts/knip-report.sh
+++ b/scripts/knip-report.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+filter_pnpm_noise() {
+  grep -v '^ *>' | grep -v 'ELIFECYCLE'
+}
+
+set +e
+markdown_output=$(pnpm knip --reporter markdown 2>&1 | filter_pnpm_noise)
+default_output=$(pnpm knip 2>&1 | filter_pnpm_noise)
+exit_code=$?
+set -e
+
+# exit code 2以上は実行エラーとして失敗させる
+if [[ "${exit_code}" -ge 2 ]]; then
+  echo "${default_output}"
+  exit "${exit_code}"
+fi
+
+# markdown reporterの出力が "# Knip report" のみなら問題なし
+stripped=$(echo "${markdown_output}" | sed '/^$/d' | sed 's/^[[:space:]]*//')
+if [[ "${stripped}" == "# Knip report" ]]; then
+  has_issues=false
+else
+  has_issues=true
+fi
+
+# config-hintsの抽出
+config_hints=$(echo "${default_output}" | sed -n '/^Configuration hints/,/^$/p')
+if [[ -n "${config_hints}" ]]; then
+  has_config_hints=true
+else
+  has_config_hints=false
+fi
+
+if [[ "${has_issues}" == false && "${has_config_hints}" == false ]]; then
+  echo "問題は見つかりませんでした :tada:"
+  exit 0
+fi
+
+if [[ "${has_issues}" == true ]]; then
+  echo "${markdown_output}"
+  echo ""
+fi
+
+if [[ "${has_config_hints}" == true ]]; then
+  echo "## Configuration Hints"
+  echo ""
+  echo '```'
+  echo "${config_hints}"
+  echo '```'
+fi


### PR DESCRIPTION
## Summary
- `actions/github-script`によるIssue管理ロジックを`k35o/patrol-board@v1`に置き換え
- knipの実行とMarkdown整形を`scripts/knip-report.sh`に分離
- knipの`markdown`レポーターを活用してIssueでの表示を改善

## Test plan
- [ ] `workflow_dispatch`でワークフローを手動実行し、Issueが作成/更新されることを確認