### PR TITLE
refactor: useEffect除去とadmin Storybook stories追加

### DIFF
--- a/apps/admin/src/app/(authenticated)/_components/admin-header/admin-header.stories.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/admin-header/admin-header.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+import { AdminHeader } from './admin-header';
+
+const meta: Meta<typeof AdminHeader> = {
+  title: 'admin/admin-header',
+  component: AdminHeader,
+};
+
+export default meta;
+type Story = StoryObj<typeof AdminHeader>;
+
+export const Primary: Story = {};
+
+export const DisplaysNavigation: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(canvas.getByText('k8o')).toBeInTheDocument();
+    await expect(canvas.getByText('Admin')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('link', { name: 'よんでいるもの' }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('link', { name: 'レポート' }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('link', { name: 'Baseline' }),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/admin/src/app/(authenticated)/_components/toggle-theme/toggle-theme.stories.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/toggle-theme/toggle-theme.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+import { ToggleTheme } from './toggle-theme';
+
+const meta: Meta<typeof ToggleTheme> = {
+  title: 'admin/toggle-theme',
+  component: ToggleTheme,
+};
+
+export default meta;
+type Story = StoryObj<typeof ToggleTheme>;
+
+export const Primary: Story = {};
+
+export const DisplaysToggleButton: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByRole('button', { name: 'テーマを切り替える' }),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/sync-button/sync-button.stories.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/sync-button/sync-button.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+import { SyncButton } from './sync-button';
+
+const meta: Meta<typeof SyncButton> = {
+  title: 'admin/reading-list/sync-button',
+  component: SyncButton,
+};
+
+export default meta;
+type Story = StoryObj<typeof SyncButton>;
+
+export const Primary: Story = {};
+
+export const DisplaysSyncButton: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await expect(
+      canvas.getByRole('button', { name: '記事を同期' }),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/main/src/app/_components/contact-to-me/contact-to-me.tsx
+++ b/apps/main/src/app/_components/contact-to-me/contact-to-me.tsx
@@ -11,13 +11,7 @@ import {
   Textarea,
   useToast,
 } from '@k8o/arte-odyssey';
-import {
-  type FC,
-  useActionState,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react';
+import { type FC, useActionState, useCallback, useState } from 'react';
 import { contact } from '@/app/_api/contact-to-me';
 
 export const ContactToMe: FC = () => {
@@ -45,19 +39,25 @@ const ContactToMeModal: FC<{
   isOpen: boolean;
   onClose: () => void;
 }> = ({ isOpen, onClose }) => {
-  const [state, formAction, pending] = useActionState(contact, {
-    success: null,
-    defaultValue: '',
-  });
   const { onOpen: onToastOpen } = useToast();
 
-  // TODO: useEffectを用いない方法で実装する
-  useEffect(() => {
-    if (state.success) {
-      onToastOpen('success', 'お問い合わせの送信に成功しました');
-      onClose();
-    }
-  }, [onClose, onToastOpen, state.success]);
+  const [state, formAction, pending] = useActionState(
+    async (
+      prevState: Awaited<ReturnType<typeof contact>>,
+      formData: FormData,
+    ) => {
+      const result = await contact(prevState, formData);
+      if (result.success) {
+        onToastOpen('success', 'お問い合わせの送信に成功しました');
+        onClose();
+      }
+      return result;
+    },
+    {
+      success: null,
+      defaultValue: '',
+    },
+  );
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>

--- a/apps/main/src/app/_components/contact-to-me/contact-to-me.tsx
+++ b/apps/main/src/app/_components/contact-to-me/contact-to-me.tsx
@@ -41,7 +41,7 @@ const ContactToMeModal: FC<{
 }> = ({ isOpen, onClose }) => {
   const { onOpen: onToastOpen } = useToast();
 
-  const [state, formAction, pending] = useActionState(
+  const handleAction = useCallback(
     async (
       prevState: Awaited<ReturnType<typeof contact>>,
       formData: FormData,
@@ -53,11 +53,13 @@ const ContactToMeModal: FC<{
       }
       return result;
     },
-    {
-      success: null,
-      defaultValue: '',
-    },
+    [onToastOpen, onClose],
   );
+
+  const [state, formAction, pending] = useActionState(handleAction, {
+    success: null,
+    defaultValue: '',
+  });
 
   return (
     <Modal isOpen={isOpen} onClose={onClose}>


### PR DESCRIPTION
## Summary
- contact-to-meコンポーネントのuseEffectをReact 19のアクションラッパーパターンに置き換え、TODOを解消
- adminアプリのtoggle-theme、sync-button、admin-headerにStorybook storiesを追加

## Test plan
- [ ] contact-to-meのお問い合わせフォームが正常に送信でき、toast表示・モーダルクローズが動作すること
- [ ] adminアプリのStorybookで新規追加した3つのstoriesが表示・テストパスすること