### PR TITLE
refactor: github-contribution-graphからResponsiveContainerを削除

### DIFF
--- a/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
@@ -5,15 +5,7 @@ import { Card } from '@k8o/arte-odyssey/card';
 import { Tooltip as ArteTooltip } from '@k8o/arte-odyssey/tooltip';
 import { formatDate } from '@repo/helpers/date/format';
 import type { FC } from 'react';
-import {
-  Bar,
-  BarChart,
-  CartesianGrid,
-  ResponsiveContainer,
-  Tooltip,
-  XAxis,
-  YAxis,
-} from 'recharts';
+import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
 import type { ContributionDay } from '@/services/github/contributions';
 
 type ChartDataItem = {
@@ -61,39 +53,37 @@ export const Presenter: FC<{
         </div>
 
         <div className="h-48">
-          <ResponsiveContainer height="100%" width="100%">
-            <BarChart data={data}>
-              <CartesianGrid
-                stroke="var(--border-subtle)"
-                strokeDasharray="3 3"
-                vertical={false}
-              />
-              <XAxis
-                axisLine={false}
-                dataKey="label"
-                tick={{ fill: 'var(--fg-mute)', fontSize: 12 }}
-                tickLine={false}
-              />
-              <YAxis
-                allowDecimals={false}
-                axisLine={false}
-                tick={{ fill: 'var(--fg-mute)', fontSize: 12 }}
-                tickLine={false}
-                width={30}
-              />
-              <Tooltip
-                content={<CustomTooltip />}
-                cursor={{ fill: 'var(--bg-subtle)' }}
-                position={{ y: 0 }}
-              />
-              <Bar
-                activeBar={{ fill: 'var(--teal-700)' }}
-                dataKey="count"
-                fill="var(--teal-600)"
-                radius={[4, 4, 0, 0]}
-              />
-            </BarChart>
-          </ResponsiveContainer>
+          <BarChart data={data} height={192} width="100%">
+            <CartesianGrid
+              stroke="var(--border-subtle)"
+              strokeDasharray="3 3"
+              vertical={false}
+            />
+            <XAxis
+              axisLine={false}
+              dataKey="label"
+              tick={{ fill: 'var(--fg-mute)', fontSize: 12 }}
+              tickLine={false}
+            />
+            <YAxis
+              allowDecimals={false}
+              axisLine={false}
+              tick={{ fill: 'var(--fg-mute)', fontSize: 12 }}
+              tickLine={false}
+              width={30}
+            />
+            <Tooltip
+              content={<CustomTooltip />}
+              cursor={{ fill: 'var(--bg-subtle)' }}
+              position={{ y: 0 }}
+            />
+            <Bar
+              activeBar={{ fill: 'var(--teal-700)' }}
+              dataKey="count"
+              fill="var(--teal-600)"
+              radius={[4, 4, 0, 0]}
+            />
+          </BarChart>
         </div>
 
         <div className="text-fg-muted text-xs">


### PR DESCRIPTION
## Summary
- `ResponsiveContainer` ラッパーを削除
- `BarChart` に `width="100%"` と `height={192}` を直接渡すように変更
- インポートから `ResponsiveContainer` を削除してコードをシンプル化

## Test plan
- [ ] GitHub Contribution Graphが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)