### PR TITLE
fix: ArteOdysseyトークンの違反を修正

### DIFF
--- a/apps/admin/src/app/(authenticated)/reading-list/_components/article-table/article-table.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/article-table/article-table.tsx
@@ -58,7 +58,7 @@ const DeleteButton: FC<{ id: number; title: string }> = ({ id, title }) => {
           <Dialog.Content>
             <div className="flex flex-col gap-6">
               <p className="text-sm">「{title}」を削除しますか？</p>
-              {error && <p className="text-fg-danger text-sm">{error}</p>}
+              {error && <p className="text-fg-error text-sm">{error}</p>}
               <div className="flex justify-end gap-3">
                 <Button
                   color="gray"

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/delete-source-button/delete-source-button.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/delete-source-button/delete-source-button.tsx
@@ -55,7 +55,7 @@ export const DeleteSourceButton = ({
               <p className="text-sm">
                 「{title}」を削除しますか？この操作は取り消せません。
               </p>
-              {error && <p className="text-fg-danger text-sm">{error}</p>}
+              {error && <p className="text-fg-error text-sm">{error}</p>}
               <div className="flex justify-end gap-3">
                 <Button
                   color="gray"

--- a/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
@@ -89,7 +89,7 @@ export const Presenter: FC<{
           </BarChart>
         </div>
 
-        <div className="text-fg-muted text-xs">
+        <div className="text-fg-mute text-xs">
           {period}で{totalContributions}件
         </div>
       </div>

--- a/apps/main/src/app/_components/playgrounds/active-view-transition/active-view-transition-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/active-view-transition/active-view-transition-demo.tsx
@@ -105,13 +105,13 @@ export function ActiveViewTransitionDemo() {
         <div className="flex items-center gap-2">
           <div
             aria-hidden="true"
-            className="size-3 rounded-full bg-green-500 transition-indicator"
+            className="size-3 rounded-full bg-border-success transition-indicator"
           />
-          <span className="text-fg-muted text-sm">
+          <span className="text-fg-mute text-sm">
             {isTransitioning ? '遷移中...' : '待機中'}
           </span>
         </div>
-        <span className="text-fg-muted text-sm">
+        <span className="text-fg-mute text-sm">
           {currentIndex + 1} / {CARDS.length}
         </span>
       </div>

--- a/apps/main/src/app/_components/playgrounds/invoker-commands/custom-command-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/invoker-commands/custom-command-demo.tsx
@@ -37,7 +37,7 @@ export function CustomCommandDemo() {
     <div className="space-y-4">
       <div className="flex gap-2">
         <button
-          className="rounded-md bg-primary-base px-4 py-2 text-primary-fg"
+          className="rounded-md bg-primary-bg px-4 py-2 text-primary-fg"
           // @ts-expect-error -- commandfor is not yet in TypeScript types
           // biome-ignore lint/nursery/noUnknownAttribute: Baseline 2025
           command="--zoom-in"
@@ -48,7 +48,7 @@ export function CustomCommandDemo() {
           拡大
         </button>
         <button
-          className="rounded-md bg-primary-base px-4 py-2 text-primary-fg"
+          className="rounded-md bg-primary-bg px-4 py-2 text-primary-fg"
           // @ts-expect-error -- commandfor is not yet in TypeScript types
           // biome-ignore lint/nursery/noUnknownAttribute: Baseline 2025
           command="--zoom-out"

--- a/apps/main/src/app/_components/playgrounds/invoker-commands/dialog-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/invoker-commands/dialog-demo.tsx
@@ -2,7 +2,7 @@ export function DialogDemo() {
   return (
     <div className="space-y-4">
       <button
-        className="rounded-md bg-primary-base px-4 py-2 text-primary-fg"
+        className="rounded-md bg-primary-bg px-4 py-2 text-primary-fg"
         // @ts-expect-error -- commandfor is not yet in TypeScript types
         // biome-ignore lint/nursery/noUnknownAttribute: Baseline 2025
         command="show-modal"
@@ -15,7 +15,7 @@ export function DialogDemo() {
 
       <dialog
         aria-label="デモダイアログ"
-        className="m-auto rounded-lg bg-bg-base p-6 shadow-md backdrop:bg-black/50"
+        className="m-auto rounded-lg bg-bg-base p-6 shadow-md backdrop:bg-back-drop"
         id="demo-dialog"
       >
         <div className="space-y-4">

--- a/apps/main/src/app/_components/playgrounds/invoker-commands/popover-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/invoker-commands/popover-demo.tsx
@@ -5,7 +5,7 @@ export function PopoverDemo() {
         <div className="space-y-2">
           <p className="text-fg-mute text-sm">Invoker Commands API</p>
           <button
-            className="rounded-md bg-primary-base px-4 py-2 text-primary-fg"
+            className="rounded-md bg-primary-bg px-4 py-2 text-primary-fg"
             // @ts-expect-error -- commandfor is not yet in TypeScript types
             // biome-ignore lint/nursery/noUnknownAttribute: Baseline 2025
             command="toggle-popover"
@@ -19,7 +19,7 @@ export function PopoverDemo() {
         <div className="space-y-2">
           <p className="text-fg-mute text-sm">Popover API</p>
           <button
-            className="rounded-md bg-primary-base px-4 py-2 text-primary-fg"
+            className="rounded-md bg-primary-bg px-4 py-2 text-primary-fg"
             // biome-ignore lint/nursery/noUnknownAttribute: not unknown
             popoverTarget="demo-popover"
             // biome-ignore lint/nursery/noUnknownAttribute: not unknown

--- a/apps/main/src/app/_components/playgrounds/view-transitions/view-transition-basic-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/view-transitions/view-transition-basic-demo.tsx
@@ -130,7 +130,7 @@ export function ViewTransitionBasicDemo() {
             resolvedTheme === 'dark' ? item.color.dark : item.color.light;
           return (
             <li
-              className="flex items-center justify-between rounded-md p-4 text-white opacity-80"
+              className="flex items-center justify-between rounded-md p-4 opacity-80"
               key={item.id}
               style={{
                 viewTransitionName: isViewTransitionEnabled
@@ -138,6 +138,7 @@ export function ViewTransitionBasicDemo() {
                   : 'none',
                 viewTransitionClass: 'item',
                 backgroundColor: bgColor,
+                color: 'var(--white)',
               }}
             >
               <span className="font-bold">{item.text}</span>

--- a/apps/main/src/app/blog/(articles)/input-file-webkitdirectory/_components/file-input-examples.tsx
+++ b/apps/main/src/app/blog/(articles)/input-file-webkitdirectory/_components/file-input-examples.tsx
@@ -3,7 +3,7 @@
 import { FormControl } from '@k8o/arte-odyssey';
 
 const inputClassName =
-  'max-w-80 cursor-pointer rounded-full text-center font-bold bg-primary-bg text-fg hover:bg-primary-bg/90 active:bg-primary-bg/80 focus-visible:border-transparent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-info px-4 py-2 text-md';
+  'max-w-80 cursor-pointer rounded-full text-center font-bold bg-primary-bg text-primary-fg hover:bg-primary-bg/90 active:bg-primary-bg/80 focus-visible:border-transparent focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-border-info px-4 py-2 text-md';
 
 export const BasicFileInputExamples = () => {
   return (

--- a/apps/main/src/app/qr-generator/_components/qr-generator/qr-generator.tsx
+++ b/apps/main/src/app/qr-generator/_components/qr-generator/qr-generator.tsx
@@ -98,7 +98,10 @@ export const QrGenerator = () => {
         <div className="flex flex-col items-center gap-4 p-5">
           {qrCodeSvg ? (
             <>
-              <div className="flex w-full items-center justify-center overflow-hidden rounded-xl bg-white p-4">
+              <div
+                className="flex w-full items-center justify-center overflow-hidden rounded-xl p-4"
+                style={{ backgroundColor: 'var(--white)' }}
+              >
                 <div
                   className="flex items-center justify-center"
                   dangerouslySetInnerHTML={{ __html: qrCodeSvg }}

--- a/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns-by-table.tsx
+++ b/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns-by-table.tsx
@@ -66,7 +66,7 @@ export const CreateColumnsByTable: FC<Props> = ({
 
               return (
                 <tr
-                  className={`transition-colors ${hasError ? 'bg-bg-error/5' : 'hover:bg-bg-baseHover'}`}
+                  className={`transition-colors ${hasError ? 'bg-bg-error/5' : 'hover:bg-bg-subtle'}`}
                   key={id}
                 >
                   <td className="px-3 py-2.5">

--- a/apps/main/src/app/sql-table-builder/page.tsx
+++ b/apps/main/src/app/sql-table-builder/page.tsx
@@ -36,7 +36,7 @@ const StepIndicator = ({
   <div className="flex items-center gap-2 sm:gap-3">
     <div
       className={`flex h-6 w-6 items-center justify-center rounded-full font-bold text-xs transition-colors sm:h-8 sm:w-8 sm:text-sm ${
-        isActive ? 'bg-bg-primary text-fg-onFill' : 'bg-bg-mute text-fg-mute'
+        isActive ? 'bg-primary-bg text-primary-fg' : 'bg-bg-mute text-fg-mute'
       }`}
     >
       {step}

--- a/apps/main/src/app/text-diff/_components/text-diff/diff-output.tsx
+++ b/apps/main/src/app/text-diff/_components/text-diff/diff-output.tsx
@@ -10,7 +10,7 @@ type DiffOutputProps = {
 export const DiffOutput: FC<DiffOutputProps> = ({ diff }) => {
   if (diff.length === 0) {
     return (
-      <p className="text-fg-muted">
+      <p className="text-fg-mute">
         テキストを入力すると、差分がここに表示されます
       </p>
     );
@@ -24,7 +24,7 @@ export const DiffOutput: FC<DiffOutputProps> = ({ diff }) => {
     !firstDiff.added &&
     !firstDiff.removed
   ) {
-    return <p className="text-fg-muted">差分はありません</p>;
+    return <p className="text-fg-mute">差分はありません</p>;
   }
 
   return (


### PR DESCRIPTION
## Summary
- ArteOdyssey CSSに定義されていない無効なトークン（例: `text-fg-muted` → `text-fg-mute`、`bg-primary-base` → `bg-primary-bg`、`text-fg-danger` → `text-fg-error`、`bg-bg-baseHover` → `hover:bg-bg-subtle` など）を有効なトークンに置換
- 標準Tailwindの色（`bg-white`、`bg-green-500`、`backdrop:bg-black/50`、`text-white`）をArteOdyssey トークン（`bg-border-success`、`backdrop:bg-back-drop`）またはinline style（`var(--white)`）に置換
- 検出ルール（lint scriptとCI step）の追加は別PRに分離

## Test plan
- [x] `pnpm run check` (Biome) パス
- [x] `pnpm run type-check` パス
- [ ] 視覚確認: contribution graph、view-transition playgrounds、QRジェネレーター、SQLテーブルビルダー、admin reading-list の表示崩れがないこと