### PR TITLE
fix: Renovateにリポジトリを指定する環境変数を追加

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -26,3 +26,5 @@ jobs:
         uses: renovatebot/github-action@68a3ea99af6ad249940b5a9fdf44fc6d7f14378b # v46.1.6
         with:
           token: ${{ steps.generate-token.outputs.token }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
Renovateが対象リポジトリを認識できず `No repositories found` となっていたため、`RENOVATE_REPOSITORIES` を追加。