### PR TITLE
fix: Vercelのignore-buildで無関係なアプリがビルドされる問題を修正

### DIFF
--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -36,10 +36,22 @@ readonly BASE_SHA="${VERCEL_GIT_PREVIOUS_SHA:-origin/main}"
 log "Using BASE_SHA=$BASE_SHA"
 
 # Vercelのshallow cloneにはbranchのtipしか含まれないため、origin/mainをbaseに使う場合は
-# 明示的にfetchしないと `git diff` や turbo の base 参照解決に失敗する
+# 明示的にfetchしないと `git diff` や turbo の base 参照解決に失敗する。
+# Vercelビルド環境では `origin` リモートが未設定のケースがあるため、
+# 既存リモートがなければ環境変数からGitHubのURLを組み立てて直接fetchする。
 if [ "$BASE_SHA" = "origin/main" ]; then
-  if ! git fetch --depth=1 origin main 2>&1; then
-    log "Warning: git fetch origin main failed, may cause fallback to build"
+  if FETCH_URL=$(git remote get-url origin 2>/dev/null); then
+    :
+  elif [ -n "${VERCEL_GIT_REPO_OWNER:-}" ] && [ -n "${VERCEL_GIT_REPO_SLUG:-}" ]; then
+    FETCH_URL="https://github.com/${VERCEL_GIT_REPO_OWNER}/${VERCEL_GIT_REPO_SLUG}.git"
+  else
+    FETCH_URL=""
+  fi
+
+  if [ -z "$FETCH_URL" ]; then
+    log "Warning: could not resolve remote URL for main fetch"
+  elif ! git fetch --depth=1 "$FETCH_URL" main:refs/remotes/origin/main 2>&1; then
+    log "Warning: git fetch $FETCH_URL main failed, may cause fallback to build"
   fi
 fi
 


### PR DESCRIPTION
## 概要

Vercel の Ignored Build Step（`scripts/ignore-build.sh`）が shallow clone 環境で `git fetch` に失敗し、本来スキップできるはずの無関係なアプリ（例: #1698 における `admin`）までビルドが走っていた問題を修正する。

## 動機

#1698 の admin preview ビルドのログより:

```
>> Using BASE_SHA=origin/main
fatal: 'origin' does not appear to be a git repository
>> Warning: git fetch origin main failed, may cause fallback to build
>> Proceeding: failed to get changed files (fatal: ambiguous argument 'origin/main': unknown revision or path not in the working tree.
```

`VERCEL_GIT_PREVIOUS_SHA` が空だと `BASE_SHA` が `origin/main` にフォールバックするが、Vercel の shallow clone には `origin` リモートが設定されていないケースがあり、`git fetch origin main` → `git diff origin/main HEAD` がいずれも失敗する。結果として「安全側フォールバック（= ビルド実行）」の分岐に入り、turbo affected の判定に到達できていなかった。

## 詳細

- 既存の `git remote get-url origin` が成功すればそれを使う（ローカル実行時の挙動を維持）
- 取得できない場合は `VERCEL_GIT_REPO_OWNER` / `VERCEL_GIT_REPO_SLUG` から `https://github.com/<owner>/<repo>.git` を組み立てて fetch
- refspec を `main:refs/remotes/origin/main` と明示し、後続の `origin/main` 参照を確実に解決できるようにする

## 気をつけるポイント

- 失敗モードはすべて従来どおり `exit 1`（= ビルド実行）に倒れる設計を維持しているため、この修正で「スキップすべきでないアプリがスキップされる」事故は起きない
- 本スクリプト自身が変更対象なので、この PR のプレビュービルドでは `build configuration changed` 判定で main / admin どちらもビルドされる。効果が出るのはマージ後の次の PR から

## 影響範囲

- すべての Vercel プロジェクト（`k8o`, `k8o-admin`）の Ignored Build Step 判定

## テスト

- `bash -n scripts/ignore-build.sh` で構文チェック済み
- 手元の一時リポで `VERCEL_GIT_REPO_OWNER=k35o VERCEL_GIT_REPO_SLUG=k8o` 環境変数から組み立てた URL で `git fetch --depth=1 "$URL" main:refs/remotes/origin/main` が成功し、`git rev-parse origin/main` が `39fa3c73...` に解決できることを確認