### PR TITLE
fix: Vercel ignore-buildのturbo affected判定が機能しない問題を修正

### DIFF
--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -1,46 +1,57 @@
 #!/bin/bash
 # Vercel Ignored Build Step
+# 使い方: bash scripts/ignore-build.sh <app-name>
 # exit 0 = ビルドスキップ, exit 1 = ビルド実行
 
-APP_NAME=$1
+set -euo pipefail
+
+readonly APP_NAME="${1:-}"
+
+log() {
+  echo ">> $*"
+}
 
 if [ -z "$APP_NAME" ]; then
-  echo "Usage: bash scripts/ignore-build.sh <app-name>"
+  echo "Usage: bash scripts/ignore-build.sh <app-name>" >&2
   exit 1
 fi
 
 # renovateブランチはpreviewビルドをスキップ
-if [[ "$VERCEL_GIT_COMMIT_REF" == renovate/* ]]; then
-  echo ">> Skipping: Renovate branch ($VERCEL_GIT_COMMIT_REF)"
+if [[ "${VERCEL_GIT_COMMIT_REF:-}" == renovate/* ]]; then
+  log "Skipping: Renovate branch (${VERCEL_GIT_COMMIT_REF})"
   exit 0
 fi
 
-# mainブランチのproductionビルドではmerge-baseがHEAD自身となりaffectedが空になるため、
-# 前回成功したデプロイのSHAをbaseに設定する
-if [ -n "$VERCEL_GIT_PREVIOUS_SHA" ]; then
-  export TURBO_SCM_BASE="$VERCEL_GIT_PREVIOUS_SHA"
-  echo ">> Using TURBO_SCM_BASE=$VERCEL_GIT_PREVIOUS_SHA"
-fi
+# mainブランチのproductionビルドでは merge-base が HEAD 自身となり affected が空になるため、
+# 前回成功したデプロイのSHAを base に使う。preview ビルドでは origin/main との差分を見る
+readonly BASE_SHA="${VERCEL_GIT_PREVIOUS_SHA:-origin/main}"
+log "Using BASE_SHA=$BASE_SHA"
 
-# ビルド判定ロジック自体やVercel設定が変わったときは安全側に倒してビルド実行
-BASE_SHA="${TURBO_SCM_BASE:-origin/main}"
+# 変更ファイルが取得できなければ安全側に倒してビルド
 if ! CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD 2>&1); then
-  echo ">> Proceeding: failed to get changed files ($CHANGED_FILES)"
-  exit 1
-fi
-if echo "$CHANGED_FILES" | grep -qE "^(scripts/ignore-build\.sh|apps/$APP_NAME/vercel\.json|turbo\.json)$"; then
-  echo ">> Proceeding: build configuration changed"
+  log "Proceeding: failed to get changed files ($CHANGED_FILES)"
   exit 1
 fi
 
-# turbo query affectedで対象アプリに影響があるか判定
-AFFECTED=$(pnpm turbo query "query { affectedPackages { items { name } } }")
+# ビルド判定ロジック自体や Vercel 設定が変わったら安全側に倒してビルド
+if echo "$CHANGED_FILES" | grep -qE "^(scripts/ignore-build\.sh|apps/$APP_NAME/vercel\.json|turbo\.json)$"; then
+  log "Proceeding: build configuration changed"
+  exit 1
+fi
+
+# turbo affected で対象アプリに影響があるか判定
+# NOTE: 旧来の `turbo query "query { affectedPackages { ... } }"` は TURBO_SCM_BASE 等の
+# 環境変数を尊重せず常に空を返すため、`turbo query affected --base` を使う
+if ! AFFECTED=$(pnpm turbo query affected --packages --base "$BASE_SHA"); then
+  log "Proceeding: turbo query failed"
+  exit 1
+fi
 echo "$AFFECTED"
 
 if echo "$AFFECTED" | grep -q "\"name\": \"$APP_NAME\""; then
-  echo ">> Proceeding: $APP_NAME is affected"
+  log "Proceeding: $APP_NAME is affected"
   exit 1
 fi
 
-echo ">> Skipping: $APP_NAME is not affected"
+log "Skipping: $APP_NAME is not affected"
 exit 0

--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 readonly APP_NAME="${1:-}"
 
 log() {
-  echo ">> $*"
+  echo ">> $*" >&2
 }
 
 if [ -z "$APP_NAME" ]; then


### PR DESCRIPTION
## 概要

`scripts/ignore-build.sh` の `turbo query` 呼び出しが TURBO_SCM_BASE を尊重せず、production マージコミットで常に「影響なし」と判定されて Vercel の deploy がスキップされていた問題を修正した。あわせてスクリプト全体をリファクタした。

## 動機

PR #1683 のマージ後、main への production deploy が \"Canceled by Ignored Build Step\" となり反映されなかった。調査したところ、旧実装の以下のクエリは環境変数を読まず、変更があっても `items: []` を返す：

```
pnpm turbo query "query { affectedPackages { items { name } } }"
```

ローカル検証：
- `TURBO_SCM_BASE=<prev> turbo query "..."` → 空
- `turbo query affected --packages --base <prev>` → 正しく main を返す

新しいサブコマンド形式 `turbo query affected` は `--base` フラグで明示的にベースSHAを渡せるため、こちらに置き換える。

## 詳細

- `turbo query affected --packages --base "$BASE_SHA"` に差し替え
- `TURBO_SCM_BASE` の export を廃止（使っていた唯一の箇所が `turbo query` だったため）
- `set -euo pipefail` を追加し、意図しないエラーを検知しやすく
- `log()` 関数で `>>` プレフィックス出力を統一
- `turbo query` 自体が失敗したら安全側に倒してビルド実行
- `BASE_SHA` は `VERCEL_GIT_PREVIOUS_SHA` を直接使い、未設定時は `origin/main` にフォールバック

## 気をつけるポイント

- このスクリプト自体の変更は、既存の安全網 (`scripts/ignore-build\.sh` が diff に含まれる場合は無条件ビルド) により、マージ後の production も確実にビルドされる
- `pnpm turbo query` の stderr （pnpm/turbo の進捗ログ）は従来通り Vercel のログに流れる

## 影響範囲

- apps/main, apps/admin の両方の Vercel deploy 判定

## テスト

- [x] ローカルで `VERCEL_GIT_PREVIOUS_SHA=<prev> bash scripts/ignore-build.sh main` が `main is affected` で exit 1
- [x] `VERCEL_GIT_PREVIOUS_SHA=<head> bash scripts/ignore-build.sh main` が `not affected` で exit 0
- [x] `VERCEL_GIT_COMMIT_REF=renovate/foo` で Renovate ブランチスキップ
- [x] `bash -n` 構文チェック
- [x] Codex による外部レビューで correctness issue なしを確認