### PR TITLE
fix: /tags/[id]をPPR静的シェルに含める

### DIFF
--- a/apps/main/src/app/tags/[id]/page.tsx
+++ b/apps/main/src/app/tags/[id]/page.tsx
@@ -1,5 +1,4 @@
 import { notFound } from 'next/navigation';
-import { Suspense } from 'react';
 import { getTag } from '@/services/tags/tag';
 import { getTags } from '@/services/tags/tags';
 import { TagContent } from '../_components/tag-content';
@@ -12,7 +11,7 @@ export async function generateStaticParams() {
   }));
 }
 
-async function TagContentWrapper({ params }: PageProps<'/tags/[id]'>) {
+export default async function Page({ params }: PageProps<'/tags/[id]'>) {
   const id = (await params).id;
   const tag = await getTag(Number(id));
 
@@ -21,12 +20,4 @@ async function TagContentWrapper({ params }: PageProps<'/tags/[id]'>) {
   }
 
   return <TagContent {...tag} />;
-}
-
-export default function Page(props: PageProps<'/tags/[id]'>) {
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <TagContentWrapper {...props} />
-    </Suspense>
-  );
 }


### PR DESCRIPTION
## 概要
`/tags/[id]` が PPR シェルに何も入らず、fallback として素の `<div>Loading...</div>` が見えていた問題を修正。

## 動機
next-browser の PPR シェル解析で `/tags/[id]` に 3 つの dynamic hole があり、シェルにはレイアウト枠しか入っていないことが判明した。`generateStaticParams` で全タグを列挙しており `getTag` も `'use cache'` 済みなので、本来は完全に prerender できるページ。

## 詳細
- `Page` を `TagContentWrapper` + `Suspense` で分けるのをやめ、`Page` で直接 `params` を await して `getTag` を呼ぶように変更
- これにより Suspense 境界が消え、該当ページがまるごと静的シェルに含まれる

## 確認
- next-browser の `ppr lock` → `goto /tags/1` → `ppr unlock` で dynamic holes が 0 になることを確認
- `pnpm -F main type-check` 通過