### PR TITLE
feat: カラーHexクイズ機能を追加

### DIFF
--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-quiz.stories.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-quiz.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+import { ColorQuiz } from './color-quiz';
+
+const meta: Meta<typeof ColorQuiz> = {
+  title: 'app/color-quiz/color-quiz',
+  component: ColorQuiz,
+};
+
+export default meta;
+type Story = StoryObj<typeof ColorQuiz>;
+
+export const Primary: Story = {};
+
+export const ColorToHexMode: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 「色からHexを当てる」タブがデフォルトで選択されている
+    const tab = canvas.getByRole('tab', {
+      name: '色からHexを当てる',
+    });
+    await expect(tab).toHaveAttribute('aria-selected', 'true');
+
+    // 回答ボタンが無効の状態で表示されている
+    const submitButton = canvas.getByRole('button', {
+      name: '回答する',
+    });
+    await expect(submitButton).toBeDisabled();
+  },
+};
+
+export const ColorToHexSubmit: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+
+    // hex選択肢の最初をクリック
+    const panel = canvas.getByRole('tabpanel');
+    const hexButtons = within(panel).getAllByRole('button');
+    const optionButton = hexButtons.find((btn) =>
+      btn.textContent?.startsWith('#'),
+    );
+    if (optionButton) {
+      await userEvent.click(optionButton);
+    }
+
+    // 回答ボタンが有効になる
+    const submitButton = canvas.getByRole('button', {
+      name: '回答する',
+    });
+    await expect(submitButton).toBeEnabled();
+
+    // 回答する
+    await userEvent.click(submitButton);
+
+    // 結果画面に「次の問題へ」ボタンが表示される
+    await expect(
+      canvas.getByRole('button', { name: '次の問題へ' }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const HexToColorMode: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+
+    // 「Hexから色を当てる」タブに切り替え
+    const tab = canvas.getByRole('tab', {
+      name: 'Hexから色を当てる',
+    });
+    await userEvent.click(tab);
+
+    await expect(tab).toHaveAttribute('aria-selected', 'true');
+
+    // 回答ボタンが無効の状態で表示されている
+    const submitButton = canvas.getByRole('button', {
+      name: '回答する',
+    });
+    await expect(submitButton).toBeDisabled();
+  },
+};
+
+export const HexToColorSubmit: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+
+    // 「Hexから色を当てる」タブに切り替え
+    const tab = canvas.getByRole('tab', {
+      name: 'Hexから色を当てる',
+    });
+    await userEvent.click(tab);
+
+    // 色の選択肢をクリック
+    const panel = canvas.getByRole('tabpanel');
+    const colorButtons = within(panel).getAllByRole('button');
+    const optionButton = colorButtons.find(
+      (btn) => !btn.textContent?.includes('回答する'),
+    );
+    if (optionButton) {
+      await userEvent.click(optionButton);
+    }
+
+    // 回答する
+    const submitButton = canvas.getByRole('button', {
+      name: '回答する',
+    });
+    await userEvent.click(submitButton);
+
+    // 結果画面に「次の問題へ」ボタンが表示される
+    await expect(
+      canvas.getByRole('button', { name: '次の問題へ' }),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-quiz.stories.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-quiz.stories.tsx
@@ -34,15 +34,13 @@ export const ColorToHexSubmit: Story = {
   play: async ({ canvasElement, userEvent }) => {
     const canvas = within(canvasElement);
 
-    // hex選択肢の最初をクリック
+    // hex選択肢の最初をクリック（aria-labelで特定）
     const panel = canvas.getByRole('tabpanel');
-    const hexButtons = within(panel).getAllByRole('button');
-    const optionButton = hexButtons.find((btn) =>
-      btn.textContent?.startsWith('#'),
-    );
-    if (optionButton) {
-      await userEvent.click(optionButton);
-    }
+    const optionButtons = within(panel).getAllByRole('button', {
+      name: /^Hexの選択肢:/,
+    });
+    await expect(optionButtons.length).toBeGreaterThan(0);
+    await userEvent.click(optionButtons[0] as HTMLElement);
 
     // 回答ボタンが有効になる
     const submitButton = canvas.getByRole('button', {
@@ -90,15 +88,13 @@ export const HexToColorSubmit: Story = {
     });
     await userEvent.click(tab);
 
-    // 色の選択肢をクリック
+    // 色の選択肢をクリック（aria-labelで特定）
     const panel = canvas.getByRole('tabpanel');
-    const colorButtons = within(panel).getAllByRole('button');
-    const optionButton = colorButtons.find(
-      (btn) => !btn.textContent?.includes('回答する'),
-    );
-    if (optionButton) {
-      await userEvent.click(optionButton);
-    }
+    const optionButtons = within(panel).getAllByRole('button', {
+      name: /^色の選択肢:/,
+    });
+    await expect(optionButtons.length).toBeGreaterThan(0);
+    await userEvent.click(optionButtons[0] as HTMLElement);
 
     // 回答する
     const submitButton = canvas.getByRole('button', {

--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-quiz.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-quiz.tsx
@@ -6,6 +6,7 @@ import { ColorToHex } from './color-to-hex';
 import { HexToColor } from './hex-to-color';
 
 export const ColorQuiz = () => {
+  // 子コンポーネントがMath.random()で初期値を生成するため、SSRでのhydration mismatchを防ぐ
   const [isMounted, setIsMounted] = useState(false);
 
   useEffect(() => {

--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-quiz.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-quiz.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { Tabs } from '@k8o/arte-odyssey';
+import { useEffect, useState } from 'react';
+import { ColorToHex } from './color-to-hex';
+import { HexToColor } from './hex-to-color';
+
+export const ColorQuiz = () => {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  return (
+    <Tabs.Root
+      defaultSelectedId="color-to-hex"
+      ids={['color-to-hex', 'hex-to-color']}
+    >
+      <Tabs.List label="クイズモード">
+        <Tabs.Tab id="color-to-hex">色からHexを当てる</Tabs.Tab>
+        <Tabs.Tab id="hex-to-color">Hexから色を当てる</Tabs.Tab>
+      </Tabs.List>
+      <Tabs.Panel id="color-to-hex">{isMounted && <ColorToHex />}</Tabs.Panel>
+      <Tabs.Panel id="hex-to-color">{isMounted && <HexToColor />}</Tabs.Panel>
+    </Tabs.Root>
+  );
+};

--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { Button, Card, FormControl, TextField } from '@k8o/arte-odyssey';
+import { type ChangeEventHandler, type FC, useCallback, useState } from 'react';
+import {
+  accuracyScore,
+  generateRandomHex,
+  getContrastTextColor,
+  getScoreMessage,
+  isValidHex,
+} from '../../_utils/color-quiz';
+
+type Phase = 'question' | 'result';
+
+export const ColorToHex: FC = () => {
+  const [targetHex, setTargetHex] = useState(() => generateRandomHex());
+  const [userInput, setUserInput] = useState('');
+  const [phase, setPhase] = useState<Phase>('question');
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
+    (e) => {
+      const value = e.target.value.replace(/[^0-9a-fA-F]/g, '').slice(0, 6);
+      setUserInput(value);
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(() => {
+    if (!isValidHex(userInput)) return;
+    setPhase('result');
+  }, [userInput]);
+
+  const handleNext = useCallback(() => {
+    setTargetHex(generateRandomHex());
+    setUserInput('');
+    setPhase('question');
+  }, []);
+
+  if (phase === 'result') {
+    const score = accuracyScore(userInput, targetHex);
+    const message = getScoreMessage(score);
+
+    return (
+      <div className="flex flex-col gap-6">
+        <div className="text-center">
+          <p className="font-bold text-4xl">{score}%</p>
+          <p className="mt-1 text-fg-mute text-lg">{message}</p>
+        </div>
+        <div className="grid grid-cols-2 gap-4">
+          <div className="flex flex-col gap-2">
+            <p className="text-center text-fg-mute text-sm">あなたの回答</p>
+            <div
+              className="flex h-32 items-center justify-center rounded-xl"
+              style={{ backgroundColor: `#${userInput}` }}
+            >
+              <p
+                className="font-bold text-lg tracking-wider"
+                style={{ color: getContrastTextColor(userInput) }}
+              >
+                #{userInput}
+              </p>
+            </div>
+          </div>
+          <div className="flex flex-col gap-2">
+            <p className="text-center text-fg-mute text-sm">正解</p>
+            <div
+              className="flex h-32 items-center justify-center rounded-xl"
+              style={{ backgroundColor: `#${targetHex}` }}
+            >
+              <p
+                className="font-bold text-lg tracking-wider"
+                style={{ color: getContrastTextColor(targetHex) }}
+              >
+                #{targetHex}
+              </p>
+            </div>
+          </div>
+        </div>
+        <Button fullWidth onClick={handleNext} size="lg">
+          次の問題へ
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div
+        className="flex h-48 w-full items-center justify-center rounded-xl"
+        style={{ backgroundColor: `#${targetHex}` }}
+      >
+        <p
+          className="font-bold text-2xl tracking-wider"
+          style={{ color: getContrastTextColor(targetHex) }}
+        >
+          ?
+        </p>
+      </div>
+      <Card>
+        <div className="p-5">
+          <FormControl
+            label="この色のHexコードは？"
+            renderInput={({ labelId: _, ...props }) => (
+              <div className="flex w-full items-center gap-2">
+                <span className="text-fg-mute">#</span>
+                <TextField
+                  {...props}
+                  onChange={handleChange}
+                  placeholder="例: ff5733"
+                  value={userInput}
+                />
+              </div>
+            )}
+          />
+        </div>
+      </Card>
+      <Button
+        disabled={!isValidHex(userInput)}
+        fullWidth
+        onClick={handleSubmit}
+        size="lg"
+      >
+        回答する
+      </Button>
+    </div>
+  );
+};

--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
@@ -1,87 +1,40 @@
 'use client';
 
-import { Button, Card, FormControl, TextField } from '@k8o/arte-odyssey';
-import { type ChangeEventHandler, type FC, useCallback, useState } from 'react';
+import { Badge, Button } from '@k8o/arte-odyssey';
+import { type FC, useCallback, useMemo, useState } from 'react';
 import {
-  accuracyScore,
+  generateDistractors,
   generateRandomHex,
   getContrastTextColor,
-  getScoreMessage,
-  isValidHex,
+  shuffleArray,
 } from '../../_utils/color-quiz';
 
 type Phase = 'question' | 'result';
 
+const OPTION_COUNT = 4;
+
 export const ColorToHex: FC = () => {
   const [targetHex, setTargetHex] = useState(() => generateRandomHex());
-  const [userInput, setUserInput] = useState('');
+  const [selectedHex, setSelectedHex] = useState<string | null>(null);
   const [phase, setPhase] = useState<Phase>('question');
 
-  const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
-    (e) => {
-      const value = e.target.value.replace(/[^0-9a-fA-F]/g, '').slice(0, 6);
-      setUserInput(value);
-    },
-    [],
-  );
+  const options = useMemo(() => {
+    const distractors = generateDistractors(targetHex, OPTION_COUNT - 1);
+    return shuffleArray([targetHex, ...distractors]);
+  }, [targetHex]);
 
   const handleSubmit = useCallback(() => {
-    if (!isValidHex(userInput)) return;
+    if (selectedHex === null) return;
     setPhase('result');
-  }, [userInput]);
+  }, [selectedHex]);
 
   const handleNext = useCallback(() => {
     setTargetHex(generateRandomHex());
-    setUserInput('');
+    setSelectedHex(null);
     setPhase('question');
   }, []);
 
-  if (phase === 'result') {
-    const score = accuracyScore(userInput, targetHex);
-    const message = getScoreMessage(score);
-
-    return (
-      <div className="flex flex-col gap-6">
-        <div className="text-center">
-          <p className="font-bold text-4xl">{score}%</p>
-          <p className="mt-1 text-fg-mute text-lg">{message}</p>
-        </div>
-        <div className="grid grid-cols-2 gap-4">
-          <div className="flex flex-col gap-2">
-            <p className="text-center text-fg-mute text-sm">あなたの回答</p>
-            <div
-              className="flex h-32 items-center justify-center rounded-xl"
-              style={{ backgroundColor: `#${userInput}` }}
-            >
-              <p
-                className="font-bold text-lg tracking-wider"
-                style={{ color: getContrastTextColor(userInput) }}
-              >
-                #{userInput}
-              </p>
-            </div>
-          </div>
-          <div className="flex flex-col gap-2">
-            <p className="text-center text-fg-mute text-sm">正解</p>
-            <div
-              className="flex h-32 items-center justify-center rounded-xl"
-              style={{ backgroundColor: `#${targetHex}` }}
-            >
-              <p
-                className="font-bold text-lg tracking-wider"
-                style={{ color: getContrastTextColor(targetHex) }}
-              >
-                #{targetHex}
-              </p>
-            </div>
-          </div>
-        </div>
-        <Button fullWidth onClick={handleNext} size="lg">
-          次の問題へ
-        </Button>
-      </div>
-    );
-  }
+  const isCorrect = selectedHex === targetHex;
 
   return (
     <div className="flex flex-col gap-6">
@@ -89,39 +42,114 @@ export const ColorToHex: FC = () => {
         className="flex h-48 w-full items-center justify-center rounded-xl"
         style={{ backgroundColor: `#${targetHex}` }}
       >
-        <p
-          className="font-bold text-2xl tracking-wider"
-          style={{ color: getContrastTextColor(targetHex) }}
-        >
-          ?
-        </p>
+        {phase === 'result' && (
+          <p
+            className="font-bold text-lg tracking-wider"
+            style={{ color: getContrastTextColor(targetHex) }}
+          >
+            #{targetHex}
+          </p>
+        )}
       </div>
-      <Card>
-        <div className="p-5">
-          <FormControl
-            label="この色のHexコードは？"
-            renderInput={({ labelId: _, ...props }) => (
-              <div className="flex w-full items-center gap-2">
-                <span className="text-fg-mute">#</span>
-                <TextField
-                  {...props}
-                  onChange={handleChange}
-                  placeholder="例: ff5733"
-                  value={userInput}
-                />
+      {phase === 'result' && (
+        <div className="text-center">
+          <p className="font-bold text-lg">
+            {isCorrect ? '正解！' : '不正解...'}
+          </p>
+          {selectedHex !== null && !isCorrect && (
+            <div className="mt-4 grid grid-cols-2 gap-4">
+              <div className="flex flex-col gap-2">
+                <p className="text-center text-fg-mute text-sm">あなたの回答</p>
+                <div
+                  className="flex h-24 items-center justify-center rounded-xl"
+                  style={{ backgroundColor: `#${selectedHex}` }}
+                >
+                  <p
+                    className="font-bold text-sm tracking-wider"
+                    style={{
+                      color: getContrastTextColor(selectedHex),
+                    }}
+                  >
+                    #{selectedHex}
+                  </p>
+                </div>
               </div>
-            )}
-          />
+              <div className="flex flex-col gap-2">
+                <p className="text-center text-fg-mute text-sm">正解</p>
+                <div
+                  className="flex h-24 items-center justify-center rounded-xl"
+                  style={{ backgroundColor: `#${targetHex}` }}
+                >
+                  <p
+                    className="font-bold text-sm tracking-wider"
+                    style={{
+                      color: getContrastTextColor(targetHex),
+                    }}
+                  >
+                    #{targetHex}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
         </div>
-      </Card>
-      <Button
-        disabled={!isValidHex(userInput)}
-        fullWidth
-        onClick={handleSubmit}
-        size="lg"
-      >
-        回答する
-      </Button>
+      )}
+      <div className="grid grid-cols-2 gap-4">
+        {options.map((hex) => {
+          const isSelected = selectedHex === hex;
+          const isAnswer = hex === targetHex;
+          const showCorrectBadge = phase === 'result' && isAnswer;
+          const showWrongBadge = phase === 'result' && isSelected && !isAnswer;
+
+          return (
+            <button
+              className={[
+                'relative flex h-14 items-center justify-center rounded-xl border border-border-base font-mono text-sm tracking-wider transition-all',
+                isSelected && phase === 'question'
+                  ? 'bg-primary-bg-subtle ring-2 ring-primary-border'
+                  : 'bg-bg-base',
+                showCorrectBadge
+                  ? 'bg-bg-success ring-2 ring-border-success'
+                  : '',
+                showWrongBadge ? 'bg-bg-error ring-2 ring-border-error' : '',
+                phase === 'question' ? 'cursor-pointer hover:bg-bg-mute' : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+              disabled={phase === 'result'}
+              key={hex}
+              onClick={() => setSelectedHex(hex)}
+              type="button"
+            >
+              #{hex}
+              {showCorrectBadge && (
+                <span className="absolute top-1 right-1">
+                  <Badge size="sm" text="正解" tone="success" />
+                </span>
+              )}
+              {showWrongBadge && (
+                <span className="absolute top-1 right-1">
+                  <Badge size="sm" text="あなたの回答" tone="error" />
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      {phase === 'question' ? (
+        <Button
+          disabled={selectedHex === null}
+          fullWidth
+          onClick={handleSubmit}
+          size="lg"
+        >
+          回答する
+        </Button>
+      ) : (
+        <Button fullWidth onClick={handleNext} size="lg">
+          次の問題へ
+        </Button>
+      )}
     </div>
   );
 };

--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
@@ -1,40 +1,21 @@
 'use client';
 
 import { Badge, Button } from '@k8o/arte-odyssey';
-import { type FC, useCallback, useMemo, useState } from 'react';
-import {
-  generateDistractors,
-  generateRandomHex,
-  getContrastTextColor,
-  shuffleArray,
-} from '../../_utils/color-quiz';
-
-type Phase = 'question' | 'result';
-
-const OPTION_COUNT = 4;
+import type { FC } from 'react';
+import { getContrastTextColor } from '../../_utils/color-quiz';
+import { useColorQuiz } from './use-color-quiz';
 
 export const ColorToHex: FC = () => {
-  const [targetHex, setTargetHex] = useState(() => generateRandomHex());
-  const [selectedHex, setSelectedHex] = useState<string | null>(null);
-  const [phase, setPhase] = useState<Phase>('question');
-
-  const options = useMemo(() => {
-    const distractors = generateDistractors(targetHex, OPTION_COUNT - 1);
-    return shuffleArray([targetHex, ...distractors]);
-  }, [targetHex]);
-
-  const handleSubmit = useCallback(() => {
-    if (selectedHex === null) return;
-    setPhase('result');
-  }, [selectedHex]);
-
-  const handleNext = useCallback(() => {
-    setTargetHex(generateRandomHex());
-    setSelectedHex(null);
-    setPhase('question');
-  }, []);
-
-  const isCorrect = selectedHex === targetHex;
+  const {
+    targetHex,
+    selectedHex,
+    setSelectedHex,
+    phase,
+    options,
+    isCorrect,
+    handleSubmit,
+    handleNext,
+  } = useColorQuiz();
 
   return (
     <div className="flex flex-col gap-6">
@@ -103,6 +84,7 @@ export const ColorToHex: FC = () => {
 
           return (
             <button
+              aria-label={`Hexの選択肢: #${hex}`}
               className={[
                 'relative flex h-14 items-center justify-center rounded-xl border border-border-base font-mono text-sm tracking-wider transition-all',
                 'bg-bg-base',

--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
@@ -105,13 +105,12 @@ export const ColorToHex: FC = () => {
             <button
               className={[
                 'relative flex h-14 items-center justify-center rounded-xl border border-border-base font-mono text-sm tracking-wider transition-all',
+                'bg-bg-base',
                 isSelected && phase === 'question'
-                  ? 'bg-primary-bg-subtle ring-2 ring-primary-border'
-                  : 'bg-bg-base',
-                showCorrectBadge
-                  ? 'bg-bg-success ring-2 ring-border-success'
+                  ? 'ring-2 ring-primary-border'
                   : '',
-                showWrongBadge ? 'bg-bg-error ring-2 ring-border-error' : '',
+                showCorrectBadge ? 'ring-2 ring-border-success' : '',
+                showWrongBadge ? 'ring-2 ring-border-error' : '',
                 phase === 'question' ? 'cursor-pointer hover:bg-bg-mute' : '',
               ]
                 .filter(Boolean)

--- a/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { Badge, Button } from '@k8o/arte-odyssey';
+import { type FC, useCallback, useMemo, useState } from 'react';
+import {
+  generateDistractors,
+  generateRandomHex,
+  getContrastTextColor,
+  shuffleArray,
+} from '../../_utils/color-quiz';
+
+type Phase = 'question' | 'result';
+
+const OPTION_COUNT = 4;
+
+export const HexToColor: FC = () => {
+  const [targetHex, setTargetHex] = useState(() => generateRandomHex());
+  const [selectedHex, setSelectedHex] = useState<string | null>(null);
+  const [phase, setPhase] = useState<Phase>('question');
+
+  const options = useMemo(() => {
+    const distractors = generateDistractors(targetHex, OPTION_COUNT - 1);
+    return shuffleArray([targetHex, ...distractors]);
+  }, [targetHex]);
+
+  const handleSubmit = useCallback(() => {
+    if (selectedHex === null) return;
+    setPhase('result');
+  }, [selectedHex]);
+
+  const handleNext = useCallback(() => {
+    setTargetHex(generateRandomHex());
+    setSelectedHex(null);
+    setPhase('question');
+  }, []);
+
+  const isCorrect = selectedHex === targetHex;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="text-center">
+        <p className="font-bold font-mono text-3xl tracking-widest">
+          #{targetHex}
+        </p>
+        {phase === 'result' && (
+          <p className="mt-2 font-bold text-lg">
+            {isCorrect ? '正解！' : '不正解...'}
+          </p>
+        )}
+      </div>
+      <div className="grid grid-cols-2 gap-4">
+        {options.map((hex) => {
+          const isSelected = selectedHex === hex;
+          const isAnswer = hex === targetHex;
+          const showCorrectBadge = phase === 'result' && isAnswer;
+          const showWrongBadge = phase === 'result' && isSelected && !isAnswer;
+
+          return (
+            <button
+              className={[
+                'relative flex h-28 items-center justify-center rounded-xl transition-all',
+                isSelected && phase === 'question'
+                  ? 'ring-4 ring-primary-border'
+                  : '',
+                showCorrectBadge ? 'ring-4 ring-border-success' : '',
+                showWrongBadge ? 'ring-4 ring-border-error' : '',
+                phase === 'question' ? 'cursor-pointer hover:opacity-80' : '',
+              ]
+                .filter(Boolean)
+                .join(' ')}
+              disabled={phase === 'result'}
+              key={hex}
+              onClick={() => setSelectedHex(hex)}
+              style={{ backgroundColor: `#${hex}` }}
+              type="button"
+            >
+              {phase === 'result' && (
+                <p
+                  className="font-bold text-sm tracking-wider"
+                  style={{
+                    color: getContrastTextColor(hex),
+                  }}
+                >
+                  #{hex}
+                </p>
+              )}
+              {showCorrectBadge && (
+                <span className="absolute top-2 right-2">
+                  <Badge text="正解" tone="success" />
+                </span>
+              )}
+              {showWrongBadge && (
+                <span className="absolute top-2 right-2">
+                  <Badge text="あなたの回答" tone="error" />
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+      {phase === 'question' ? (
+        <Button
+          disabled={selectedHex === null}
+          fullWidth
+          onClick={handleSubmit}
+          size="lg"
+        >
+          回答する
+        </Button>
+      ) : (
+        <Button fullWidth onClick={handleNext} size="lg">
+          次の問題へ
+        </Button>
+      )}
+    </div>
+  );
+};

--- a/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
@@ -1,40 +1,21 @@
 'use client';
 
 import { Badge, Button } from '@k8o/arte-odyssey';
-import { type FC, useCallback, useMemo, useState } from 'react';
-import {
-  generateDistractors,
-  generateRandomHex,
-  getContrastTextColor,
-  shuffleArray,
-} from '../../_utils/color-quiz';
-
-type Phase = 'question' | 'result';
-
-const OPTION_COUNT = 4;
+import type { FC } from 'react';
+import { getContrastTextColor } from '../../_utils/color-quiz';
+import { useColorQuiz } from './use-color-quiz';
 
 export const HexToColor: FC = () => {
-  const [targetHex, setTargetHex] = useState(() => generateRandomHex());
-  const [selectedHex, setSelectedHex] = useState<string | null>(null);
-  const [phase, setPhase] = useState<Phase>('question');
-
-  const options = useMemo(() => {
-    const distractors = generateDistractors(targetHex, OPTION_COUNT - 1);
-    return shuffleArray([targetHex, ...distractors]);
-  }, [targetHex]);
-
-  const handleSubmit = useCallback(() => {
-    if (selectedHex === null) return;
-    setPhase('result');
-  }, [selectedHex]);
-
-  const handleNext = useCallback(() => {
-    setTargetHex(generateRandomHex());
-    setSelectedHex(null);
-    setPhase('question');
-  }, []);
-
-  const isCorrect = selectedHex === targetHex;
+  const {
+    targetHex,
+    selectedHex,
+    setSelectedHex,
+    phase,
+    options,
+    isCorrect,
+    handleSubmit,
+    handleNext,
+  } = useColorQuiz();
 
   return (
     <div className="flex flex-col gap-6">

--- a/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
@@ -57,6 +57,7 @@ export const HexToColor: FC = () => {
 
           return (
             <button
+              aria-label={`色の選択肢: #${hex}`}
               className={[
                 'relative flex h-28 items-center justify-center rounded-xl transition-all',
                 isSelected && phase === 'question'

--- a/apps/main/src/app/color-quiz/_components/color-quiz/index.ts
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/index.ts
@@ -1,0 +1,1 @@
+export * from './color-quiz';

--- a/apps/main/src/app/color-quiz/_components/color-quiz/use-color-quiz.ts
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/use-color-quiz.ts
@@ -1,0 +1,45 @@
+import { useCallback, useMemo, useState } from 'react';
+import {
+  generateDistractors,
+  generateRandomHex,
+  shuffleArray,
+} from '../../_utils/color-quiz';
+
+type Phase = 'question' | 'result';
+
+const OPTION_COUNT = 4;
+
+export const useColorQuiz = () => {
+  const [targetHex, setTargetHex] = useState(() => generateRandomHex());
+  const [selectedHex, setSelectedHex] = useState<string | null>(null);
+  const [phase, setPhase] = useState<Phase>('question');
+
+  const options = useMemo(() => {
+    const distractors = generateDistractors(targetHex, OPTION_COUNT - 1);
+    return shuffleArray([targetHex, ...distractors]);
+  }, [targetHex]);
+
+  const handleSubmit = useCallback(() => {
+    if (selectedHex === null) return;
+    setPhase('result');
+  }, [selectedHex]);
+
+  const handleNext = useCallback(() => {
+    setTargetHex(generateRandomHex());
+    setSelectedHex(null);
+    setPhase('question');
+  }, []);
+
+  const isCorrect = selectedHex === targetHex;
+
+  return {
+    targetHex,
+    selectedHex,
+    setSelectedHex,
+    phase,
+    options,
+    isCorrect,
+    handleSubmit,
+    handleNext,
+  };
+};

--- a/apps/main/src/app/color-quiz/_utils/color-quiz.ts
+++ b/apps/main/src/app/color-quiz/_utils/color-quiz.ts
@@ -1,0 +1,119 @@
+const MAX_DISTANCE = Math.sqrt(255 ** 2 * 3);
+
+export const generateRandomHex = (): string => {
+  const r = Math.floor(Math.random() * 256);
+  const g = Math.floor(Math.random() * 256);
+  const b = Math.floor(Math.random() * 256);
+  return [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
+};
+
+export const isValidHex = (hex: string): boolean => {
+  return /^[0-9a-fA-F]{6}$/.test(hex);
+};
+
+const hexToRgb = (hex: string): { r: number; g: number; b: number } => {
+  const r = Number.parseInt(hex.slice(0, 2), 16);
+  const g = Number.parseInt(hex.slice(2, 4), 16);
+  const b = Number.parseInt(hex.slice(4, 6), 16);
+  return { r, g, b };
+};
+
+const colorDistance = (hex1: string, hex2: string): number => {
+  const c1 = hexToRgb(hex1);
+  const c2 = hexToRgb(hex2);
+  return Math.sqrt(
+    (c1.r - c2.r) ** 2 + (c1.g - c2.g) ** 2 + (c1.b - c2.b) ** 2,
+  );
+};
+
+export const accuracyScore = (guessHex: string, targetHex: string): number => {
+  const distance = colorDistance(guessHex, targetHex);
+  return Math.round((1 - distance / MAX_DISTANCE) * 100);
+};
+
+export const getScoreMessage = (score: number): string => {
+  if (score === 100) return '完璧！';
+  if (score >= 90) return 'すばらしい！';
+  if (score >= 70) return 'いい線いってる！';
+  if (score >= 50) return 'まずまず！';
+  return 'もう少し！';
+};
+
+// 色の明るさを判定してテキストカラーを決定する
+const getOverlayColor = (hex: string): string => {
+  const { r, g, b } = hexToRgb(hex);
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? '#000000' : '#ffffff';
+};
+
+export const getContrastTextColor = (hex: string): string => {
+  return getOverlayColor(hex);
+};
+
+const MIN_DISTANCE_FROM_CORRECT = 40;
+const MIN_DISTANCE_BETWEEN_OPTIONS = 25;
+
+export const generateDistractors = (
+  correctHex: string,
+  count: number,
+): string[] => {
+  const correct = hexToRgb(correctHex);
+  const distractors: string[] = [];
+
+  let attempts = 0;
+  while (distractors.length < count && attempts < 1000) {
+    attempts++;
+    const r = Math.max(
+      0,
+      Math.min(
+        255,
+        correct.r +
+          (Math.random() > 0.5 ? 1 : -1) *
+            (40 + Math.floor(Math.random() * 80)),
+      ),
+    );
+    const g = Math.max(
+      0,
+      Math.min(
+        255,
+        correct.g +
+          (Math.random() > 0.5 ? 1 : -1) *
+            (40 + Math.floor(Math.random() * 80)),
+      ),
+    );
+    const b = Math.max(
+      0,
+      Math.min(
+        255,
+        correct.b +
+          (Math.random() > 0.5 ? 1 : -1) *
+            (40 + Math.floor(Math.random() * 80)),
+      ),
+    );
+
+    const hex = [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
+
+    const distFromCorrect = colorDistance(hex, correctHex);
+    if (distFromCorrect < MIN_DISTANCE_FROM_CORRECT) continue;
+
+    const tooClose = distractors.some(
+      (d) => colorDistance(hex, d) < MIN_DISTANCE_BETWEEN_OPTIONS,
+    );
+    if (tooClose) continue;
+
+    distractors.push(hex);
+  }
+
+  return distractors;
+};
+
+export const shuffleArray = <T>(array: T[]): T[] => {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    const temp = shuffled[i];
+    shuffled[i] = shuffled[j] as T;
+    shuffled[j] = temp as T;
+  }
+  return shuffled;
+};

--- a/apps/main/src/app/color-quiz/_utils/color-quiz.ts
+++ b/apps/main/src/app/color-quiz/_utils/color-quiz.ts
@@ -1,14 +1,8 @@
-const MAX_DISTANCE = Math.sqrt(255 ** 2 * 3);
-
 export const generateRandomHex = (): string => {
   const r = Math.floor(Math.random() * 256);
   const g = Math.floor(Math.random() * 256);
   const b = Math.floor(Math.random() * 256);
   return [r, g, b].map((v) => v.toString(16).padStart(2, '0')).join('');
-};
-
-export const isValidHex = (hex: string): boolean => {
-  return /^[0-9a-fA-F]{6}$/.test(hex);
 };
 
 const hexToRgb = (hex: string): { r: number; g: number; b: number } => {
@@ -24,19 +18,6 @@ const colorDistance = (hex1: string, hex2: string): number => {
   return Math.sqrt(
     (c1.r - c2.r) ** 2 + (c1.g - c2.g) ** 2 + (c1.b - c2.b) ** 2,
   );
-};
-
-export const accuracyScore = (guessHex: string, targetHex: string): number => {
-  const distance = colorDistance(guessHex, targetHex);
-  return Math.round((1 - distance / MAX_DISTANCE) * 100);
-};
-
-export const getScoreMessage = (score: number): string => {
-  if (score === 100) return '完璧！';
-  if (score >= 90) return 'すばらしい！';
-  if (score >= 70) return 'いい線いってる！';
-  if (score >= 50) return 'まずまず！';
-  return 'もう少し！';
 };
 
 // 色の明るさを判定してテキストカラーを決定する

--- a/apps/main/src/app/color-quiz/layout.tsx
+++ b/apps/main/src/app/color-quiz/layout.tsx
@@ -1,0 +1,29 @@
+import { Heading } from '@k8o/arte-odyssey';
+import type { Metadata } from 'next';
+
+export const metadata = {
+  title: 'カラーHexクイズ',
+  description: '色からHexコードを当てたり、Hexコードから色を選ぶクイズです。',
+  openGraph: {
+    title: 'カラーHexクイズ',
+    description: '色からHexコードを当てたり、Hexコードから色を選ぶクイズです。',
+    url: 'https://k8o.me/color-quiz',
+    siteName: 'k8o',
+    locale: 'ja',
+    type: 'website',
+  },
+  twitter: {
+    title: 'カラーHexクイズ',
+    card: 'summary',
+    description: '色からHexコードを当てたり、Hexコードから色を選ぶクイズです。',
+  },
+} satisfies Metadata;
+
+export default function Layout({ children }: LayoutProps<'/color-quiz'>) {
+  return (
+    <div className="flex h-full flex-col gap-4">
+      <Heading type="h2">カラーHexクイズ</Heading>
+      {children}
+    </div>
+  );
+}

--- a/apps/main/src/app/color-quiz/opengraph-image.tsx
+++ b/apps/main/src/app/color-quiz/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { OgImage } from '@/app/_components/og-image';
+
+export const alt = 'color quiz';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function OpenGraphImage() {
+  return await OgImage({ title: 'color quiz' });
+}

--- a/apps/main/src/app/color-quiz/page.tsx
+++ b/apps/main/src/app/color-quiz/page.tsx
@@ -1,0 +1,9 @@
+import { ColorQuiz } from './_components/color-quiz';
+
+export default function Page() {
+  return (
+    <section className="py-10">
+      <ColorQuiz />
+    </section>
+  );
+}

--- a/apps/main/src/app/color-quiz/page.tsx
+++ b/apps/main/src/app/color-quiz/page.tsx
@@ -2,7 +2,7 @@ import { ColorQuiz } from './_components/color-quiz';
 
 export default function Page() {
   return (
-    <section className="py-10">
+    <section className="rounded-xl bg-bg-raised p-5 sm:p-6">
       <ColorQuiz />
     </section>
   );

--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -174,6 +174,11 @@ export default function Home() {
             title="カラーコード職人"
           />
           <AppCard
+            description="色からHexコードを当てたり、Hexコードから色を選ぶクイズです。"
+            link="/color-quiz"
+            title="カラーHexクイズ"
+          />
+          <AppCard
             description="border-radiusを視覚的に操作してCSSを生成します。"
             link="/radius-maker"
             title="かどまるラボ"


### PR DESCRIPTION
## Summary
- 色からHexコードを当てるモードと、Hexコードから色を当てるモードの2つのクイズを `/color-quiz` に追加
- 両モードとも4択の選択肢形式で、回答後に正解/不正解のフィードバックと色の比較を表示
- ホームページのAssistセクションにカードを追加

## Test plan
- [ ] `/color-quiz` で「色からHexを当てる」モードが正しく動作する
- [ ] `/color-quiz` で「Hexから色を当てる」モードが正しく動作する
- [ ] タブ切り替えが正常に動作する
- [ ] Storybookのplay関数テストが通る