### PR TITLE
refactor: Tailwindのarbitrary valueを標準ユーティリティに置き換え

### DIFF
--- a/apps/main/src/app/_components/playgrounds/popover/popover-api-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/popover/popover-api-demo.tsx
@@ -16,7 +16,7 @@ export const PopoverApiDemo: FC = () => {
         </Button>
       </div>
       <p
-        className="m-auto max-w-1/3 rounded-md p-4 opacity-0 transition-opacity duration-500 backdrop:bg-[#00000080] open:opacity-100 starting:open:opacity-0"
+        className="m-auto max-w-1/3 rounded-md p-4 opacity-0 transition-opacity duration-500 backdrop:bg-back-drop open:opacity-100 starting:open:opacity-0"
         id="popover1"
         popover="auto"
       >

--- a/apps/main/src/app/radius-maker/_components/control-panel/control-panel.tsx
+++ b/apps/main/src/app/radius-maker/_components/control-panel/control-panel.tsx
@@ -130,8 +130,8 @@ export const ControlPanel: FC = () => {
           <div
             className="flex items-center justify-center"
             style={{
-              width: fluidPx(BASE_SIZE + 24),
-              height: fluidPx(BASE_SIZE + 24),
+              width: `calc(${fluidPx(BASE_SIZE)} + 24px)`,
+              height: `calc(${fluidPx(BASE_SIZE)} + 24px)`,
             }}
           >
             <div

--- a/apps/main/src/app/radius-maker/_components/control-panel/control-panel.tsx
+++ b/apps/main/src/app/radius-maker/_components/control-panel/control-panel.tsx
@@ -16,7 +16,12 @@ import { useControlPanel } from './use-control-panel';
 
 // ベースサイズ（px）
 const BASE_SIZE = 192;
-const BASE_SIZE_SM = 384;
+
+// ビューポート幅640px〜1280pxでモバイル値→2倍に連続スケーリング
+const fluidPx = (mobile: number): string => {
+  const desktop = mobile * 2;
+  return `clamp(${mobile}px, ${((mobile * 100) / 640).toFixed(2)}vw, ${desktop}px)`;
+};
 
 const OperateButton: FC<{
   label: string;
@@ -81,16 +86,10 @@ export const ControlPanel: FC = () => {
 
   // アスペクト比に応じたサイズを計算
   const containerSize = useMemo(() => {
-    const calcSize = (base: number) => {
-      if (aspectRatio >= 1) {
-        return { width: base, height: base / aspectRatio };
-      }
-      return { width: base * aspectRatio, height: base };
-    };
-    return {
-      mobile: calcSize(BASE_SIZE),
-      desktop: calcSize(BASE_SIZE_SM),
-    };
+    if (aspectRatio >= 1) {
+      return { width: BASE_SIZE, height: BASE_SIZE / aspectRatio };
+    }
+    return { width: BASE_SIZE * aspectRatio, height: BASE_SIZE };
   }, [aspectRatio]);
 
   const handleCopy = async () => {
@@ -130,37 +129,19 @@ export const ControlPanel: FC = () => {
         <div className="order-2 flex items-center justify-center sm:sticky sm:top-6 sm:order-1">
           <div
             className="flex items-center justify-center"
-            data-radius-area
             style={{
-              width: BASE_SIZE + 24,
-              height: BASE_SIZE + 24,
+              width: fluidPx(BASE_SIZE + 24),
+              height: fluidPx(BASE_SIZE + 24),
             }}
           >
-            <style>{`
-              @media (min-width: 640px) {
-                [data-radius-area] {
-                  width: ${(BASE_SIZE_SM + 24).toString()}px !important;
-                  height: ${(BASE_SIZE_SM + 24).toString()}px !important;
-                }
-              }
-            `}</style>
             <div
               className="relative border-2 border-primary-border border-dashed"
-              data-radius-wrapper
               ref={containerRef}
               style={{
-                width: containerSize.mobile.width,
-                height: containerSize.mobile.height,
+                width: fluidPx(containerSize.width),
+                height: fluidPx(containerSize.height),
               }}
             >
-              <style>{`
-                @media (min-width: 640px) {
-                  [data-radius-wrapper] {
-                    width: ${containerSize.desktop.width}px !important;
-                    height: ${containerSize.desktop.height}px !important;
-                  }
-                }
-              `}</style>
               <div
                 className="absolute size-full bg-primary-fg"
                 style={{

--- a/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns-by-table.tsx
+++ b/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns-by-table.tsx
@@ -30,7 +30,7 @@ export const CreateColumnsByTable: FC<Props> = ({
 
   return (
     <div className="-mx-6 overflow-x-auto sm:mx-0">
-      <div className="min-w-[800px] px-6 sm:min-w-0 sm:px-0">
+      <div className="min-w-200 px-6 sm:min-w-0 sm:px-0">
         <table className="w-full">
           <thead>
             <tr className="border-border-base border-b bg-bg-mute">


### PR DESCRIPTION
## Summary
- `min-w-[800px]` → `min-w-200`（sql-table-builder）
- `backdrop:bg-[#00000080]` → `backdrop:bg-back-drop`（popover-api-demo）
- radius-makerのメディアクエリ+`!important`を`clamp()`による連続スケーリングに置き換え

## Test plan
- [ ] sql-table-builderのテーブルが横スクロール時に正しい最小幅を保つこと
- [ ] popover-api-demoのbackdropが正しく半透明黒で表示されること
- [ ] radius-makerのシェイプエディタがビューポート幅に応じて滑らかにリサイズされること