### PR TITLE
refactor: フィードバックカードのUIとロジックを改善

### DIFF
--- a/apps/main/src/app/_components/feedback-card/feedback-card.tsx
+++ b/apps/main/src/app/_components/feedback-card/feedback-card.tsx
@@ -1,72 +1,122 @@
+'use client';
+
 import { Button } from '@k8o/arte-odyssey/button';
 import { FormControl } from '@k8o/arte-odyssey/form/form-control';
 import { Textarea } from '@k8o/arte-odyssey/form/textarea';
+import { BadIcon, GoodIcon } from '@k8o/arte-odyssey/icons';
 import { cn } from '@repo/helpers/cn';
-import { type FC, useState } from 'react';
-import { FEEDBACK_OPTIONS } from '@/services/feedbacks';
+import {
+  type FC,
+  type KeyboardEvent,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
+
+const OPTIONS = [
+  { id: 1, label: '良い', icon: GoodIcon },
+  { id: 2, label: '悪い', icon: BadIcon },
+] as const;
 
 export const FeedbackCard: FC<{
   title: string;
   onSubmit: (feedback: number | null, comment: string) => Promise<void>;
 }> = ({ title, onSubmit }) => {
   const [feedbackId, setFeedbackId] = useState<number | null>(null);
-  const [comment, setComment] = useState<string>('');
-  const [isPending, setIsPending] = useState(false);
-  const isInvalidComment = comment.length > 500;
+  const [comment, setComment] = useState('');
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [isPending, startTransition] = useTransition();
+  const buttonRefs = useRef<Array<HTMLButtonElement | null>>([]);
 
+  const isInvalidComment = comment.length > 500;
   const isDisabled = !(feedbackId || comment) || isInvalidComment || isPending;
+
+  const handleKeyDown = (e: KeyboardEvent, index: number): void => {
+    let next: number | null = null;
+    if (e.key === 'ArrowRight' || e.key === 'ArrowDown') {
+      next = (index + 1) % OPTIONS.length;
+    } else if (e.key === 'ArrowLeft' || e.key === 'ArrowUp') {
+      next = (index - 1 + OPTIONS.length) % OPTIONS.length;
+    }
+    if (next === null) return;
+    e.preventDefault();
+    const option = OPTIONS[next];
+    if (option) setFeedbackId(option.id);
+    buttonRefs.current[next]?.focus();
+  };
+
+  const focusIndex =
+    feedbackId !== null ? OPTIONS.findIndex((o) => o.id === feedbackId) : 0;
+
+  if (isSubmitted) {
+    return (
+      <div className="flex flex-col items-center gap-2 py-8 text-center">
+        <p className="font-bold text-fg-base text-lg">
+          フィードバックありがとうございます！
+        </p>
+        <p className="text-fg-mute text-sm">記事の改善に役立てます。</p>
+      </div>
+    );
+  }
 
   return (
     <form
-      className="flex flex-col gap-6"
+      className="flex flex-col gap-5"
       onSubmit={(e) => {
         e.preventDefault();
-        setIsPending(true);
-        void onSubmit(feedbackId, comment).then(() => {
-          setIsPending(false);
-          setComment('');
-          setFeedbackId(null);
+        startTransition(async () => {
+          await onSubmit(feedbackId, comment);
+          setIsSubmitted(true);
         });
       }}
     >
-      <p className="font-bold text-xl">{title}</p>
-      <div
-        aria-required="false"
-        className="grid grid-cols-2 gap-4 sm:grid-cols-4"
-        role="radiogroup"
-      >
-        {FEEDBACK_OPTIONS.map((option) => {
-          const Icon = option.icon;
-          return (
-            <div className="flex items-center justify-center" key={option.id}>
-              {/* biome-ignore lint/a11y/useSemanticElements: カスタムスタイルのラジオボタンとして使用 */}
-              <button
-                aria-checked={feedbackId === option.id}
-                className={cn(
-                  'flex w-full max-w-28 flex-col items-center justify-center gap-2 rounded-lg bg-primary-bg-subtle p-3 text-primary-fg',
-                  'aria-selected:border-2 aria-selected:border-primary-border aria-selected:bg-primary-bg aria-selected:text-fg-base',
-                )}
-                onClick={() => {
-                  if (feedbackId === option.id) {
-                    setFeedbackId(null);
-                    return;
-                  }
-                  setFeedbackId(option.id);
-                }}
-                role="radio"
-                type="button"
-                value={option.id}
-              >
-                <Icon />
-                <span className="text-xs sm:text-sm">{option.label}</span>
-              </button>
-            </div>
-          );
-        })}
+      <div className="flex flex-col gap-1">
+        <p className="font-bold text-fg-base text-xl">{title}</p>
+        <p className="text-fg-mute text-sm">
+          リアクションかコメントどちらかで送信できます
+        </p>
       </div>
       <FormControl
+        label="リアクション"
+        renderInput={({ labelId: _ }) => (
+          <div aria-required="false" className="flex gap-2" role="radiogroup">
+            {OPTIONS.map((option, index) => {
+              const Icon = option.icon;
+              const isSelected = feedbackId === option.id;
+              return (
+                // biome-ignore lint/a11y/useSemanticElements: カスタムスタイルのラジオボタンとして使用
+                <button
+                  aria-checked={isSelected}
+                  className={cn(
+                    'flex items-center gap-2 rounded-lg border border-border-base px-4 py-2 text-fg-mute transition-colors duration-150',
+                    'hover:border-primary-border hover:text-primary-fg',
+                    'aria-checked:border-primary-border aria-checked:text-primary-fg',
+                  )}
+                  key={option.id}
+                  onClick={() => {
+                    setFeedbackId(isSelected ? null : option.id);
+                  }}
+                  onKeyDown={(e) => {
+                    handleKeyDown(e, index);
+                  }}
+                  ref={(el) => {
+                    buttonRefs.current[index] = el;
+                  }}
+                  role="radio"
+                  tabIndex={index === focusIndex ? 0 : -1}
+                  type="button"
+                >
+                  <Icon size="md" />
+                  <span className="text-sm">{option.label}</span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      />
+      <FormControl
         errorText={isInvalidComment ? '500文字以内でご記入ください' : undefined}
-        helpText="500文字以内でご記入ください"
+        helpText="執筆のモチベーションや記事の修正・改善に活用します"
         isInvalid={isInvalidComment}
         label="コメント"
         renderInput={({ labelId: _, ...props }) => (


### PR DESCRIPTION
## Summary

- `aria-selected` → `aria-checked` のバグ修正（選択スタイルが効いていなかった）
- 8択 → 良い/悪いの2択にシンプル化
- 送信後に完了メッセージを表示
- `useTransition` で `isPending` の手動管理を廃止（React 19）
- roving tabindex パターンで矢印キーナビゲーションを実装
- `FormControl` でリアクション・コメントのラベルを統一
- タイトル下に送信条件の説明文を追加

## Test plan

- [ ] 良い/悪いを選択して送信できる
- [ ] コメントのみで送信できる
- [ ] 送信後に完了メッセージが表示される
- [ ] 矢印キーでリアクションを切り替えられる
- [ ] Tabキーでグループ全体に1回だけフォーカスが当たる

🤖 Generated with [Claude Code](https://claude.com/claude-code)