### PR TITLE
chore: minimumReleaseAgeExcludeから不要なパッケージを削除

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,11 +49,6 @@ minimumReleaseAge: 4320
 
 minimumReleaseAgeExclude:
   - '@k8o/*'
-  - '@storybook/*'
-  - storybook
-  - '@next/*'
-  - next
-  - '@vercel/next-browser'
 
 onlyBuiltDependencies:
   - lefthook


### PR DESCRIPTION
## Summary
- `pnpm-workspace.yaml`の`minimumReleaseAgeExclude`からStorybook・Next.js関連パッケージ（`@storybook/*`, `storybook`, `@next/*`, `next`, `@vercel/next-browser`）を削除

## Test plan
- [ ] `pnpm install`が正常に動作すること
- [ ] ビルドが通ること