### PR TITLE
feat: Artifactsにmdscrollとstorybook-framework-hono-viteを追加

### DIFF
--- a/apps/main/src/services/artifacts/artifacts.test.ts
+++ b/apps/main/src/services/artifacts/artifacts.test.ts
@@ -5,7 +5,7 @@ describe('getArtifacts', () => {
   it('公開している制作物一覧を返す', () => {
     const projects = getArtifacts();
 
-    expect(projects).toHaveLength(7);
+    expect(projects).toHaveLength(9);
     expect(projects).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -31,6 +31,18 @@ describe('getArtifacts', () => {
           githubUrl: 'https://github.com/k35o/storybook-addon-mock-date',
           websiteUrl: null,
           npmPackageName: 'storybook-addon-mock-date',
+        }),
+        expect.objectContaining({
+          name: 'storybook-framework-hono-vite',
+          githubUrl: 'https://github.com/k35o/storybook-framework-hono-vite',
+          websiteUrl: null,
+          npmPackageName: 'storybook-framework-hono-vite',
+        }),
+        expect.objectContaining({
+          name: 'mdscroll',
+          githubUrl: 'https://github.com/k35o/mdscroll',
+          websiteUrl: null,
+          npmPackageName: 'mdscroll',
         }),
       ]),
     );

--- a/apps/main/src/services/artifacts/artifacts.ts
+++ b/apps/main/src/services/artifacts/artifacts.ts
@@ -69,5 +69,23 @@ export const getArtifacts = (): Artifact[] => {
       npmPackageName: 'storybook-addon-mock-date',
       tags: ['TypeScript', 'Storybook'],
     },
+    {
+      name: 'storybook-framework-hono-vite',
+      description:
+        'Hono JSXで書いたコンポーネントを@storybook/react-viteと同じ感覚で扱うためのStorybookフレームワーク。',
+      githubUrl: 'https://github.com/k35o/storybook-framework-hono-vite',
+      websiteUrl: null,
+      npmPackageName: 'storybook-framework-hono-vite',
+      tags: ['Storybook', 'Hono', 'Vite'],
+    },
+    {
+      name: 'mdscroll',
+      description:
+        'Markdownをブラウザでプレビューするためのコマンドラインツール。',
+      githubUrl: 'https://github.com/k35o/mdscroll',
+      websiteUrl: null,
+      npmPackageName: 'mdscroll',
+      tags: ['AI Agent', 'Tool'],
+    },
   ];
 };

--- a/apps/main/src/services/artifacts/artifacts.ts
+++ b/apps/main/src/services/artifacts/artifacts.ts
@@ -16,7 +16,7 @@ export const getArtifacts = (): Artifact[] => {
       githubUrl: 'https://github.com/k35o/arte-odyssey',
       websiteUrl: 'https://arte-odyssey.k8o.me/',
       npmPackageName: null,
-      tags: ['Design System', 'TypeScript', 'React'],
+      tags: ['Design System', 'React'],
     },
     {
       name: 'renovate-config',
@@ -24,7 +24,7 @@ export const getArtifacts = (): Artifact[] => {
       githubUrl: 'https://github.com/k35o/renovate-config',
       websiteUrl: null,
       npmPackageName: null,
-      tags: ['Renovate', 'Config', 'Automation'],
+      tags: ['Renovate', 'Config', 'Personal'],
     },
     {
       name: 'dotfiles',
@@ -32,7 +32,7 @@ export const getArtifacts = (): Artifact[] => {
       githubUrl: 'https://github.com/k35o/dotfiles',
       websiteUrl: null,
       npmPackageName: null,
-      tags: ['Shell', 'CLI', 'macOS'],
+      tags: ['Dotfiles', 'Shell', 'Config', 'Personal'],
     },
     {
       name: 'skills',
@@ -41,7 +41,7 @@ export const getArtifacts = (): Artifact[] => {
       githubUrl: 'https://github.com/k35o/skills',
       websiteUrl: null,
       npmPackageName: null,
-      tags: ['AI Agent', 'Skills', 'Automation'],
+      tags: ['AI Agent', 'Skills', 'Config', 'Personal'],
     },
     {
       name: 'better-css-modules',
@@ -49,7 +49,7 @@ export const getArtifacts = (): Artifact[] => {
       githubUrl: 'https://github.com/k35o/better-css-modules',
       websiteUrl: null,
       npmPackageName: '@better-css-modules/core',
-      tags: ['CSS Modules', 'TypeScript', 'Tooling'],
+      tags: ['CSS Modules', 'webpack', 'Vite', 'Turbopack'],
     },
     {
       name: 'patrol-board',
@@ -58,7 +58,7 @@ export const getArtifacts = (): Artifact[] => {
       githubUrl: 'https://github.com/k35o/patrol-board',
       websiteUrl: null,
       npmPackageName: null,
-      tags: ['TypeScript', 'GitHub Actions'],
+      tags: ['GitHub Actions', 'Tool'],
     },
     {
       name: 'storybook-addon-mock-date',
@@ -67,7 +67,7 @@ export const getArtifacts = (): Artifact[] => {
       githubUrl: 'https://github.com/k35o/storybook-addon-mock-date',
       websiteUrl: null,
       npmPackageName: 'storybook-addon-mock-date',
-      tags: ['TypeScript', 'Storybook'],
+      tags: ['Storybook', 'Date'],
     },
     {
       name: 'storybook-framework-hono-vite',


### PR DESCRIPTION
## Summary
- Artifacts一覧に `mdscroll` と `storybook-framework-hono-vite` を追加
- 既存エントリのタグを整理（汎用的な `TypeScript` / `Tooling` / `Automation` 等を外し、対象の識別性が高いタグに寄せる）
- 個人設定系（`renovate-config` / `dotfiles` / `skills`）に `Config` と `Personal` を付与

## Test plan
- [x] `pnpm vitest run --project="services test" src/services/artifacts/artifacts.test.ts`