### PR TITLE
fix: RenovateワークフローのPRトリガーを改善

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -6,8 +6,8 @@ on:
     - cron: '0 0 * * 6'
   issues:
     types: [edited]
-  pull_request:
-    types: [edited]
+  pull_request_target:
+    types: [edited, closed]
   workflow_dispatch:
 
 permissions:
@@ -20,7 +20,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'issues' && contains(github.event.issue.title, 'Dependency Dashboard') && github.event.sender.login == github.repository_owner) ||
-      (github.event_name == 'pull_request' && github.event.sender.login == github.repository_owner && contains(github.event.pull_request.labels.*.name, 'renovate'))
+      (github.event_name == 'pull_request_target' && github.event.sender.login == github.repository_owner && contains(github.event.pull_request.labels.*.name, 'renovate'))
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
## Summary
- `pull_request`を`pull_request_target`に変更
- PRの`closed`イベントを追加し、PR閉じた時にもRenovateが再実行されるように

## Test plan
- [ ] Renovate PRのbodyを編集した時にワークフローが実行されることを確認
- [ ] Renovate PRを閉じた時にワークフローが実行されることを確認