### PR TITLE
feat: Baseline一覧に直近1週間の更新フィルタを追加

### DIFF
--- a/apps/main/src/app/baseline/_components/baseline-feature-list.stories.tsx
+++ b/apps/main/src/app/baseline/_components/baseline-feature-list.stories.tsx
@@ -4,48 +4,60 @@ import type { BaselineFeature } from '@/services/baseline/baseline';
 import type { BlogLink } from '@/services/baseline/feature-blog-map';
 import { BaselineFeatureList } from './baseline-feature-list';
 
+const now = Date.now();
+const toIso = (offsetMs: number): string =>
+  new Date(now - offsetMs).toISOString();
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 const FEATURES: BaselineFeature[] = [
   {
     featureId: 'popover',
     name: 'Popover API',
     status: 'widely',
     date: '2026-01-27',
+    updatedAt: toIso(2 * DAY_MS),
   },
   {
     featureId: 'view-transitions',
     name: 'View transitions',
     status: 'widely',
     date: '2026-01-14',
+    updatedAt: toIso(30 * DAY_MS),
   },
   {
     featureId: 'font-family-math',
     name: 'Math font family',
     status: 'newly',
     date: '2026-03-24',
+    updatedAt: toIso(3 * DAY_MS),
   },
   {
     featureId: 'iterator-concat',
     name: 'Iterator.concat()',
     status: 'newly',
     date: '2026-03-24',
+    updatedAt: toIso(30 * DAY_MS),
   },
   {
     featureId: 'scope',
     name: '@scope',
     status: 'widely',
     date: '2025-09-27',
+    updatedAt: toIso(60 * DAY_MS),
   },
   {
     featureId: 'promise-try',
     name: 'Promise.try()',
     status: 'newly',
     date: '2025-07-02',
+    updatedAt: toIso(90 * DAY_MS),
   },
   {
     featureId: 'highlight',
     name: 'Custom highlight',
     status: 'newly',
     date: '2025-03-12',
+    updatedAt: toIso(180 * DAY_MS),
   },
 ];
 
@@ -144,5 +156,19 @@ export const EmptyResult: Story = {
     await expect(
       canvas.getByText('該当する機能が見つかりません'),
     ).toBeInTheDocument();
+  },
+};
+
+export const FilterByRecentOnly: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const recentCheckbox = canvas.getByRole('checkbox', {
+      name: '直近1週間の更新のみ',
+    });
+    await userEvent.click(recentCheckbox);
+    await expect(canvas.getByText('Popover API')).toBeInTheDocument();
+    await expect(canvas.getByText('Math font family')).toBeInTheDocument();
+    await expect(canvas.queryByText('View transitions')).toBeNull();
+    await expect(canvas.queryByText('Iterator.concat()')).toBeNull();
   },
 };

--- a/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
+++ b/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
@@ -128,12 +128,10 @@ export const BaselineFeatureList: FC<{
   const [recentThresholdMs, setRecentThresholdMs] = useState(0);
 
   const toggleRecentOnly = () => {
-    setRecentOnly((prev) => {
-      if (!prev) {
-        setRecentThresholdMs(Date.now() - SEVEN_DAYS_MS);
-      }
-      return !prev;
-    });
+    if (!recentOnly) {
+      setRecentThresholdMs(Date.now() - SEVEN_DAYS_MS);
+    }
+    setRecentOnly((prev) => !prev);
   };
 
   const availableYears = useMemo(() => getAvailableYears(features), [features]);

--- a/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
+++ b/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
@@ -19,6 +19,8 @@ type StatusVisibility = {
   widely: boolean;
 };
 
+const SEVEN_DAYS_MS = 7 * 24 * 60 * 60 * 1000;
+
 const getAvailableYears = (features: BaselineFeature[]): string[] => {
   const years = new Set<string>();
   for (const feature of features) {
@@ -32,7 +34,16 @@ const FeatureList: FC<{
   blogMap: Record<string, BlogLink>;
   visibility: StatusVisibility;
   query: string;
-}> = ({ features, blogMap, visibility, query }) => {
+  recentOnly: boolean;
+  recentThresholdMs: number;
+}> = ({
+  features,
+  blogMap,
+  visibility,
+  query,
+  recentOnly,
+  recentThresholdMs,
+}) => {
   const filtered = useMemo(() => {
     let result = features;
     result = result.filter(
@@ -40,6 +51,11 @@ const FeatureList: FC<{
         (f.status === 'newly' && visibility.newly) ||
         (f.status === 'widely' && visibility.widely),
     );
+    if (recentOnly) {
+      result = result.filter(
+        (f) => new Date(f.updatedAt).getTime() >= recentThresholdMs,
+      );
+    }
     if (query) {
       const lowerQuery = query.toLowerCase();
       result = result.filter(
@@ -49,7 +65,7 @@ const FeatureList: FC<{
       );
     }
     return result;
-  }, [features, visibility, query]);
+  }, [features, visibility, query, recentOnly, recentThresholdMs]);
 
   return (
     <div className="flex flex-col gap-4">
@@ -108,6 +124,17 @@ export const BaselineFeatureList: FC<{
     widely: true,
   });
   const [query, setQuery] = useState('');
+  const [recentOnly, setRecentOnly] = useState(false);
+  const [recentThresholdMs, setRecentThresholdMs] = useState(0);
+
+  const toggleRecentOnly = () => {
+    setRecentOnly((prev) => {
+      if (!prev) {
+        setRecentThresholdMs(Date.now() - SEVEN_DAYS_MS);
+      }
+      return !prev;
+    });
+  };
 
   const availableYears = useMemo(() => getAvailableYears(features), [features]);
 
@@ -132,17 +159,20 @@ export const BaselineFeatureList: FC<{
       const matchesVisibility =
         (feature.status === 'newly' && visibility.newly) ||
         (feature.status === 'widely' && visibility.widely);
+      const matchesRecent =
+        !recentOnly ||
+        new Date(feature.updatedAt).getTime() >= recentThresholdMs;
       const matchesQuery =
         !query ||
         feature.name.toLowerCase().includes(lowerQuery) ||
         feature.featureId.toLowerCase().includes(lowerQuery);
-      if (matchesVisibility && matchesQuery) {
+      if (matchesVisibility && matchesRecent && matchesQuery) {
         const year = feature.date.slice(0, 4);
         counts.set(year, (counts.get(year) ?? 0) + 1);
       }
     }
     return counts;
-  }, [features, visibility, query]);
+  }, [features, visibility, query, recentOnly, recentThresholdMs]);
 
   const defaultYear = availableYears.includes(currentYear)
     ? currentYear
@@ -166,26 +196,33 @@ export const BaselineFeatureList: FC<{
             )}
           />
         </div>
-        <div className="flex gap-4 text-sm">
+        <div className="flex flex-wrap items-center gap-x-8 gap-y-4 text-sm">
+          <div className="flex gap-4">
+            <Checkbox
+              label="Newly Available"
+              onChange={() =>
+                setVisibility((prev) => ({
+                  ...prev,
+                  newly: !prev.newly,
+                }))
+              }
+              value={visibility.newly}
+            />
+            <Checkbox
+              label="Widely Available"
+              onChange={() =>
+                setVisibility((prev) => ({
+                  ...prev,
+                  widely: !prev.widely,
+                }))
+              }
+              value={visibility.widely}
+            />
+          </div>
           <Checkbox
-            label="Newly Available"
-            onChange={() =>
-              setVisibility((prev) => ({
-                ...prev,
-                newly: !prev.newly,
-              }))
-            }
-            value={visibility.newly}
-          />
-          <Checkbox
-            label="Widely Available"
-            onChange={() =>
-              setVisibility((prev) => ({
-                ...prev,
-                widely: !prev.widely,
-              }))
-            }
-            value={visibility.widely}
+            label="直近1週間の更新のみ"
+            onChange={toggleRecentOnly}
+            value={recentOnly}
           />
         </div>
       </div>
@@ -214,6 +251,8 @@ export const BaselineFeatureList: FC<{
                   blogMap={blogMap}
                   features={data?.features ?? []}
                   query={query}
+                  recentOnly={recentOnly}
+                  recentThresholdMs={recentThresholdMs}
                   visibility={visibility}
                 />
               </Tabs.Panel>

--- a/apps/main/src/services/baseline/baseline.ts
+++ b/apps/main/src/services/baseline/baseline.ts
@@ -5,6 +5,7 @@ export type BaselineFeature = {
   name: string;
   status: 'newly' | 'widely';
   date: string;
+  updatedAt: string;
 };
 
 export async function getBaselineFeatures(): Promise<BaselineFeature[]> {
@@ -16,6 +17,7 @@ export async function getBaselineFeatures(): Promise<BaselineFeature[]> {
       name: s.name,
       status: s.status,
       date: s.date,
+      updatedAt: s.updatedAt,
     }))
     .toSorted((a, b) => b.date.localeCompare(a.date));
 }


### PR DESCRIPTION
## 概要

`/baseline` ページに「直近1週間の更新のみ」フィルタを追加し、通知で追加された差分を把握しやすくした。

## 動機

Baseline更新の通知を受けても、一覧画面からは何が新しく追加・更新されたのかが視覚的にわからず使いにくかった。`baseline_snapshots.updated_at` を利用して直近の更新のみに絞り込めるようにする。

## 詳細

- `BaselineFeature` 型と `getBaselineFeatures` に `updatedAt` を追加
- `baseline-feature-list.tsx` に「直近1週間の更新のみ」チェックボックスを追加
  - 閾値 (`Date.now() - 7日`) はチェックボックスON時に計算してstateに保持
  - 年タブのカウント表示もフィルタ結果に連動
- k8o-design方針に合わせて、ステータス系フィルタ（Newly/Widely）と時間系フィルタを `gap-x-8` のゆとりで視覚的に分離。行数は増やさずfirst viewを犠牲にしない
- Storybookの `FEATURES` に `updatedAt` を相対時刻で付与し、`FilterByRecentOnly` ストーリーで挙動をテスト

## 気をつけるポイント

- `Date.now()` はprerender中に評価するとNext.js 16で警告が出るため、useState初期化関数ではなくチェックボックスの onChange ハンドラで評価している
- `updatedAt` は DBスキーマの `$onUpdate` により snapshot の status/date等が変わったときに自動更新される

## 影響範囲

- `/baseline` ページ
- `@/services/baseline/baseline` (型とreturn値の拡張)

## テスト

- [x] `pnpm -F main exec vitest run --project=storybook src/app/baseline` (7件pass)
- [x] `pnpm -F main type-check`
- [x] `pnpm run check` (Biome)