### PR TITLE
fix: align og image aspect ratio

### DIFF
--- a/apps/main/src/app/base-converter/opengraph-image.tsx
+++ b/apps/main/src/app/base-converter/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = '基数チェンジャー';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/blog/opengraph-image.tsx
+++ b/apps/main/src/app/blog/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = 'blog';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/color-converter/opengraph-image.tsx
+++ b/apps/main/src/app/color-converter/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = 'color converter';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/contrast-checker/opengraph-image.tsx
+++ b/apps/main/src/app/contrast-checker/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = 'コントラストチェッカー';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/japanese-text-fixer/opengraph-image.tsx
+++ b/apps/main/src/app/japanese-text-fixer/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = '日本語校正くん';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/moji-count/opengraph-image.tsx
+++ b/apps/main/src/app/moji-count/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = 'もじカウント';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/opengraph-image.tsx
+++ b/apps/main/src/app/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = 'k8o';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/oss/opengraph-image.tsx
+++ b/apps/main/src/app/oss/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = 'oss';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/playgrounds/opengraph-image.tsx
+++ b/apps/main/src/app/playgrounds/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = 'Playgrounds';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/radius-maker/opengraph-image.tsx
+++ b/apps/main/src/app/radius-maker/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = 'かどまるラボ';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/sql-table-builder/opengraph-image.tsx
+++ b/apps/main/src/app/sql-table-builder/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = 'SQLテーブルメーカー';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/talks/opengraph-image.tsx
+++ b/apps/main/src/app/talks/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = 'talks';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';

--- a/apps/main/src/app/text-diff/opengraph-image.tsx
+++ b/apps/main/src/app/text-diff/opengraph-image.tsx
@@ -3,7 +3,7 @@ import { OgImage } from '@/app/_components/og-image';
 export const alt = 'テキスト差分チェッカー';
 export const size = {
   width: 1200,
-  height: 600,
+  height: 630,
 };
 
 export const contentType = 'image/png';


### PR DESCRIPTION
## Summary
- fix the exported Open Graph image size from 1200x600 to 1200x630 for pages using the shared OgImage component
- resolve the aspect ratio mismatch that affected inherited pages such as /reading-list

## Testing
- not run (metadata size alignment change only)