### PR TITLE
refactor: @repo/databaseのauth exportを分離

### DIFF
--- a/apps/admin/src/app/api/auth/[...all]/route.ts
+++ b/apps/admin/src/app/api/auth/[...all]/route.ts
@@ -1,4 +1,4 @@
-import { auth } from '@repo/database';
+import { auth } from '@repo/database/auth';
 import { toNextJsHandler } from 'better-auth/next-js';
 
 export const { POST, GET } = toNextJsHandler(auth);

--- a/apps/admin/src/libs/verify-session.ts
+++ b/apps/admin/src/libs/verify-session.ts
@@ -1,5 +1,5 @@
 import 'server-only';
-import { auth } from '@repo/database';
+import { auth } from '@repo/database/auth';
 import { headers } from 'next/headers';
 import { redirect } from 'next/navigation';
 

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -6,10 +6,15 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./src/index.ts",
+      "types": "./src/db.ts",
       "storybook": "./src/__mocks__/db.ts",
-      "node": "./src/index.ts",
-      "default": "./src/index.ts"
+      "node": "./src/db.ts",
+      "default": "./src/db.ts"
+    },
+    "./auth": {
+      "types": "./src/auth.ts",
+      "node": "./src/auth.ts",
+      "default": "./src/auth.ts"
     }
   },
   "scripts": {

--- a/packages/database/src/__mocks__/db.ts
+++ b/packages/database/src/__mocks__/db.ts
@@ -16,5 +16,3 @@ export const db = Object.assign(drizzleDb, {
     increment: (column: AnyColumn, value = 1) => sql`${column} + ${value}`,
   },
 });
-
-export const auth = {} as Record<string, unknown>;

--- a/packages/database/src/index.ts
+++ b/packages/database/src/index.ts
@@ -1,4 +1,0 @@
-// schema と utils は内部実装として直接アクセスさせない
-
-export { auth } from './auth';
-export { db } from './db';


### PR DESCRIPTION
## Summary
- `@repo/database`のエントリポイントからauthを分離し、`@repo/database/auth`として別パスに
- main appで`import { db } from '@repo/database'`した際にBetter Authが評価されて警告が出る問題を解消
- Storybookモックからも不要なauth exportを削除

## Test plan
- [ ] main appのdev serverでBetter Auth関連の警告が出ないことを確認
- [ ] admin appの認証機能が正常に動作すること
- [ ] Storybookテストが全通過すること