### PR TITLE
chore: @k8o/arte-odyssey v6.0.0にアップデート

### DIFF
--- a/apps/admin/src/app/(authenticated)/_components/stat-card/stat-card.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/stat-card/stat-card.tsx
@@ -9,7 +9,7 @@ export const StatCard = ({
   description?: string;
 }) => {
   return (
-    <Card variant="secondary">
+    <Card>
       <div className="flex flex-col gap-1 p-4">
         <p className="text-fg-mute text-sm">{label}</p>
         <p className="font-bold text-2xl">{value}</p>

--- a/apps/admin/src/app/(authenticated)/reports/_components/reports-content/reports-content.tsx
+++ b/apps/admin/src/app/(authenticated)/reports/_components/reports-content/reports-content.tsx
@@ -27,14 +27,14 @@ export const ReportsContent = async () => {
   return (
     <div className="flex flex-col gap-10">
       <section className="grid grid-cols-1 gap-6 sm:grid-cols-3">
-        <Card appearance="shadow" variant="primary">
+        <Card appearance="shadow">
           <div className="flex flex-col gap-2 p-6">
             <p className="text-fg-mute text-sm">総レポート数</p>
             <p className="font-bold text-3xl">{totalCount}</p>
           </div>
         </Card>
         {typeCounts.map((t) => (
-          <Card appearance="shadow" key={t.type} variant="primary">
+          <Card appearance="shadow" key={t.type}>
             <div className="flex flex-col gap-2 p-6">
               <p className="text-fg-mute text-sm">{t.type}</p>
               <p className="font-bold text-3xl">{t.count}</p>
@@ -50,7 +50,7 @@ export const ReportsContent = async () => {
           <h3 className="font-bold text-lg">最新レポート</h3>
           <p className="mt-1 text-fg-mute text-sm">直近100件のレポートを表示</p>
         </div>
-        <Card appearance="shadow" variant="primary">
+        <Card appearance="shadow">
           <ReportTable reports={reports} />
         </Card>
       </section>

--- a/apps/main/src/app/_components/link-card/image.tsx
+++ b/apps/main/src/app/_components/link-card/image.tsx
@@ -12,7 +12,7 @@ export const MetaImage: FC<{
   }
 
   return (
-    <div className="flex w-full flex-col justify-center overflow-hidden rounded-t-lg bg-bg-subtle sm:w-48 sm:shrink-0 sm:rounded-t-none sm:rounded-l-lg">
+    <div className="flex w-full flex-col justify-center overflow-hidden rounded-t-xl bg-bg-subtle sm:w-48 sm:shrink-0 sm:rounded-t-none sm:rounded-l-xl">
       <div className="relative aspect-video w-full">
         <Image
           alt=""

--- a/apps/main/src/app/_components/link-card/link-card.tsx
+++ b/apps/main/src/app/_components/link-card/link-card.tsx
@@ -20,7 +20,7 @@ export const LinkCardLoading: FC<{
     <InteractiveCard appearance={appearance}>
       <a href={href} rel="noopener noreferrer" target="_blank">
         <div className="flex animate-pulse flex-col overflow-hidden sm:flex-row">
-          <div className="w-full rounded-t-lg bg-bg-mute sm:w-48 sm:shrink-0 sm:rounded-t-none sm:rounded-l-lg">
+          <div className="w-full rounded-t-xl bg-bg-mute sm:w-48 sm:shrink-0 sm:rounded-t-none sm:rounded-l-xl">
             <div className="aspect-video w-full bg-bg-mute" />
           </div>
           <div className="flex flex-1 flex-col gap-3 p-4">

--- a/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
+++ b/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
@@ -2,7 +2,6 @@
 
 import {
   Badge,
-  Card,
   Checkbox,
   FormControl,
   Tabs,
@@ -150,80 +149,78 @@ export const BaselineFeatureList: FC<{
     : availableYears[0];
 
   return (
-    <Card appearance="shadow">
-      <div className="flex flex-col gap-6 p-5 sm:p-6">
-        <div className="flex flex-col gap-4">
-          <div className="sm:max-w-64">
-            <FormControl
-              label="検索"
-              renderInput={(props) => (
-                <TextField
-                  {...props}
-                  onChange={(e) => {
-                    setQuery(e.target.value);
-                  }}
-                  placeholder="機能名で検索..."
-                  value={query}
-                />
-              )}
-            />
-          </div>
-          <div className="flex gap-4 text-sm">
-            <Checkbox
-              label="Newly Available"
-              onChange={() =>
-                setVisibility((prev) => ({
-                  ...prev,
-                  newly: !prev.newly,
-                }))
-              }
-              value={visibility.newly}
-            />
-            <Checkbox
-              label="Widely Available"
-              onChange={() =>
-                setVisibility((prev) => ({
-                  ...prev,
-                  widely: !prev.widely,
-                }))
-              }
-              value={visibility.widely}
-            />
-          </div>
+    <section className="flex flex-col gap-6 rounded-xl bg-bg-raised p-5 sm:p-6">
+      <div className="flex flex-col gap-4">
+        <div className="sm:max-w-64">
+          <FormControl
+            label="検索"
+            renderInput={(props) => (
+              <TextField
+                {...props}
+                onChange={(e) => {
+                  setQuery(e.target.value);
+                }}
+                placeholder="機能名で検索..."
+                value={query}
+              />
+            )}
+          />
         </div>
+        <div className="flex gap-4 text-sm">
+          <Checkbox
+            label="Newly Available"
+            onChange={() =>
+              setVisibility((prev) => ({
+                ...prev,
+                newly: !prev.newly,
+              }))
+            }
+            value={visibility.newly}
+          />
+          <Checkbox
+            label="Widely Available"
+            onChange={() =>
+              setVisibility((prev) => ({
+                ...prev,
+                widely: !prev.widely,
+              }))
+            }
+            value={visibility.widely}
+          />
+        </div>
+      </div>
 
-        {defaultYear && (
-          <Tabs.Root
-            defaultSelectedId={defaultYear}
-            ids={availableYears as [string, ...string[]]}
-          >
-            <Tabs.List label="年を選択">
-              {availableYears.map((year) => {
-                const count = filteredCountByYear.get(year) ?? 0;
-                return (
-                  <Tabs.Tab id={year} key={year}>
-                    {year}
-                    <span className="ml-1 text-fg-mute text-xs">{count}</span>
-                  </Tabs.Tab>
-                );
-              })}
-            </Tabs.List>
+      {defaultYear && (
+        <Tabs.Root
+          defaultSelectedId={defaultYear}
+          ids={availableYears as [string, ...string[]]}
+        >
+          <Tabs.List label="年を選択">
             {availableYears.map((year) => {
-              const data = dataByYear.get(year);
+              const count = filteredCountByYear.get(year) ?? 0;
               return (
-                <Tabs.Panel id={year} key={year}>
-                  <FeatureList
-                    blogMap={blogMap}
-                    features={data?.features ?? []}
-                    query={query}
-                    visibility={visibility}
-                  />
-                </Tabs.Panel>
+                <Tabs.Tab id={year} key={year}>
+                  {year}
+                  <span className="ml-1 text-fg-mute text-xs">{count}</span>
+                </Tabs.Tab>
               );
             })}
-          </Tabs.Root>
-        )}
-      </div>
-    </Card>
+          </Tabs.List>
+          {availableYears.map((year) => {
+            const data = dataByYear.get(year);
+            return (
+              <Tabs.Panel id={year} key={year}>
+                <FeatureList
+                  blogMap={blogMap}
+                  features={data?.features ?? []}
+                  query={query}
+                  visibility={visibility}
+                />
+              </Tabs.Panel>
+            );
+          })}
+        </Tabs.Root>
+      )}
+    </section>
   );
 };

--- a/apps/main/src/app/blog/_components/blog-layout/table-of-contents/progress-bar.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/table-of-contents/progress-bar.tsx
@@ -31,7 +31,7 @@ export const ProgressBar: FC<{
           cy="16"
           fill="none"
           r={radius}
-          stroke="var(--bg-base)"
+          stroke="var(--bg-raised)"
           strokeWidth="3"
         />
         {/* 進捗の円 */}

--- a/apps/main/src/app/blog/_components/blog-layout/table-of-contents/table-of-contents.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/table-of-contents/table-of-contents.tsx
@@ -93,7 +93,7 @@ export const TableOfContents: FC<{
   return (
     <details
       className={cn(
-        'fixed w-80 rounded-xl bg-bg-base shadow-md',
+        'fixed w-80 rounded-xl bg-bg-raised shadow-md',
         'right-4 bottom-4 open:right-0 open:bottom-0 sm:right-16 sm:bottom-8 sm:open:right-16 sm:open:bottom-8',
         'open:details-content:border-border-mute open:details-content:border-t open:details-content:p-4 open:details-content:pt-0',
       )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@k8o/arte-odyssey':
-      specifier: 6.0.0
-      version: 6.0.0
+      specifier: 6.0.1
+      version: 6.0.1
     '@storybook/addon-a11y':
       specifier: 10.3.3
       version: 10.3.3
@@ -127,7 +127,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 6.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)
+        version: 6.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -218,7 +218,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 6.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)
+        version: 6.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)
       '@mdx-js/loader':
         specifier: 3.1.1
         version: 3.1.1
@@ -1471,8 +1471,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@k8o/arte-odyssey@6.0.0':
-    resolution: {integrity: sha512-AYfBmVsazWr8CmwRu1Q3unMPTbdIrU2g3oZ6WwyGRaCIGp6dnlPQ/G5WdFTi3TWDar/Pv8B6ONK0Y9Yvgdf/1g==}
+  '@k8o/arte-odyssey@6.0.1':
+    resolution: {integrity: sha512-uIyb5H4z4qzQWa4VUTcHzaLmwcrPnwpL4M6bWafM1LrhdZUshGrxeednQRCfAD6KNKoF/D12ZKQPIuISed3btg==}
     peerDependencies:
       '@types/react': '>=19.0.0'
       '@types/react-dom': '>=19.0.0'
@@ -6719,7 +6719,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@k8o/arte-odyssey@6.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)':
+  '@k8o/arte-odyssey@6.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react': 19.2.14

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@k8o/arte-odyssey':
-      specifier: 5.0.4
-      version: 5.0.4
+      specifier: 6.0.0
+      version: 6.0.0
     '@storybook/addon-a11y':
       specifier: 10.3.3
       version: 10.3.3
@@ -127,7 +127,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 5.0.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)
+        version: 6.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -218,7 +218,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 5.0.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)
+        version: 6.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)
       '@mdx-js/loader':
         specifier: 3.1.1
         version: 3.1.1
@@ -1471,8 +1471,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@k8o/arte-odyssey@5.0.4':
-    resolution: {integrity: sha512-M3cvRwhGbPwaM2qwgqcYeqkDC6z7mfnbxWAog4rnLWlmBfeS+uTbIYTV2Zl9k5TQGuVXMhIy5XM5QtBiaN0PLw==}
+  '@k8o/arte-odyssey@6.0.0':
+    resolution: {integrity: sha512-AYfBmVsazWr8CmwRu1Q3unMPTbdIrU2g3oZ6WwyGRaCIGp6dnlPQ/G5WdFTi3TWDar/Pv8B6ONK0Y9Yvgdf/1g==}
     peerDependencies:
       '@types/react': '>=19.0.0'
       '@types/react-dom': '>=19.0.0'
@@ -6719,7 +6719,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@k8o/arte-odyssey@5.0.4(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)':
+  '@k8o/arte-odyssey@6.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(tailwindcss@4.2.2)(typescript@6.0.2)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@types/react': 19.2.14

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - packages/*
 
 catalog:
-  '@k8o/arte-odyssey': 5.0.4
+  '@k8o/arte-odyssey': 6.0.0
   '@storybook/addon-a11y': 10.3.3
   '@storybook/addon-docs': 10.3.3
   '@storybook/addon-mcp': '0.5.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - packages/*
 
 catalog:
-  '@k8o/arte-odyssey': 6.0.0
+  '@k8o/arte-odyssey': 6.0.1
   '@storybook/addon-a11y': 10.3.3
   '@storybook/addon-docs': 10.3.3
   '@storybook/addon-mcp': '0.5.0'


### PR DESCRIPTION
## Summary
- @k8o/arte-odyssey を 5.0.4 → 6.0.0 にアップデート
- Card の variant prop 削除に対応（`variant="primary"` / `variant="secondary"` を全箇所から除去）

## Test plan
- [ ] `pnpm run type-check` が通ること
- [ ] `pnpm run check` が通ること
- [ ] admin/main両アプリでCardの表示が崩れていないこと