### PR TITLE
refactor: コンテンツ最大幅を per-layout 制御に変更

### DIFF
--- a/apps/main/src/app/_components/content-container/content-container.tsx
+++ b/apps/main/src/app/_components/content-container/content-container.tsx
@@ -1,0 +1,23 @@
+import { cn } from '@repo/helpers/cn';
+import type { FC, ReactNode } from 'react';
+
+type Width = 'narrow' | 'default' | 'wide' | 'full';
+
+const widthClasses: Record<Width, string> = {
+  narrow: 'max-w-3xl',
+  default: 'max-w-5xl',
+  wide: 'max-w-7xl',
+  full: 'max-w-none',
+};
+
+export const ContentContainer: FC<{
+  children: ReactNode;
+  width?: Width;
+  className?: string;
+}> = ({ children, width = 'default', className }) => {
+  return (
+    <div className={cn('mx-auto w-full', widthClasses[width], className)}>
+      {children}
+    </div>
+  );
+};

--- a/apps/main/src/app/_components/content-container/index.ts
+++ b/apps/main/src/app/_components/content-container/index.ts
@@ -1,0 +1,1 @@
+export * from './content-container';

--- a/apps/main/src/app/_components/global-layout/footer/footer.tsx
+++ b/apps/main/src/app/_components/global-layout/footer/footer.tsx
@@ -5,11 +5,9 @@ import { formatDate } from '@repo/helpers/date/format';
 export function Footer() {
   return (
     <footer className="flex items-center justify-center p-4">
-      <div className="max-w-5xl">
-        <p className="text-fg-mute md:text-lg">
-          ©︎ 2024〜{formatDate(new Date(), 'yyyy')} k8o. All Rights Reserved.
-        </p>
-      </div>
+      <p className="text-fg-mute md:text-lg">
+        ©︎ 2024〜{formatDate(new Date(), 'yyyy')} k8o. All Rights Reserved.
+      </p>
     </footer>
   );
 }

--- a/apps/main/src/app/_components/global-layout/global-layout.tsx
+++ b/apps/main/src/app/_components/global-layout/global-layout.tsx
@@ -27,17 +27,15 @@ export const GlobalLayout: FC<{ children: ReactNode }> = ({ children }) => {
           <LlmLink />
         </div>
       </Header>
-      <main className="flex grow justify-center">
-        <div className="w-full max-w-5xl p-4 pt-10">{children}</div>
+      <main className="flex grow justify-center px-4 pt-10 pb-4">
+        {children}
       </main>
       <Suspense
         fallback={
           <footer className="flex items-center justify-center p-4">
-            <div className="max-w-5xl">
-              <p className="text-fg-mute md:text-lg">
-                ©︎ 2024〜2026 k8o. All Rights Reserved.
-              </p>
-            </div>
+            <p className="text-fg-mute md:text-lg">
+              ©︎ 2024〜2026 k8o. All Rights Reserved.
+            </p>
           </footer>
         }
       >

--- a/apps/main/src/app/artifacts/layout.tsx
+++ b/apps/main/src/app/artifacts/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'Artifacts',
@@ -21,9 +22,11 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/artifacts'>) {
   return (
-    <div className="flex flex-col gap-6">
-      <Heading type="h2">Artifacts</Heading>
-      {children}
-    </div>
+    <ContentContainer width="wide">
+      <div className="flex flex-col gap-6">
+        <Heading type="h2">Artifacts</Heading>
+        {children}
+      </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/base-converter/layout.tsx
+++ b/apps/main/src/app/base-converter/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: '基数チェンジャー',
@@ -21,9 +22,11 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/base-converter'>) {
   return (
-    <div className="flex h-full flex-col gap-4">
-      <Heading type="h2">基数チェンジャー</Heading>
-      {children}
-    </div>
+    <ContentContainer>
+      <div className="flex h-full flex-col gap-4">
+        <Heading type="h2">基数チェンジャー</Heading>
+        {children}
+      </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/baseline/layout.tsx
+++ b/apps/main/src/app/baseline/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 import { BaselineHelpDialog } from './_components/baseline-help-dialog';
 
 const description =
@@ -25,12 +26,14 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/baseline'>) {
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex items-center gap-2">
-        <Heading type="h2">Baseline</Heading>
-        <BaselineHelpDialog />
+    <ContentContainer width="wide">
+      <div className="flex flex-col gap-6">
+        <div className="flex items-center gap-2">
+          <Heading type="h2">Baseline</Heading>
+          <BaselineHelpDialog />
+        </div>
+        {children}
       </div>
-      {children}
-    </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -49,7 +49,7 @@ export const BlogLayoutContent: FC<BlogLayoutContentProps> = ({
   const shouldUseRecommendedBlogs = recommendedBlogs !== undefined;
 
   return (
-    <div className="gap-4 xl:flex xl:has-[>:nth-child(2)]:-mx-36">
+    <div className="gap-4 xl:flex">
       <ViewReporter slug={slug} />
       <div className="m-auto flex flex-col gap-8 xl:max-w-5xl">
         <article className="rounded-xl bg-bg-base/90 px-3 pt-8 pb-8 sm:px-10">

--- a/apps/main/src/app/blog/layout.tsx
+++ b/apps/main/src/app/blog/layout.tsx
@@ -1,6 +1,7 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { ContentContainer } from '@/app/_components/content-container';
 import { ExternalBlog } from './_components/external-blog';
 
 export const metadata = {
@@ -29,15 +30,17 @@ export default function Layout({ children }: LayoutProps<'/blog'>) {
         href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css"
         rel="stylesheet"
       />
-      <div className="flex flex-col gap-6">
-        <div className="flex items-center justify-between">
-          <Link className="hover:underline" href="/blog">
-            <Heading type="h2">Blog</Heading>
-          </Link>
-          <ExternalBlog />
+      <ContentContainer>
+        <div className="flex flex-col gap-6">
+          <div className="flex items-center justify-between">
+            <Link className="hover:underline" href="/blog">
+              <Heading type="h2">Blog</Heading>
+            </Link>
+            <ExternalBlog />
+          </div>
+          {children}
         </div>
-        {children}
-      </div>
+      </ContentContainer>
     </>
   );
 }

--- a/apps/main/src/app/color-converter/layout.tsx
+++ b/apps/main/src/app/color-converter/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'カラーコード職人',
@@ -21,9 +22,11 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/color-converter'>) {
   return (
-    <div className="flex h-full flex-col gap-4">
-      <Heading type="h2">カラーコード職人</Heading>
-      {children}
-    </div>
+    <ContentContainer>
+      <div className="flex h-full flex-col gap-4">
+        <Heading type="h2">カラーコード職人</Heading>
+        {children}
+      </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/color-quiz/layout.tsx
+++ b/apps/main/src/app/color-quiz/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'カラーHexクイズ',
@@ -21,9 +22,11 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/color-quiz'>) {
   return (
-    <div className="flex h-full flex-col gap-4">
-      <Heading type="h2">カラーHexクイズ</Heading>
-      {children}
-    </div>
+    <ContentContainer>
+      <div className="flex h-full flex-col gap-4">
+        <Heading type="h2">カラーHexクイズ</Heading>
+        {children}
+      </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/contrast-checker/layout.tsx
+++ b/apps/main/src/app/contrast-checker/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'コントラストチェッカー',
@@ -21,9 +22,11 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/contrast-checker'>) {
   return (
-    <div className="flex h-full flex-col gap-4">
-      <Heading type="h2">コントラストチェッカー</Heading>
-      {children}
-    </div>
+    <ContentContainer>
+      <div className="flex h-full flex-col gap-4">
+        <Heading type="h2">コントラストチェッカー</Heading>
+        {children}
+      </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/japanese-text-fixer/layout.tsx
+++ b/apps/main/src/app/japanese-text-fixer/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 import { ProofreadProvider } from './_state/provider';
 
 export const metadata = {
@@ -24,9 +25,11 @@ export default function Layout({
   children,
 }: LayoutProps<'/japanese-text-fixer'>) {
   return (
-    <div className="flex h-full flex-col gap-4">
-      <Heading type="h2">日本語校正くん</Heading>
-      <ProofreadProvider>{children}</ProofreadProvider>
-    </div>
+    <ContentContainer>
+      <div className="flex h-full flex-col gap-4">
+        <Heading type="h2">日本語校正くん</Heading>
+        <ProofreadProvider>{children}</ProofreadProvider>
+      </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/moji-count/layout.tsx
+++ b/apps/main/src/app/moji-count/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'もじカウント',
@@ -21,9 +22,11 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/moji-count'>) {
   return (
-    <div className="flex h-full flex-col gap-4">
-      <Heading type="h2">もじカウント</Heading>
-      {children}
-    </div>
+    <ContentContainer>
+      <div className="flex h-full flex-col gap-4">
+        <Heading type="h2">もじカウント</Heading>
+        {children}
+      </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -10,6 +10,7 @@ import {
 } from '@k8o/arte-odyssey';
 import Image from 'next/image';
 import { AppCard } from './_components/app-card';
+import { ContentContainer } from './_components/content-container';
 import { EmailTooltip } from './_components/email-tooltip';
 import { ActivityErrorBoundary } from './_components/error-boundary';
 import { GitHubContributionGraph } from './_components/github-contribution-graph';
@@ -18,7 +19,7 @@ import k8o from './_images/k8o.jpg';
 
 export default function Home() {
   return (
-    <div className="flex flex-col gap-12">
+    <ContentContainer className="flex flex-col gap-12" width="wide">
       <Card>
         <div className="p-6">
           <div className="flex flex-col items-center gap-6 sm:flex-row sm:gap-8">
@@ -195,6 +196,6 @@ export default function Home() {
           />
         </div>
       </div>
-    </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/playgrounds/layout.tsx
+++ b/apps/main/src/app/playgrounds/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'Playgrounds',
@@ -18,5 +19,5 @@ export const metadata = {
 export default function PlaygroundsLayout({
   children,
 }: LayoutProps<'/playgrounds'>) {
-  return children;
+  return <ContentContainer>{children}</ContentContainer>;
 }

--- a/apps/main/src/app/qr-generator/layout.tsx
+++ b/apps/main/src/app/qr-generator/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'QRキット',
@@ -21,9 +22,11 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/qr-generator'>) {
   return (
-    <div className="flex h-full flex-col gap-4">
-      <Heading type="h2">QRキット</Heading>
-      {children}
-    </div>
+    <ContentContainer>
+      <div className="flex h-full flex-col gap-4">
+        <Heading type="h2">QRキット</Heading>
+        {children}
+      </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/radius-maker/layout.tsx
+++ b/apps/main/src/app/radius-maker/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'かどまるラボ',
@@ -21,9 +22,11 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/radius-maker'>) {
   return (
-    <div className="flex h-full flex-col gap-4">
-      <Heading type="h2">かどまるラボ</Heading>
-      {children}
-    </div>
+    <ContentContainer>
+      <div className="flex h-full flex-col gap-4">
+        <Heading type="h2">かどまるラボ</Heading>
+        {children}
+      </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/reading-list/layout.tsx
+++ b/apps/main/src/app/reading-list/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading, IconLink, RSSIcon } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'Readings',
@@ -21,19 +22,21 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/reading-list'>) {
   return (
-    <div className="flex flex-col gap-8">
-      <div className="flex items-center justify-between">
-        <Heading type="h2">Readings</Heading>
-        <IconLink
-          bg="base"
-          href="/reading-list/feed"
-          label="RSSフィード"
-          openInNewTab
-        >
-          <RSSIcon />
-        </IconLink>
+    <ContentContainer>
+      <div className="flex flex-col gap-8">
+        <div className="flex items-center justify-between">
+          <Heading type="h2">Readings</Heading>
+          <IconLink
+            bg="base"
+            href="/reading-list/feed"
+            label="RSSフィード"
+            openInNewTab
+          >
+            <RSSIcon />
+          </IconLink>
+        </div>
+        {children}
       </div>
-      {children}
-    </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/sql-table-builder/layout.tsx
+++ b/apps/main/src/app/sql-table-builder/layout.tsx
@@ -1,6 +1,7 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
 import { Suspense } from 'react';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'SQLテーブルメーカー',
@@ -23,9 +24,11 @@ export default function Layout({
   children,
 }: LayoutProps<'/sql-table-builder'>) {
   return (
-    <div className="flex flex-col gap-4">
-      <Heading type="h2">SQLテーブルメーカー</Heading>
-      <Suspense fallback={null}>{children}</Suspense>
-    </div>
+    <ContentContainer>
+      <div className="flex flex-col gap-4">
+        <Heading type="h2">SQLテーブルメーカー</Heading>
+        <Suspense fallback={null}>{children}</Suspense>
+      </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/tags/layout.tsx
+++ b/apps/main/src/app/tags/layout.tsx
@@ -1,6 +1,7 @@
 import { Heading, TagIcon } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
 import Link from 'next/link';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'Tags',
@@ -25,23 +26,25 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/tags'>) {
   return (
-    <div className="flex flex-col gap-6">
-      <div className="flex flex-col gap-4">
-        <Link href="/tags">
-          <Heading type="h2">
-            <span className="flex items-center gap-1">
-              <span className="text-primary-fg">
-                <TagIcon />
+    <ContentContainer>
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-col gap-4">
+          <Link href="/tags">
+            <Heading type="h2">
+              <span className="flex items-center gap-1">
+                <span className="text-primary-fg">
+                  <TagIcon />
+                </span>
+                タグ置き場
               </span>
-              タグ置き場
-            </span>
-          </Heading>
-        </Link>
-        <p>
-          k8oで提供するサービスやブログのタグをまとめました。各タグを利用するコンテンツを確認できます。
-        </p>
+            </Heading>
+          </Link>
+          <p>
+            k8oで提供するサービスやブログのタグをまとめました。各タグを利用するコンテンツを確認できます。
+          </p>
+        </div>
+        {children}
       </div>
-      {children}
-    </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/talks/layout.tsx
+++ b/apps/main/src/app/talks/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'Talks',
@@ -21,9 +22,11 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/talks'>) {
   return (
-    <div className="flex flex-col gap-6">
-      <Heading type="h2">Talks</Heading>
-      {children}
-    </div>
+    <ContentContainer>
+      <div className="flex flex-col gap-6">
+        <Heading type="h2">Talks</Heading>
+        {children}
+      </div>
+    </ContentContainer>
   );
 }

--- a/apps/main/src/app/text-diff/layout.tsx
+++ b/apps/main/src/app/text-diff/layout.tsx
@@ -1,5 +1,6 @@
 import { Heading } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
+import { ContentContainer } from '@/app/_components/content-container';
 
 export const metadata = {
   title: 'テキスト差分チェッカー',
@@ -21,9 +22,11 @@ export const metadata = {
 
 export default function Layout({ children }: LayoutProps<'/text-diff'>) {
   return (
-    <div className="flex h-full flex-col gap-4">
-      <Heading type="h2">テキスト差分チェッカー</Heading>
-      {children}
-    </div>
+    <ContentContainer>
+      <div className="flex h-full flex-col gap-4">
+        <Heading type="h2">テキスト差分チェッカー</Heading>
+        {children}
+      </div>
+    </ContentContainer>
   );
 }

--- a/biome.json
+++ b/biome.json
@@ -7,7 +7,12 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!**/mockServiceWorker.js", "!**/migrations/meta"]
+    "includes": [
+      "**",
+      "!**/mockServiceWorker.js",
+      "!**/migrations/meta",
+      "!.claude/worktrees"
+    ]
   },
   "formatter": {
     "enabled": true,


### PR DESCRIPTION
## 概要

GlobalLayout に固定で置いていた `max-w-5xl` の横幅制約を外し、各ルートの layout が幅を決められるように `ContentContainer` コンポーネントを導入した。

## 動機

- 横幅 1024px 固定が強い制約で、home のカードグリッドや baseline のリストに対して窮屈に感じていた
- 一方でブログのような読み物系は 1024px が適切
- 一律に広げる/狭めるのではなく、ページごとに幅を選べる形にしたい

## 詳細

### ContentContainer コンポーネント (新規)

`apps/main/src/app/_components/content-container/` に追加。幅 variant を 4 種持つ:

- `narrow` → `max-w-3xl` (768px)
- `default` → `max-w-5xl` (1024px)
- `wide` → `max-w-7xl` (1280px)
- `full` → `max-w-none`

### GlobalLayout / Footer

- `<main>` から `max-w-5xl` を除去し、padding と centering だけ担当に
- Footer 内の冗長な `max-w-5xl` wrapper も除去

### 各 layout

- **wide (max-w-7xl)**: `/` (home)、`/baseline`、`/artifacts`
- **default (max-w-5xl)**: `/blog`、`/playgrounds`、`/reading-list`、`/talks`、`/tags`、および 10 個のツール系 (`base-converter`、`color-converter`、`color-quiz`、`contrast-checker`、`japanese-text-fixer`、`moji-count`、`qr-generator`、`radius-maker`、`sql-table-builder`、`text-diff`)

### BlogLayout の -mx-36 除去

`blog-layout.tsx` にあった `xl:has-[>:nth-child(2)]:-mx-36` は GlobalLayout が 5xl キャップしていた時代の break-out hack。ContentContainer 化で不要になったので削除。これで記事ページの content が viewport 中央に素直に収まり、Header の pill と edge が揃う。

### biome.json

pre-commit hook が `.claude/worktrees/` 配下の nested root config を拾って落ちるため、`files.includes` に `!.claude/worktrees/**` を追加。

## 気をつけるポイント

- ブログ記事ページの -mx-36 除去により、TOC 表示時のレイアウトが変わっている可能性あり (TOC は `fixed` positioned なので記事本体の centering には影響しないはず、目視では正常)
- 各ページの layout に `ContentContainer` の import/wrap が追加されているので、新規ページ追加時は同様に包む必要あり

## 影響範囲

全ページの横幅。特に home / baseline / artifacts は従来より広く (1024→1280px)、他は維持。

## テスト

- `pnpm run type-check`: ✓
- 1280 / 1440 / 1680 / 1920 / 2560 / 3440 / 1080 / 720 / 640 / 375 の各 viewport で home / baseline / blog 記事を表示確認、左右 inset 対称・horizontal overflow なしを確認
- 段階リサイズでの挙動も確認 (fresh open と同じ結果)