### PR TITLE
fix: Renovateトリガー条件を修正

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -16,8 +16,8 @@ jobs:
     if: >-
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'issues' && contains(github.event.issue.title, 'Dependency Dashboard') && github.event.sender.login == 'k35o') ||
-      (github.event_name == 'pull_request' && github.event.sender.login == 'k35o' && contains(github.event.pull_request.labels.*.name, 'renovate'))
+      (github.event_name == 'issues' && contains(github.event.issue.title, 'Dependency Dashboard') && github.event.sender.login == github.repository_owner) ||
+      (github.event_name == 'pull_request' && github.event.sender.login == github.repository_owner && contains(github.event.pull_request.labels.*.name, 'renovate'))
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
Dependency Dashboardのチェックボックス操作でRenovateが発火しなかった問題を修正。

- issueはタイトルに「Dependency Dashboard」を含む場合のみ発火
- PRは`renovate`ラベル付きの場合のみ発火