### PR TITLE
feat: databaseパッケージにdrizzle-kit studioスクリプトを追加

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -18,6 +18,7 @@
     "generate": "drizzle-kit generate",
     "generate:custom": "drizzle-kit generate --custom",
     "migrate": "drizzle-kit migrate",
+    "studio": "drizzle-kit studio",
     "export:schema": "drizzle-kit export > ./schema.sql",
     "build:erd": "liam erd build --input './src/schema/*.ts' --format drizzle",
     "preview:erd": "pnpm run build:erd && pnpm dlx http-server dist"


### PR DESCRIPTION
## Summary
- `packages/database/package.json` に `"studio": "drizzle-kit studio"` スクリプトを追加
- `pnpm run -F @repo/database studio` でDrizzle Studioを起動可能に

## Test plan
- [ ] `pnpm run -F @repo/database studio` でDrizzle Studioが起動することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)