### PR TITLE
feat: Baseline一覧にfeature_idを表示

### DIFF
--- a/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
+++ b/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
@@ -87,9 +87,14 @@ const FeatureList: FC<{
                   text={feature.status === 'newly' ? 'Newly' : 'Widely'}
                   tone={feature.status === 'newly' ? 'info' : 'success'}
                 />
-                <span className="min-w-0 flex-1 text-sm leading-relaxed">
-                  {feature.name}
-                </span>
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="text-sm leading-relaxed">
+                    {feature.name}
+                  </span>
+                  <span className="font-mono text-fg-mute text-xs">
+                    {feature.featureId}
+                  </span>
+                </div>
                 {blog && (
                   <Link
                     className="shrink-0 text-primary-fg text-xs transition-colors duration-150 ease-out hover:underline"


### PR DESCRIPTION
## 概要

`/baseline` の各アイテムに `feature_id` を機能名の下に表示する。

## 動機

ブログ記事のMDX metadataに書く `featureIds` の値を参照するため、画面上で該当featureのIDを確認できるようにしたい。

## 詳細

- 機能名の下に `featureId` を `font-mono text-fg-mute text-xs` で表示
- 検索フィルタは既に `featureId` もマッチ対象だったのでロジック変更なし

## 影響範囲

- `/baseline` ページの一覧表示

## テスト

- [x] `pnpm -F main exec vitest run --project=storybook src/app/baseline` (7件pass)
- [x] `pnpm run check` (Biome)