### PR TITLE
fix: Vercel ignore-buildで同一commitの再ビルドを実行するよう修正

### DIFF
--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -22,6 +22,14 @@ if [[ "${VERCEL_GIT_COMMIT_REF:-}" == renovate/* ]]; then
   exit 0
 fi
 
+# 同一commitの再ビルド（Vercelダッシュボードからの手動Redeployやenv var変更後の再ビルド）は常に実行する
+if [ -n "${VERCEL_GIT_COMMIT_SHA:-}" ] \
+  && [ -n "${VERCEL_GIT_PREVIOUS_SHA:-}" ] \
+  && [ "${VERCEL_GIT_COMMIT_SHA}" = "${VERCEL_GIT_PREVIOUS_SHA}" ]; then
+  log "Proceeding: redeploy of same commit (${VERCEL_GIT_COMMIT_SHA})"
+  exit 1
+fi
+
 # mainブランチのproductionビルドでは merge-base が HEAD 自身となり affected が空になるため、
 # 前回成功したデプロイのSHAを base に使う。preview ビルドでは origin/main との差分を見る
 readonly BASE_SHA="${VERCEL_GIT_PREVIOUS_SHA:-origin/main}"


### PR DESCRIPTION
## 概要

Vercelダッシュボードからの手動Redeployや、env var変更後の再ビルドが、`ignore-build.sh` によってスキップされてしまう問題を修正。

## 動機

env var のみを更新した後に Vercel ダッシュボードから Redeploy を実行しても、`turbo query affected` が空になり、ビルドがスキップされてしまっていた（`Skipping: main is not affected`）。このため env var 更新の反映が難しかった。

## 詳細

- `VERCEL_GIT_COMMIT_SHA` と `VERCEL_GIT_PREVIOUS_SHA` が一致するケース（= 同一 commit に対する再ビルド）を早期に検知し、常にビルドを実行するように分岐を追加
- 通常の git push（新しい commit がある）では両者が一致しないため、既存の turbo affected 判定はそのまま動作する

## 影響範囲

- `apps/main` / `apps/admin` の Vercel デプロイにおける Ignored Build Step の挙動
- 既存の自動ビルドには影響なし（新しい commit があるケースでは `COMMIT_SHA != PREVIOUS_SHA` のため本分岐に入らない）