### PR TITLE
fix: productionビルドのIgnoreCommandがaffected判定で常にスキップされる問題を修正

### DIFF
--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -15,6 +15,13 @@ if [[ "$VERCEL_GIT_COMMIT_REF" == renovate/* ]]; then
   exit 0
 fi
 
+# mainブランチのproductionビルドではmerge-baseがHEAD自身となりaffectedが空になるため、
+# 前回成功したデプロイのSHAをbaseに設定する
+if [ -n "$VERCEL_GIT_PREVIOUS_SHA" ]; then
+  export TURBO_SCM_BASE="$VERCEL_GIT_PREVIOUS_SHA"
+  echo ">> Using TURBO_SCM_BASE=$VERCEL_GIT_PREVIOUS_SHA"
+fi
+
 # turbo query affectedで対象アプリに影響があるか判定
 AFFECTED=$(pnpm turbo query "query { affectedPackages { items { name } } }")
 echo "$AFFECTED"


### PR DESCRIPTION
## Summary
- mainブランチのproductionビルド時に `turbo query affectedPackages` のbase refが `merge-base(HEAD, main) = HEAD` となり、affectedが常に空になっていた
- 結果、最近のproductionデプロイがVercelで `Ignored` 扱いになっていた
- `VERCEL_GIT_PREVIOUS_SHA`（前回成功デプロイのSHA）を `TURBO_SCM_BASE` に設定して正しく差分判定するよう修正

## Test plan
- [ ] このPR自体のmainマージ後、Vercel productionビルドが実行されること（`scripts/ignore-build.sh` が変更されているのでaffected判定にかかわらず両アプリビルドされる想定）
- [ ] 以降のmainマージで、変更がmainアプリのみの場合はadminをスキップ、その逆も成立すること