### PR TITLE
chore: Dependency DashboardやPRのチェックボックスでRenovateを発火可能にする

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -4,11 +4,18 @@ on:
   schedule:
     - cron: '0 15,18,21 * * 5'
     - cron: '0 0 * * 6'
+  issues:
+    types: [edited]
+  pull_request:
+    types: [edited]
   workflow_dispatch:
 
 jobs:
   renovate:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'issues' && github.event_name != 'pull_request' ||
+      contains(github.event.*.labels.*.name, 'renovate')
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
issueやPRの編集イベント（チェックボックス操作）でRenovateワークフローを発火できるようにする。`renovate`ラベル付きのissue/PRのみが対象。