### PR TITLE
chore: Vercelの不要ビルドをスキップするIgnored Build Stepを追加

### DIFF
--- a/apps/admin/vercel.json
+++ b/apps/admin/vercel.json
@@ -1,4 +1,5 @@
 {
+  "ignoreCommand": "bash ../../scripts/ignore-build.sh admin",
   "crons": [
     {
       "path": "/api/crons/weekly-notifications",

--- a/apps/main/vercel.json
+++ b/apps/main/vercel.json
@@ -1,0 +1,3 @@
+{
+  "ignoreCommand": "bash ../../scripts/ignore-build.sh main"
+}

--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Vercel Ignored Build Step
+# exit 0 = ビルドスキップ, exit 1 = ビルド実行
+
+APP_NAME=$1
+
+if [ -z "$APP_NAME" ]; then
+  echo "Usage: bash scripts/ignore-build.sh <app-name>"
+  exit 1
+fi
+
+# renovateブランチはpreviewビルドをスキップ
+if [[ "$VERCEL_GIT_COMMIT_REF" == renovate/* ]]; then
+  echo ">> Skipping: Renovate branch ($VERCEL_GIT_COMMIT_REF)"
+  exit 0
+fi
+
+# turbo query affectedで対象アプリに影響があるか判定
+AFFECTED=$(pnpm turbo query "query { affectedPackages { items { name } } }")
+echo "$AFFECTED"
+
+if echo "$AFFECTED" | grep -q "\"name\": \"$APP_NAME\""; then
+  echo ">> Proceeding: $APP_NAME is affected"
+  exit 1
+fi
+
+echo ">> Skipping: $APP_NAME is not affected"
+exit 0


### PR DESCRIPTION
## Summary
- `turbo query affectedPackages` を使い、変更の影響がないアプリのVercelビルドをスキップする `scripts/ignore-build.sh` を追加
- `renovate/*` ブランチのpreviewビルドを全スキップ
- k8o (`apps/main`) と k8o-admin (`apps/admin`) 両方の `vercel.json` に `ignoreCommand` を設定

## 背景
同一リポジトリに2つのVercelプロジェクトが紐づいており、全pushで2ビルド消費していた。
さらにRenovateが1 PRあたり複数commitをpushするため、依存更新だけでビルド時間が大量に消費されていた。

## Test plan
- [ ] Renovateブランチのpushでpreviewビルドがスキップされることを確認
- [ ] `apps/main` のみの変更で k8o-admin のビルドがスキップされることを確認
- [ ] `packages/` の変更で両方のビルドが実行されることを確認