### PR TITLE
fix: nuqsのバージョンをピン留め

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -34,7 +34,7 @@
     "drizzle-orm": "catalog:",
     "next": "catalog:",
     "next-themes": "catalog:",
-    "nuqs": "^2.8.9",
+    "nuqs": "2.8.9",
     "octokit": "5.0.5",
     "postcss": "catalog:",
     "react": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,7 +248,7 @@ importers:
         specifier: 'catalog:'
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       nuqs:
-        specifier: ^2.8.9
+        specifier: 2.8.9
         version: 2.8.9(next@16.2.1(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       octokit:
         specifier: 5.0.5


### PR DESCRIPTION
## Summary
- `nuqs`のバージョン指定を`^2.8.9`から`2.8.9`にピン留め
- Renovateの`renovate/pin-dependencies`ブランチが`pnpm install`で失敗し続けていたため、手動で対応

## Test plan
- [ ] `pnpm install`が正常に完了すること
- [ ] lockfileに差分がないこと