### PR TITLE
feat: LinkCardのfallbackをカード表示に変更

### DIFF
--- a/apps/main/src/app/_components/link-card/error-boundary.tsx
+++ b/apps/main/src/app/_components/link-card/error-boundary.tsx
@@ -1,13 +1,16 @@
-import { Anchor } from '@k8o/arte-odyssey';
 import type { FC, ReactNode } from 'react';
 import { ActivityErrorBoundary } from '@/app/_components/error-boundary';
+import { type LinkCardAppearance, LinkCardFallback } from './fallback';
 
 export const LinkCardErrorBoundary: FC<{
   href: string;
+  appearance?: LinkCardAppearance;
   children: ReactNode;
-}> = ({ href, children }) => {
+}> = ({ href, appearance = 'shadow', children }) => {
   return (
-    <ActivityErrorBoundary fallback={<Anchor href={href}>{href}</Anchor>}>
+    <ActivityErrorBoundary
+      fallback={<LinkCardFallback appearance={appearance} href={href} />}
+    >
       {children}
     </ActivityErrorBoundary>
   );

--- a/apps/main/src/app/_components/link-card/fallback.tsx
+++ b/apps/main/src/app/_components/link-card/fallback.tsx
@@ -1,0 +1,30 @@
+import { ExternalLinkIcon, InteractiveCard } from '@k8o/arte-odyssey';
+import type { FC } from 'react';
+
+export type LinkCardAppearance = 'shadow' | 'bordered';
+
+export const LinkCardFallback: FC<{
+  href: string;
+  appearance?: LinkCardAppearance;
+}> = ({ href, appearance = 'shadow' }) => {
+  return (
+    <InteractiveCard appearance={appearance}>
+      <a
+        className="group block h-full"
+        href={href}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        <div className="flex h-full flex-col gap-2 p-4">
+          <p className="line-clamp-2 break-all font-bold text-md transition-colors duration-200 ease-out group-hover:text-primary-fg">
+            {href}
+          </p>
+          <div className="mt-auto flex items-center gap-1 text-fg-subtle text-xs">
+            <ExternalLinkIcon size="sm" />
+            <p>{new URL(href).hostname}</p>
+          </div>
+        </div>
+      </a>
+    </InteractiveCard>
+  );
+};

--- a/apps/main/src/app/_components/link-card/link-card.tsx
+++ b/apps/main/src/app/_components/link-card/link-card.tsx
@@ -1,5 +1,4 @@
 import {
-  Anchor,
   ExternalLinkIcon,
   InteractiveCard,
   PublishDateIcon,
@@ -7,10 +6,9 @@ import {
 import { formatDate } from '@repo/helpers/date/format';
 import { type FC, Suspense } from 'react';
 import { LinkCardErrorBoundary } from './error-boundary';
+import { type LinkCardAppearance, LinkCardFallback } from './fallback';
 import { MetaImage } from './image';
 import { getMetadata } from './metadata';
-
-type LinkCardAppearance = 'shadow' | 'bordered';
 
 export const LinkCardLoading: FC<{
   href: string;
@@ -42,7 +40,7 @@ const Content: FC<{
   const metaData = await getMetadata(href);
 
   if (!(metaData.title || metaData.description || metaData.image)) {
-    return <Anchor href={href}>{href}</Anchor>;
+    return <LinkCardFallback appearance={appearance} href={href} />;
   }
 
   return (
@@ -95,7 +93,7 @@ export const LinkCard: FC<{
   appearance?: LinkCardAppearance;
 }> = ({ href, publishedAt, appearance = 'shadow' }) => {
   return (
-    <LinkCardErrorBoundary href={href}>
+    <LinkCardErrorBoundary appearance={appearance} href={href}>
       <Suspense
         fallback={<LinkCardLoading appearance={appearance} href={href} />}
       >


### PR DESCRIPTION
## 概要

LinkCardのfallbackで単なるAnchorを返していた箇所を、他のカードと揃うカード表示に変更した。

## 動機

reading-list等でLinkCardが並ぶ画面において、metadata取得失敗時やErrorBoundary発動時にはテキストリンクだけが返るため、周囲のカードから浮いて見えていた。

## 詳細

- `fallback.tsx` を新規追加。`InteractiveCard` + hostname 表示の `LinkCardFallback` と共有型 `LinkCardAppearance` をここに集約。
- `link-card.tsx`: metadataが空のケースで `<Anchor>` を返していた分岐を `LinkCardFallback` に置き換え。`LinkCardErrorBoundary` に `appearance` を渡すように変更。
- `error-boundary.tsx`: `ActivityErrorBoundary` の fallback を `<Anchor>` から `LinkCardFallback` に変更し、`appearance` を受け取るように。

## 影響範囲

- `apps/main` 内で `LinkCard` を使っている画面（reading-list、blog内の外部リンク参照など）。
- 正常系の見た目は変わらない。metadataなし/エラー時のみ表示が変わる。