### PR TITLE
chore: ブラウザログをターミナルに出力する設定を追加

### DIFF
--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -10,6 +10,9 @@ const nextConfig: NextConfig = {
       exclude: ['error', 'warn'],
     },
   },
+  logging: {
+    browserToTerminal: true,
+  },
   typedRoutes: true,
   cacheComponents: true,
   experimental: {


### PR DESCRIPTION
## Summary
- `next.config.ts`に`logging.browserToTerminal: true`を追加
- 開発時にブラウザのコンソールログがターミナルにも出力されるようになる

## Test plan
- [ ] `pnpm run dev`でブラウザログがターミナルに表示されること