### PR TITLE
chore: prHourlyLimitを無制限に設定

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     "monorepo:nextjs",
     "monorepo:vitest"
   ],
+  "prHourlyLimit": 0,
   "prConcurrentLimit": 10,
   "github-actions": {
     "managerFilePatterns": ["/^\\.github/actions/[^/]+/action\\.ya?ml$/"]


### PR DESCRIPTION
Renovateの時間あたりPR作成制限を解除し、1回の実行で全PRを作成できるようにする。

併せて共有設定（k35o/renovate-config）の `minimumReleaseAge` を7日→3日に変更済み。