### PR TITLE
feat: Math.sumPrecise()の記事を追加

### DIFF
--- a/apps/main/src/app/blog/(articles)/math-sum-precise/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/math-sum-precise/layout.tsx
@@ -1,0 +1,36 @@
+import type { Metadata } from 'next';
+import { getBlogContent } from '@/app/blog/_api';
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+
+const slug = 'math-sum-precise';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt.toString(),
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/math-sum-precise'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/math-sum-precise/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/math-sum-precise/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getBlogContent } from '@/app/blog/_api';
+
+export const alt = 'Math.sumPrecise()';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const blog = await getBlogContent('math-sum-precise');
+
+  return await OgImage({
+    category: 'Blog',
+    title: blog.title,
+  });
+}

--- a/apps/main/src/app/blog/(articles)/math-sum-precise/page.mdx
+++ b/apps/main/src/app/blog/(articles)/math-sum-precise/page.mdx
@@ -1,0 +1,146 @@
+---
+title: 'Math.sumPrecise()で浮動小数点数の合計を正確に計算する'
+description: 'Baseline 2026で追加されたMath.sumPrecise()は、数値のiterableを受け取り、中間結果の丸め誤差を抑えて合計を計算する静的メソッドです。reduceやforループで合計の順序によって結果が変わってしまう浮動小数点数の問題を抑えられます。'
+createdAt: 2026-04-25
+updatedAt: 2026-04-25
+featureIds:
+  - math-sum-precise
+---
+
+import { BaselineStatus } from '@k8o/arte-odyssey';
+import { LinkCard } from '@/app/_components/link-card';
+
+# Math.sumPrecise()で浮動小数点数の合計を正確に計算する
+
+<BaselineStatus featureId="math-sum-precise" />
+
+## はじめに
+
+JavaScriptの数値はIEEE 754の倍精度浮動小数点数（64bit、仮数部フィールドは52bit、隠れビットを含めて有効精度は53bit相当）で表現されるため、表現できる精度には限りがあります。`a + b`の結果も64bitに収めるために最も近い表現可能な値へ丸められるため、足し算を繰り返すと中間結果の丸め誤差が積み重なります。特に桁の大きく異なる数値が混ざると、本来0ではない合計が0になるなど、結果が大きくずれることがあります。
+
+Baseline 2026で追加された`Math.sumPrecise()`は、この合計過程で生まれる丸め誤差を取り除き、より正確な合計を返す静的メソッドです。
+
+## これまでの方法の問題点
+
+配列の合計を求めたいとき、これまでは`Array.prototype.reduce()`や`for...of`ループで`+`を使って書くのが一般的でした。
+
+```js
+const numbers = [1e20, 0.1, -1e20];
+const sum = numbers.reduce((acc, n) => acc + n, 0);
+console.log(sum); // 0
+```
+
+期待する答えは`0.1`ですが、結果は`0`になります。これは中間結果である`1e20 + 0.1`が浮動小数点数の精度の限界で丸められて`1e20`になり、その後`1e20 + (-1e20)`で`0`になるためです。
+
+順序を入れ替えて`[1e20, -1e20, 0.1]`にすれば`0.1`になりますが、入力の順序によって結果が変わってしまうこと自体が問題です。要素数が多くなるほど中間結果の丸めが積み重なり、精度が求められる計算ではこの暗黙の誤差は無視できません。
+
+## Math.sumPrecise()
+
+`Math.sumPrecise()`は数値の`iterable`を受け取り、中間の丸め誤差を避けて合計を返します。仕様は特定のアルゴリズムを指定しておらず、各値を任意精度で厳密に加算した結果を最後に一度だけ64bit浮動小数点数として表現可能な最も近い値へ丸めたときと同じ結果になることだけを要求しています。TC39 proposalのREADMEでは実装候補としてShewchukのアルゴリズム（Pythonの`math.fsum`と同系統）とNealのsuperaccumulator（xsum）が挙げられており、proposalのpolyfillではShewchukのアルゴリズムが採用されています。
+
+<LinkCard href="https://github.com/tc39/proposal-math-sum/tree/main/polyfill" />
+
+```js
+console.log(Math.sumPrecise([1e20, 0.1, -1e20])); // 0.1
+console.log(Math.sumPrecise([1, 2, 3])); // 6
+```
+
+先ほど`reduce`で`0`になった式も、`Math.sumPrecise()`を使えば期待通りの`0.1`を返します。
+
+引数は配列に限らず、`Set`やジェネレータなど`[Symbol.iterator]`を持つオブジェクトであれば渡せます。
+
+```js
+function* range(start, end) {
+  for (let i = start; i < end; i++) {
+    yield i;
+  }
+}
+
+console.log(Math.sumPrecise(range(1, 101))); // 5050
+```
+
+`Math.max()`のような可変長引数ではなく`iterable`を1つ受け取る設計になっているのは、大きな配列を渡したときに引数展開（`Math.sumPrecise(...huge)`）でスタックオーバーフローを起こさないようにするためです。proposalのREADMEでは次のように説明されています。
+
+> Math.max precedent suggests variadic, but that's really not what you want - once your lists get larger than a few tens of thousands of elements, you'll probably overflow the stack and get a RangeError.
+
+数万要素を超える配列を可変長引数で渡すとスタックを溢れて`RangeError`になるため、`Math.max()`の前例にならわず`iterable`を直接受け取る形にした、ということです。大量の数値を一度に合計するユースケースを想定した選択といえます。
+
+また、`Math.sum`ではなく`Math.sumPrecise`という名前になっている理由もREADMEに記されています。
+
+> Math.sum is the obvious name, but it's not obvious that this going to be a different (slower) algorithm than naive summation. This is called Math.sumPrecise to call attention to that difference.
+
+単に`Math.sum`だと素朴な加算をするメソッドだと誤解されかねないため、素朴な加算とは異なる（精度を優先するぶん遅い）アルゴリズムが使われていることを名前から伝えるために`sumPrecise`が採用された、ということです。
+
+## 引数の挙動
+
+`Math.sumPrecise()`の引数には数値の`iterable`のみを渡せます。`Math.max()`のように文字列を暗黙的に数値へ変換することはなく、数値以外の値が含まれていると`TypeError`が投げられます。引数自体が`iterable`でない場合（数値や`null`を直接渡した場合など）も同じく`TypeError`になります。
+
+```js
+Math.sumPrecise([1, 2, '3']); // TypeError（要素が数値でない）
+Math.sumPrecise([1, 2, null]); // TypeError（要素が数値でない）
+Math.sumPrecise(123); // TypeError（iterableでない）
+```
+
+`reduce`が文字列連結や`null`への暗黙の変換を許してしまうのに対して、`Math.sumPrecise()`は数値以外を早期に弾いてくれるため、想定外のデータが混ざった場合にバグを見つけやすくなります。
+
+空のiterableを渡した場合は`-0`が返ります。加法の単位元として`+0`ではなく`-0`が返るのは、「`-0 + x`が常に`x`と等しい」というIEEE 754の性質に合わせるためです。`-0`だけの配列も`-0`のままですが、`+0`が1つでも混ざると結果は`+0`になります。
+
+```js
+console.log(Math.sumPrecise([])); // -0
+console.log(Math.sumPrecise([-0, -0, -0])); // -0
+console.log(Math.sumPrecise([-0, -0, -0, 0])); // 0
+```
+
+`Infinity`や`NaN`が含まれる場合の挙動は少しだけ変わっています。同じ非有限値だけが含まれる場合はそのまま返り、異なる非有限値が混ざった場合は`NaN`が返ります。
+
+```js
+console.log(Math.sumPrecise([1, Infinity])); // Infinity
+console.log(Math.sumPrecise([Infinity, Infinity])); // Infinity
+console.log(Math.sumPrecise([Infinity, -Infinity])); // NaN
+console.log(Math.sumPrecise([Infinity, NaN])); // NaN
+console.log(Math.sumPrecise([1, NaN])); // NaN
+```
+
+合計値がbinary64の表現範囲を超えた場合は通常の加算と同じく`Infinity`または`-Infinity`が返ります。
+
+```js
+console.log(Math.sumPrecise([1e308, 1e308])); // Infinity
+console.log(Math.sumPrecise([-1e308, -1e308])); // -Infinity
+```
+
+## 解消できない精度の限界
+
+`Math.sumPrecise()`が取り除くのは合計時の丸め誤差だけで、入力値そのものが持つ表現誤差までは解消できません。有名な`0.1 + 0.2`の例でも、結果は`0.3`にはなりません。
+
+```js
+console.log(Math.sumPrecise([0.1, 0.2])); // 0.30000000000000004
+```
+
+これは、そもそも`0.1`と`0.2`が思っている値で格納されていないことが原因です。JavaScriptの数値は2進数の浮動小数点数で表されるので、10進数の`0.1`や`0.2`は2進数では有限桁で表せず、最も近い2進小数に丸められて格納されます。実際に格納されている値を`toPrecision()`で取り出すと、末尾に誤差が見えます。
+
+```js
+console.log((0.1).toPrecision(20)); // '0.10000000000000000555'
+console.log((0.2).toPrecision(20)); // '0.20000000000000001110'
+```
+
+この2つの値を（丸めずに）厳密に足すと`0.30000000000000001665...`になり、64bit浮動小数点数で表現できる最も近い値が`0.30000000000000004`です。つまり`Math.sumPrecise([0.1, 0.2])`は、「与えられた2つの値の正確な合計を64bit浮動小数点数に丸めた結果」としてはまったく正しい値を返しています。
+
+一方で、各要素も合計値もbinary64で厳密に表せる範囲であれば、`Math.sumPrecise()`の結果は数学的な意味でも厳密です。
+
+```js
+console.log(Math.sumPrecise([0.5, 0.25, 0.125])); // 0.875（2進数で厳密に表せる）
+console.log(Math.sumPrecise([1, 2, 3, 4, 5])); // 15
+```
+
+ただし、各要素が厳密に表現できても合計値の方がbinary64の精度を超える場合は、最後の丸めで誤差が出ます。たとえば`1`と`2 ** -54`はどちらも厳密に表現できますが、その正確な和`1 + 2**-54`はbinary64の有効精度（53bit）を超えるため、結果は最終的に`1`へ丸められます。
+
+10進数での厳密さが必要な場面では、これまでと同様の対応が必要です。
+
+- 金額を扱う場合は、整数で扱って最後に桁を戻す
+- 任意精度の10進数が必要な場合は、[decimal.js](https://github.com/MikeMcl/decimal.js)のような10進数ライブラリや、将来的に標準化が議論されている[Decimal](https://github.com/tc39/proposal-decimal)を使う
+
+## おわりに
+
+`Math.sumPrecise()`は、合計の途中で生まれる丸め誤差を抑え、入力の順序に依存しない結果を返してくれるメソッドです。
+
+`reduce`や`for`での合計はコードの見た目こそ簡潔ですが、入力の順序や桁の差で結果が変わってしまう不安が残ります。これからは、数値の合計を取る場面では`Math.sumPrecise()`を第一候補として選べば、合計過程の精度と意図の明確さの両方を得られるようになりました。

--- a/packages/database/migrations/0038_flippant_sasquatch.sql
+++ b/packages/database/migrations/0038_flippant_sasquatch.sql
@@ -1,0 +1,11 @@
+-- 新しいタグの追加
+INSERT INTO tags (id, name) VALUES (127, 'Math.sumPrecise()');--> statement-breakpoint
+-- ブログレコードの追加
+INSERT INTO blogs (id, slug, published, created_at)
+VALUES (64, 'math-sum-precise', 1, '2026-04-25T00:00:00.000Z');--> statement-breakpoint
+-- ビューカウント初期化
+INSERT INTO blog_views (blog_id, views) VALUES (64, 0);--> statement-breakpoint
+-- タグ紐付け (JavaScript: 10, Baseline 2026: 99, Math.sumPrecise(): 127)
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (64, 10);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (64, 99);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (64, 127);

--- a/packages/database/migrations/meta/0038_snapshot.json
+++ b/packages/database/migrations/meta/0038_snapshot.json
@@ -1,0 +1,1195 @@
+{
+  "id": "b2925a30-8506-4318-b525-05f13e228dab",
+  "prevId": "b0565fd9-3f9e-4018-ae0e-43052b97e916",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "tableTo": "article_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_id_idx": {
+          "name": "comments_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_id_idx": {
+          "name": "talks_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1776862465252,
       "tag": "0037_condemned_colossus",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "6",
+      "when": 1776924816680,
+      "tag": "0038_flippant_sasquatch",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
closed: https://github.com/k35o/k8o/issues/1694

## 概要

Baseline 2026に追加された`Math.sumPrecise()`を解説するブログ記事を新規追加する。

## 動機

`reduce`や`for`ループでの合計は中間結果の丸めで誤差が出るが、`Math.sumPrecise()`はそれを抑えてくれる。Baseline 2026入りのタイミングで、何が解決され何が解決されないのかを整理した記事を公開したい。

## 詳細

- `apps/main/src/app/blog/(articles)/math-sum-precise/` に記事一式（page.mdx, layout.tsx, opengraph-image.tsx）を追加
- `packages/database/migrations/0038_flippant_sasquatch.sql` でブログレコード・タグ・タグ紐付けを追加（blog id: 64, tag: Math.sumPrecise() (id: 127), JavaScript, Baseline 2026）

## 記事の構成

- 浮動小数点演算の基礎（IEEE 754 binary64 の有効精度53bit）
- `reduce` で生じる順序依存の誤差（`[1e20, 0.1, -1e20]`の例）
- `Math.sumPrecise()` の挙動とアルゴリズム（Shewchuk / xsum）
- proposalのREADMEから引用した設計判断（iterable採用・`sumPrecise`命名）
- 引数の挙動（TypeError、`-0`、Infinity/NaN、Infinity への発散）
- 解消できない精度の限界（`0.1 + 0.2`は表現誤差なので解消されない、`1 + 2**-54`の例）
- 10進数で厳密さが必要な場面の対処（整数化・decimal.js・TC39 Decimal）

## 気をつけるポイント

- proposalのREADMEは英語で直接引用しているので、必要に応じて引用表記を確認してほしい
- マイグレーションファイル（0038）の各種ID（blog: 64, tag: 127）が既存と衝突していないかを再確認してほしい

## テスト

- type-check / biome check ともパス
- `Math.sumPrecise([1e308, 1e308])`等の挙動はTC39公式polyfillで実機確認済み

## 関連

- TC39 proposal: https://github.com/tc39/proposal-math-sum
- MDN: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Math/sumPrecise