### PR TITLE
fix: link-cardのog:image URLのHTMLエンティティをデコード

### DIFF
--- a/apps/main/src/app/_components/link-card/metadata.ts
+++ b/apps/main/src/app/_components/link-card/metadata.ts
@@ -27,7 +27,7 @@ export async function getMetadata(href: string) {
   )?.[1];
   const rawDescription =
     /<meta\s+property="og:description"\s+content="(.*?)"/i.exec(html)?.[1];
-  const image = /<meta\s+property="og:image"\s+content="(.*?)"/i.exec(
+  const rawImage = /<meta\s+property="og:image"\s+content="(.*?)"/i.exec(
     html,
   )?.[1];
 
@@ -39,6 +39,7 @@ export async function getMetadata(href: string) {
   const description = rawDescription
     ? decodeHtmlEntities(rawDescription)
     : undefined;
+  const image = rawImage ? decodeHtmlEntities(rawImage) : undefined;
 
   return { title, description, image };
 }


### PR DESCRIPTION
## Summary
- link-cardで取得する `og:image` URLに `decodeHtmlEntities` を適用していなかったため、`&amp;` を含むURLが画像として解決できないケースがあった
- title/descriptionと同じようにデコードを通し、`rawImage` → `image` の命名も他のフィールドに合わせた

## Test plan
- [x] Vercel previewでignore-buildが `admin` をスキップし `main` のみビルドすることを確認する（PRの主目的）
- [ ] プレビュー上で `&amp;` を含むog:imageを持つリンクが正しく画像表示されることを目視確認