### PR TITLE
refactor: ErrorBoundaryをunstable_catchErrorに置換

### DIFF
--- a/apps/main/src/app/_components/error-boundary/activity-error-boundary.tsx
+++ b/apps/main/src/app/_components/error-boundary/activity-error-boundary.tsx
@@ -1,0 +1,10 @@
+'use client';
+
+import { unstable_catchError } from 'next/error';
+import type { ReactNode } from 'react';
+
+function Fallback({ fallback }: { fallback: ReactNode }) {
+  return fallback;
+}
+
+export const ActivityErrorBoundary = unstable_catchError(Fallback);

--- a/apps/main/src/app/_components/error-boundary/index.ts
+++ b/apps/main/src/app/_components/error-boundary/index.ts
@@ -1,0 +1,2 @@
+export { ActivityErrorBoundary } from './activity-error-boundary';
+export { SilentErrorBoundary } from './silent-error-boundary';

--- a/apps/main/src/app/_components/error-boundary/silent-error-boundary.tsx
+++ b/apps/main/src/app/_components/error-boundary/silent-error-boundary.tsx
@@ -1,0 +1,10 @@
+import type { FC, ReactNode } from 'react';
+import { ActivityErrorBoundary } from './activity-error-boundary';
+
+export const SilentErrorBoundary: FC<{
+  children: ReactNode;
+}> = ({ children }) => {
+  return (
+    <ActivityErrorBoundary fallback={null}>{children}</ActivityErrorBoundary>
+  );
+};

--- a/apps/main/src/app/_components/link-card/error-boundary.tsx
+++ b/apps/main/src/app/_components/link-card/error-boundary.tsx
@@ -1,0 +1,14 @@
+import { Anchor } from '@k8o/arte-odyssey';
+import type { FC, ReactNode } from 'react';
+import { ActivityErrorBoundary } from '@/app/_components/error-boundary';
+
+export const LinkCardErrorBoundary: FC<{
+  href: string;
+  children: ReactNode;
+}> = ({ href, children }) => {
+  return (
+    <ActivityErrorBoundary fallback={<Anchor href={href}>{href}</Anchor>}>
+      {children}
+    </ActivityErrorBoundary>
+  );
+};

--- a/apps/main/src/app/_components/link-card/link-card.tsx
+++ b/apps/main/src/app/_components/link-card/link-card.tsx
@@ -1,6 +1,7 @@
-import { Anchor, ErrorBoundary, ExternalLinkIcon } from '@k8o/arte-odyssey';
+import { Anchor, ExternalLinkIcon } from '@k8o/arte-odyssey';
 import { cn } from '@repo/helpers/cn';
 import { type FC, Suspense } from 'react';
+import { LinkCardErrorBoundary } from './error-boundary';
 import { MetaImage } from './image';
 import { getMetadata } from './metadata';
 
@@ -90,10 +91,10 @@ export const LinkCard: FC<{
   variant?: Variant;
 }> = ({ href, variant = 'horizontal' }) => {
   return (
-    <ErrorBoundary fallback={<Anchor href={href}>{href}</Anchor>}>
+    <LinkCardErrorBoundary href={href}>
       <Suspense fallback={<Loading href={href} variant={variant} />}>
         <Content href={href} variant={variant} />
       </Suspense>
-    </ErrorBoundary>
+    </LinkCardErrorBoundary>
   );
 };

--- a/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -1,6 +1,5 @@
 import {
   Badge,
-  ErrorBoundary,
   LinkButton,
   PublishDateIcon,
   Separator,
@@ -12,6 +11,7 @@ import {
 import { formatDate } from '@repo/helpers/date/format';
 import Link from 'next/link';
 import { type FC, type ReactNode, Suspense, ViewTransition } from 'react';
+import { SilentErrorBoundary } from '@/app/_components/error-boundary';
 import { getBlogContent, getBlogToc } from '@/app/blog/_api';
 import { END_OF_CONTENT_ID } from './constants';
 import { Feedback } from './feedback';
@@ -68,7 +68,7 @@ export const BlogLayout: FC<{
                   </div>
                 </ViewTransition>
               </div>
-              <ErrorBoundary fallback={null}>
+              <SilentErrorBoundary>
                 <Suspense fallback={null}>
                   <div className="flex items-center gap-1">
                     <ViewIcon size="sm" />
@@ -78,7 +78,7 @@ export const BlogLayout: FC<{
                     </span>
                   </div>
                 </Suspense>
-              </ErrorBoundary>
+              </SilentErrorBoundary>
             </div>
             <ViewTransition name={`tags-${slug}`}>
               {blog.tags.length > 0 && (
@@ -101,19 +101,19 @@ export const BlogLayout: FC<{
           {children}
         </article>
         <div id={END_OF_CONTENT_ID}>
-          <ErrorBoundary fallback={null}>
+          <SilentErrorBoundary>
             <section className="w-full rounded-md bg-bg-base/90 px-3 pt-8 pb-14 sm:px-10">
               <Feedback slug={slug} />
             </section>
-          </ErrorBoundary>
-          <ErrorBoundary fallback={null}>
+          </SilentErrorBoundary>
+          <SilentErrorBoundary>
             <Recommend slug={slug} />
-          </ErrorBoundary>
+          </SilentErrorBoundary>
         </div>
       </div>
-      <ErrorBoundary fallback={null}>
+      <SilentErrorBoundary>
         <TableOfContents headingTree={headingTree} />
-      </ErrorBoundary>
+      </SilentErrorBoundary>
     </div>
   );
 };

--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -2,7 +2,6 @@ import {
   ArteOdyssey,
   Badge,
   Card,
-  ErrorBoundary,
   GitHubIcon,
   Heading,
   IconLink,
@@ -12,6 +11,7 @@ import {
 import Image from 'next/image';
 import { AppCard } from './_components/app-card';
 import { EmailTooltip } from './_components/email-tooltip';
+import { ActivityErrorBoundary } from './_components/error-boundary';
 import { GitHubContributionGraph } from './_components/github-contribution-graph';
 import { RecentBlogs } from './_components/recent-blogs';
 import k8o from './_images/k8o.jpg';
@@ -73,7 +73,7 @@ export default function Home() {
         <div>
           <Heading type="h2">Activity</Heading>
         </div>
-        <ErrorBoundary
+        <ActivityErrorBoundary
           fallback={
             <div className="grid gap-8">
               <RecentBlogs />
@@ -88,7 +88,7 @@ export default function Home() {
               <RecentBlogs />
             </div>
           </div>
-        </ErrorBoundary>
+        </ActivityErrorBoundary>
       </div>
       <div className="flex flex-col gap-6">
         <div>


### PR DESCRIPTION
## Summary
- `@k8o/arte-odyssey`の`ErrorBoundary`をNext.jsの`unstable_catchError`ベースの実装に置換
- `ActivityErrorBoundary`を共通の基盤とし、`SilentErrorBoundary`と`LinkCardErrorBoundary`はそれをラップする構成
- 対象: `page.tsx`、`blog-layout.tsx`（4箇所）、`link-card.tsx`

## Test plan
- [ ] トップページのActivity表示がエラー時にfallbackされること
- [ ] ブログ記事ページの閲覧数・フィードバック・おすすめ・目次がエラー時に非表示になること
- [ ] リンクカードがエラー時にプレーンなリンクにfallbackされること