### PR TITLE
chore: migrate pnpm build permissions

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,9 +70,6 @@ catalogs:
       specifier: 2.1.0
       version: 2.1.0
 
-overrides:
-  katex: '>=0.16.35'
-
 importers:
 
   .:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,9 +2,6 @@ packages:
   - apps/*
   - packages/*
 
-overrides:
-  katex: '>=0.16.35'
-
 catalog:
   '@k8o/arte-odyssey': 4.2.1
   '@storybook/addon-a11y': 10.3.0
@@ -30,28 +27,17 @@ catalog:
 
 blockExoticSubdeps: true
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - '@prisma/engines'
-  - '@swc/core'
-  - '@tailwindcss/oxide'
-  - '@vercel/next-browser'
-  - bufferutil
-  - core-js
-  - core-js-pure
-  - edgedriver
-  - esbuild
-  - geckodriver
-  - sharp
-  - unrs-resolver
+allowBuilds:
+  '@prisma/engines': false
+  '@swc/core': false
+  esbuild: false
+  lefthook: true
+  msw: true
+  sharp: false
 
 minimumReleaseAge: 4320
 
 minimumReleaseAgeExclude:
   - '@k8o/*'
-
-onlyBuiltDependencies:
-  - lefthook
-  - msw
 
 verifyDepsBeforeRun: install


### PR DESCRIPTION
## Summary
- migrate pnpm build script settings from deprecated allowlists to `allowBuilds`
- keep `lefthook` and `msw` explicitly allowed, and keep selected native deps explicitly blocked
- remove the root `katex` override from workspace config and lockfile

## Testing
- pre-commit: ls-lint