### PR TITLE
fix: link-cardのgetMetadataにfetchタイムアウトを追加

### DIFF
--- a/apps/main/src/app/_components/link-card/metadata.ts
+++ b/apps/main/src/app/_components/link-card/metadata.ts
@@ -16,7 +16,7 @@ export async function getMetadata(href: string) {
 
   let html: string;
   try {
-    const res = await fetch(href);
+    const res = await fetch(href, { signal: AbortSignal.timeout(5000) });
     html = (await res.text()).trim();
   } catch {
     return { title: undefined, description: undefined, image: undefined };


### PR DESCRIPTION
## 概要
`link-card/metadata.ts` の `getMetadata` が外部URLを fetch する際に、タイムアウトを設定していなかったため、外部サイトが遅いと Next.js の \`'use cache'\` 側のタイムアウト（USE_CACHE_TIMEOUT）に引っかかって prerender が失敗することがあった。

## 動機
PR #1691 の Vercel build で以下のエラーが発生:

\`\`\`
Error: Filling a cache during prerender timed out...
at src/app/_components/link-card/metadata.ts:13:8
Error occurred prerendering page \"/reading-list\"
\`\`\`

\`/reading-list\` は多数の外部URLのメタデータを prerender で取得しているため、どれか1つが遅いとビルド全体が落ちる。

## 詳細
\`fetch(href)\` に \`{ signal: AbortSignal.timeout(5000) }\` を追加。5秒以内に応答しなければ abort され、\`catch\` で fallback値（title/description/image すべて undefined）を返す。

## 気をつけるポイント
- fallback時はメタデータが無い状態でカードが表示される（既存の挙動と同じ）
- 5秒は暫定値。必要なら調整可