### PR TITLE
chore: GitHub ActionsでセルフホストRenovateを実行するワークフローを追加

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -1,0 +1,28 @@
+name: Renovate
+
+on:
+  schedule:
+    - cron: '0 15,18,21 * * 5'
+    - cron: '0 0 * * 6'
+  workflow_dispatch:
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aca63ce09 # v1.11.7
+        with:
+          app-id: ${{ secrets.K35O_BOT_APP_ID }}
+          private-key: ${{ secrets.K35O_BOT_PRIVATE_KEY }}
+
+      - name: Checkout
+        uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # v4.2.2
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@68a3ea99af6ad249940b5a9fdf44fc6d7f14378b # v46.1.6
+        with:
+          token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## 概要

Mend HostedのRenovateがOOM（Out of Memory）で実行できない問題に対応するため、GitHub Actionsでセルフホストする構成に移行する。

## 変更内容

- `renovatebot/github-action` を使ったワークフローを追加
- JST 土曜日 0時・3時・6時・9時にスケジュール実行
- `K35O_BOT_APP_ID` / `K35O_BOT_PRIVATE_KEY` でGitHub Appトークンを生成
- 手動実行（workflow_dispatch）にも対応