### PR TITLE
fix: ビルド判定ロジック自体の変更時はaffectedを問わずビルドを実行する

### DIFF
--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -24,7 +24,10 @@ fi
 
 # ビルド判定ロジック自体やVercel設定が変わったときは安全側に倒してビルド実行
 BASE_SHA="${TURBO_SCM_BASE:-origin/main}"
-CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD 2>/dev/null || echo "")
+if ! CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD 2>&1); then
+  echo ">> Proceeding: failed to get changed files ($CHANGED_FILES)"
+  exit 1
+fi
 if echo "$CHANGED_FILES" | grep -qE "^(scripts/ignore-build\.sh|apps/$APP_NAME/vercel\.json|turbo\.json)$"; then
   echo ">> Proceeding: build configuration changed"
   exit 1

--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -22,6 +22,14 @@ if [ -n "$VERCEL_GIT_PREVIOUS_SHA" ]; then
   echo ">> Using TURBO_SCM_BASE=$VERCEL_GIT_PREVIOUS_SHA"
 fi
 
+# ビルド判定ロジック自体やVercel設定が変わったときは安全側に倒してビルド実行
+BASE_SHA="${TURBO_SCM_BASE:-origin/main}"
+CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD 2>/dev/null || echo "")
+if echo "$CHANGED_FILES" | grep -qE "^(scripts/ignore-build\.sh|apps/$APP_NAME/vercel\.json|turbo\.json)$"; then
+  echo ">> Proceeding: build configuration changed"
+  exit 1
+fi
+
 # turbo query affectedで対象アプリに影響があるか判定
 AFFECTED=$(pnpm turbo query "query { affectedPackages { items { name } } }")
 echo "$AFFECTED"


### PR DESCRIPTION
## Summary
- `scripts/ignore-build.sh` や `apps/<app>/vercel.json`、`turbo.json` はどのパッケージのinputにも含まれないため、これらだけを変更しても `turbo affectedPackages` が空となりVercelデプロイに反映されない問題を回避
- これらのファイルが変更されたコミットでは、affected判定をスキップして必ずビルドを実行する

## Background
PR #1676 で `VERCEL_GIT_PREVIOUS_SHA` を使う修正をしたが、その変更自体がpreview/productionで反映されない鶏卵問題が発生していた。

## Test plan
- [ ] このPRのpreviewビルドが（scripts/ignore-build.shの変更に反応して）実行されること
- [ ] mainマージ後のproductionビルドも実行されること