### PR TITLE
chore: claude-code-reviewのモデルをOpusに変更

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -29,6 +29,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           use_sticky_comment: true
           claude_args: |
+            --model opus
             --allowedTools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"
             --system-prompt "日本語で応答してください。"
           prompt: |


### PR DESCRIPTION
## Summary
- claude-code-reviewワークフローで使用するモデルを`--model opus`でOpusに指定

## Test plan
- [ ] PRを作成してレビューワークフローがOpusモデルで動作すること