### PR TITLE
refactor: knipで検出された未使用エクスポートとignore設定を整理

### DIFF
--- a/apps/main/src/app/baseline/_components/index.ts
+++ b/apps/main/src/app/baseline/_components/index.ts
@@ -1,2 +1,1 @@
 export { BaselineFeatureList } from './baseline-feature-list';
-export { BaselineHelpDialog } from './baseline-help-dialog';

--- a/knip.json
+++ b/knip.json
@@ -1,7 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "ignore": [
-    ".claude/worktrees/**",
     "apps/main/src/app/_components/coming-soon/index.ts",
     "apps/main/src/app/_components/development-only/development-only.tsx",
     "apps/main/src/app/_components/development-only/index.ts"

--- a/packages/database/src/schema/baseline-snapshots.ts
+++ b/packages/database/src/schema/baseline-snapshots.ts
@@ -7,8 +7,8 @@ import {
   uniqueIndex,
 } from 'drizzle-orm/sqlite-core';
 
-export const BASELINE_STATUSES = ['newly', 'widely'] as const;
-export type BaselineStatus = (typeof BASELINE_STATUSES)[number];
+const BASELINE_STATUSES = ['newly', 'widely'] as const;
+type BaselineStatus = (typeof BASELINE_STATUSES)[number];
 
 export const baselineSnapshots = sqliteTable(
   'baseline_snapshots',


### PR DESCRIPTION
## Summary
- `BaselineHelpDialog`の未使用re-exportを削除
- `BASELINE_STATUSES`/`BaselineStatus`のexportをファイルスコープに変更（外部から未使用）
- knip.jsonから不要な`.claude/worktrees/**` ignoreを削除

## Test plan
- [x] `pnpm knip` がクリーンであることを確認済み