### PR TITLE
fix: Vercelでorigin/mainをfetchしてignore-build判定を機能させる

### DIFF
--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -35,6 +35,14 @@ fi
 readonly BASE_SHA="${VERCEL_GIT_PREVIOUS_SHA:-origin/main}"
 log "Using BASE_SHA=$BASE_SHA"
 
+# Vercelのshallow cloneにはbranchのtipしか含まれないため、origin/mainをbaseに使う場合は
+# 明示的にfetchしないと `git diff` や turbo の base 参照解決に失敗する
+if [ "$BASE_SHA" = "origin/main" ]; then
+  if ! git fetch --depth=1 origin main 2>&1; then
+    log "Warning: git fetch origin main failed, may cause fallback to build"
+  fi
+fi
+
 # 変更ファイルが取得できなければ安全側に倒してビルド
 if ! CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD 2>&1); then
   log "Proceeding: failed to get changed files ($CHANGED_FILES)"


### PR DESCRIPTION
## 概要
Vercelの \`ignoreCommand\` で実行される \`scripts/ignore-build.sh\` が、Vercelのshallow cloneで \`origin/main\` ref を解決できず、safety fallback でビルドが常に実行されていた問題を修正する。

## 動機
PR #1691（apps/main のみ変更）の admin Vercel deploy ログで以下が観測された:

\`\`\`
>> Using BASE_SHA=origin/main
>> Proceeding: failed to get changed files (fatal: ambiguous argument 'origin/main': unknown revision or path not in the working tree.)
\`\`\`

Vercelは build 対象 branch の tip だけを浅く clone するので、\`origin/main\` ref は存在しない。script は \`git diff origin/main HEAD\` が失敗すると safety fallback で \`exit 1\` (ビルド実行) していたため、admin など関係ないアプリも毎回ビルドされていた。

## 詳細
\`BASE_SHA\` が \`origin/main\` の場合のみ、\`git fetch --depth=1 origin main\` を事前に実行して ref を利用可能にする。

## 気をつけるポイント
- \`VERCEL_GIT_PREVIOUS_SHA\` が設定されている場合（過去デプロイがある）は fetch しない（そのSHAはcloneに含まれている想定）
- fetch 自体が失敗しても既存の safety fallback が動くので、壊れる方向の変更ではない