### PR TITLE
fix: keep link card images in video ratio

### DIFF
--- a/apps/main/src/app/_components/link-card/image.tsx
+++ b/apps/main/src/app/_components/link-card/image.tsx
@@ -12,7 +12,7 @@ export const MetaImage: FC<{
   }
 
   return (
-    <div className="relative aspect-video w-full overflow-hidden rounded-t-lg sm:aspect-auto sm:w-48 sm:shrink-0 sm:self-stretch sm:rounded-t-none sm:rounded-l-lg">
+    <div className="relative aspect-video w-full overflow-hidden rounded-t-lg sm:w-48 sm:shrink-0 sm:rounded-t-none sm:rounded-l-lg">
       <Image
         alt=""
         className="object-cover"

--- a/apps/main/src/app/_components/link-card/link-card.tsx
+++ b/apps/main/src/app/_components/link-card/link-card.tsx
@@ -15,7 +15,7 @@ export const LinkCardLoading: FC<{ href: string }> = ({ href }) => {
     <InteractiveCard>
       <a href={href} rel="noopener noreferrer" target="_blank">
         <div className="flex animate-pulse flex-col overflow-hidden sm:flex-row">
-          <div className="aspect-video w-full rounded-t-lg bg-bg-mute sm:aspect-auto sm:w-48 sm:shrink-0 sm:self-stretch sm:rounded-t-none sm:rounded-l-lg" />
+          <div className="aspect-video w-full rounded-t-lg bg-bg-mute sm:w-48 sm:shrink-0 sm:rounded-t-none sm:rounded-l-lg" />
           <div className="flex flex-1 flex-col gap-3 p-4">
             <div className="h-5 w-3/4 rounded-md bg-bg-mute" />
             <div className="h-4 w-full rounded-md bg-bg-mute" />


### PR DESCRIPTION
## Summary
- keep LinkCard thumbnails at a fixed 16:9 ratio on desktop layouts
- stop the reading-list card images from collapsing into short banner-like thumbnails when the text block is short

## Testing
- verified against the production screenshot provided by the user
- not run locally in a browser