### PR TITLE
refactor: contribution graphをGitHub contribution calendarに切替

### DIFF
--- a/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.tsx
@@ -1,9 +1,9 @@
-import { getRepositoryCommitContributions } from '@/features/github/interface/queries';
+import { getUserContributions } from '@/features/github/interface/queries';
 
 import { Presenter } from './presenter';
 
 export const GitHubContributionGraph = async () => {
-  const days = await getRepositoryCommitContributions();
+  const days = await getUserContributions();
 
   return <Presenter days={days} />;
 };

--- a/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
@@ -51,7 +51,7 @@ export const Presenter: FC<{
               )}
             />
             <ArteTooltip.Content>
-              k8o・artifactsリポジトリへのコミット履歴
+              GitHub上のコントリビューション履歴（commit / PR / issue / review）
             </ArteTooltip.Content>
           </ArteTooltip.Root>
         </div>
@@ -111,7 +111,9 @@ const CustomTooltip: FC<{
 
   return (
     <div className="bg-bg-base text-fg-base rounded-xl px-3 py-2 shadow-md">
-      <p className="text-sm font-semibold">{item.count}件のコミット</p>
+      <p className="text-sm font-semibold">
+        {item.count}件のコントリビューション
+      </p>
       <p className="text-fg-mute text-xs">{formattedDate}</p>
     </div>
   );

--- a/apps/main/src/features/github/infrastructure/contributions.test.ts
+++ b/apps/main/src/features/github/infrastructure/contributions.test.ts
@@ -1,4 +1,4 @@
-import { fetchRepositoryCommitContributions } from './contributions';
+import { fetchUserContributions } from './contributions';
 
 const graphqlMock = vi.fn();
 
@@ -10,7 +10,7 @@ vi.mock('octokit', () => ({
   }),
 }));
 
-describe('fetchRepositoryCommitContributions', () => {
+describe('fetchUserContributions', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.useFakeTimers();
@@ -26,23 +26,23 @@ describe('fetchRepositoryCommitContributions', () => {
   it('GITHUB_TOKENが未設定の場合はエラーを投げる', async () => {
     vi.stubEnv('GITHUB_TOKEN', undefined);
 
-    await expect(
-      fetchRepositoryCommitContributions('k35o', 'k35o', 'k8o'),
-    ).rejects.toThrow('GITHUB_TOKEN is not configured');
+    await expect(fetchUserContributions('k35o')).rejects.toThrow(
+      'GITHUB_TOKEN is not configured',
+    );
   });
 
-  it('対象リポジトリが見つからない場合は直近14日分を0件で返す', async () => {
+  it('カレンダーが空の場合は直近14日分を0件で返す', async () => {
     graphqlMock.mockResolvedValue({
       user: {
         contributionsCollection: {
-          commitContributionsByRepository: [],
+          contributionCalendar: {
+            weeks: [],
+          },
         },
       },
     });
 
-    await expect(
-      fetchRepositoryCommitContributions('k35o', 'k35o', 'k8o'),
-    ).resolves.toEqual([
+    await expect(fetchUserContributions('k35o')).resolves.toEqual([
       { date: '2026-03-14', count: 0 },
       { date: '2026-03-15', count: 0 },
       { date: '2026-03-16', count: 0 },
@@ -65,99 +65,46 @@ describe('fetchRepositoryCommitContributions', () => {
         userName: 'k35o',
         from: '2026-03-13T15:00:00.000Z',
         to: '2026-03-27T14:59:59.999Z',
-        after: null,
-        pageSize: 100,
       }),
     );
   });
 
-  it('ページングしながら対象リポジトリのコミット数を日付ごとに集計する', async () => {
-    graphqlMock
-      .mockResolvedValueOnce({
-        user: {
-          contributionsCollection: {
-            commitContributionsByRepository: [
+  it('カレンダーの日次コントリビューションを期間内で集計する', async () => {
+    graphqlMock.mockResolvedValue({
+      user: {
+        contributionsCollection: {
+          contributionCalendar: {
+            weeks: [
               {
-                repository: {
-                  owner: {
-                    login: 'k35o',
-                  },
-                  name: 'k8o',
-                },
-                contributions: {
-                  pageInfo: {
-                    hasNextPage: true,
-                    endCursor: 'cursor-1',
-                  },
-                  nodes: [
-                    {
-                      occurredAt: '2026-03-20T10:00:00.000Z',
-                      commitCount: 2,
-                    },
-                    {
-                      occurredAt: '2026-03-20T23:00:00.000Z',
-                      commitCount: 1,
-                    },
-                  ],
-                },
+                contributionDays: [
+                  { date: '2026-03-14', contributionCount: 0 },
+                  { date: '2026-03-15', contributionCount: 2 },
+                ],
+              },
+              {
+                contributionDays: [
+                  { date: '2026-03-20', contributionCount: 3 },
+                  { date: '2026-03-21', contributionCount: 4 },
+                ],
+              },
+              {
+                // 期間外の日付は無視される
+                contributionDays: [
+                  { date: '2026-03-28', contributionCount: 99 },
+                ],
               },
             ],
           },
         },
-      })
-      .mockResolvedValueOnce({
-        user: {
-          contributionsCollection: {
-            commitContributionsByRepository: [
-              {
-                repository: {
-                  owner: {
-                    login: 'k35o',
-                  },
-                  name: 'k8o',
-                },
-                contributions: {
-                  pageInfo: {
-                    hasNextPage: false,
-                    endCursor: null,
-                  },
-                  nodes: [
-                    {
-                      occurredAt: '2026-03-21T00:30:00.000Z',
-                      commitCount: 4,
-                    },
-                  ],
-                },
-              },
-            ],
-          },
-        },
-      });
+      },
+    });
 
-    const result = await fetchRepositoryCommitContributions(
-      'k35o',
-      'k35o',
-      'k8o',
-    );
+    const result = await fetchUserContributions('k35o');
 
-    expect(graphqlMock).toHaveBeenCalledTimes(2);
-    expect(graphqlMock).toHaveBeenNthCalledWith(
-      1,
-      expect.any(String),
-      expect.objectContaining({
-        after: null,
-      }),
-    );
-    expect(graphqlMock).toHaveBeenNthCalledWith(
-      2,
-      expect.any(String),
-      expect.objectContaining({
-        after: 'cursor-1',
-      }),
-    );
+    expect(graphqlMock).toHaveBeenCalledTimes(1);
     expect(result).toEqual([
       { date: '2026-03-14', count: 0 },
-      { date: '2026-03-15', count: 0 },
+      { date: '2026-03-15', count: 2 },
       { date: '2026-03-16', count: 0 },
       { date: '2026-03-17', count: 0 },
       { date: '2026-03-18', count: 0 },

--- a/apps/main/src/features/github/infrastructure/contributions.ts
+++ b/apps/main/src/features/github/infrastructure/contributions.ts
@@ -7,46 +7,29 @@ import {
   getJstUtcStart,
 } from './jst';
 
-export type ContributionDay = {
+type ContributionDay = {
   date: string;
   count: number;
 };
 
 const CONTRIBUTION_DAYS = 14;
 const LAST_DAY_INDEX = CONTRIBUTION_DAYS - 1;
-const GITHUB_CONTRIBUTION_PAGE_SIZE = 100;
 
-type ContributionResponse = {
+type ContributionCalendarResponse = {
   user: {
     contributionsCollection: {
-      commitContributionsByRepository: Array<{
-        repository: {
-          owner: {
-            login: string;
-          };
-          name: string;
-        };
-        contributions: {
-          pageInfo: {
-            hasNextPage: boolean;
-            endCursor: string | null;
-          };
-          nodes: Array<{
-            occurredAt: string;
-            commitCount: number;
+      contributionCalendar: {
+        weeks: Array<{
+          contributionDays: Array<{
+            date: string;
+            contributionCount: number;
           }>;
-        };
-      }>;
+        }>;
+      };
     };
   };
 };
 
-type RepositoryContributions =
-  ContributionResponse['user']['contributionsCollection']['commitContributionsByRepository'][number];
-
-/**
- * 直近の期間の日付範囲を計算
- */
 function _getDateRange(): { from: string; to: string } {
   const now = new Date();
   const toDate = getJstDateBase(now);
@@ -59,12 +42,10 @@ function _getDateRange(): { from: string; to: string } {
 }
 
 /**
- * k8oリポジトリ専用のコントリビューションデータを取得（直近2週間）
+ * ユーザーのコントリビューション（commit / PR / issue / review）を直近2週間分取得
  */
-export async function fetchRepositoryCommitContributions(
+export async function fetchUserContributions(
   username: string,
-  owner: string,
-  repo: string,
 ): Promise<ContributionDay[]> {
   const token = process.env['GITHUB_TOKEN'];
 
@@ -77,24 +58,14 @@ export async function fetchRepositoryCommitContributions(
   const { from, to } = _getDateRange();
 
   const query = `
-    query($userName:String!, $from:DateTime!, $to:DateTime!, $after:String, $pageSize:Int!) {
+    query($userName:String!, $from:DateTime!, $to:DateTime!) {
       user(login: $userName) {
         contributionsCollection(from: $from, to: $to) {
-          commitContributionsByRepository(maxRepositories: 100) {
-            repository {
-              owner {
-                login
-              }
-              name
-            }
-            contributions(first: $pageSize, after: $after) {
-              pageInfo {
-                hasNextPage
-                endCursor
-              }
-              nodes {
-                occurredAt
-                commitCount
+          contributionCalendar {
+            weeks {
+              contributionDays {
+                date
+                contributionCount
               }
             }
           }
@@ -103,64 +74,17 @@ export async function fetchRepositoryCommitContributions(
     }
   `;
 
+  const response: ContributionCalendarResponse = await octokit.graphql(query, {
+    userName: username,
+    from: getJstUtcStart(from),
+    to: getJstUtcEnd(to),
+  });
+
   const contributionMap = new Map<string, number>();
-  const createRepoContributionsIterator =
-    (): AsyncIterable<RepositoryContributions> => {
-      let cursor: string | null = null;
-      let done = false;
-
-      return {
-        [Symbol.asyncIterator]: () => ({
-          next: async () => {
-            if (done) {
-              return { done: true, value: undefined };
-            }
-
-            const response: ContributionResponse = await octokit.graphql(
-              query,
-              {
-                userName: username,
-                from: getJstUtcStart(from),
-                to: getJstUtcEnd(to),
-                after: cursor,
-                pageSize: GITHUB_CONTRIBUTION_PAGE_SIZE,
-              },
-            );
-
-            const repoContributions =
-              response.user.contributionsCollection.commitContributionsByRepository.find(
-                (r) =>
-                  r.repository.owner.login === owner &&
-                  r.repository.name === repo,
-              );
-
-            if (repoContributions === undefined) {
-              done = true;
-              return { done: true, value: undefined };
-            }
-
-            const { pageInfo } = repoContributions.contributions;
-            if (pageInfo.hasNextPage && pageInfo.endCursor !== null) {
-              cursor = pageInfo.endCursor;
-            } else {
-              done = true;
-            }
-
-            return { done: false, value: repoContributions };
-          },
-        }),
-      };
-    };
-
-  for await (const repoContributions of createRepoContributionsIterator()) {
-    for (const contribution of repoContributions.contributions.nodes) {
-      const date = contribution.occurredAt.split('T')[0];
-      if (date !== undefined) {
-        contributionMap.set(
-          date,
-          (contributionMap.get(date) ?? 0) + contribution.commitCount,
-        );
-      }
+  for (const week of response.user.contributionsCollection.contributionCalendar
+    .weeks) {
+    for (const day of week.contributionDays) {
+      contributionMap.set(day.date, day.contributionCount);
     }
   }
 

--- a/apps/main/src/features/github/interface/queries.ts
+++ b/apps/main/src/features/github/interface/queries.ts
@@ -1,58 +1,17 @@
 import { cacheLife } from 'next/cache';
 
-import { getArtifacts } from '@/features/artifacts/interface/queries';
-
-import { fetchRepositoryCommitContributions } from '../infrastructure/contributions';
+import { fetchUserContributions } from '../infrastructure/contributions';
 
 export type ContributionDay = Awaited<
-  ReturnType<typeof fetchRepositoryCommitContributions>
+  ReturnType<typeof fetchUserContributions>
 >[number];
 
 const USERNAME = 'k35o';
-const OWNER = 'k35o';
 
-function parseGitHubRepo(
-  githubUrl: string,
-): { owner: string; repo: string } | null {
-  const match = /^https:\/\/github\.com\/([^/]+)\/([^/]+)/.exec(githubUrl);
-  if (match?.[1] === undefined || match[2] === undefined) {
-    return null;
-  }
-  return { owner: match[1], repo: match[2] };
-}
-
-function mergeContributions(results: ContributionDay[][]): ContributionDay[] {
-  const mergedMap = new Map<string, ContributionDay>();
-  for (const days of results) {
-    for (const day of days) {
-      const existing = mergedMap.get(day.date);
-      mergedMap.set(day.date, {
-        ...day,
-        count: (existing?.count ?? 0) + day.count,
-      });
-    }
-  }
-
-  return Array.from(mergedMap.values()).toSorted((a, b) =>
-    a.date.localeCompare(b.date),
-  );
-}
-
-export async function getRepositoryCommitContributions() {
+export async function getUserContributions() {
   'use cache';
   cacheLife('minutes');
 
-  const artifactRepos = getArtifacts()
-    .map((artifact) => parseGitHubRepo(artifact.githubUrl))
-    .filter((repo): repo is { owner: string; repo: string } => repo !== null);
-
-  const repos = [{ owner: OWNER, repo: 'k8o' }, ...artifactRepos];
-
-  const results = await Promise.all(
-    repos.map(({ owner, repo }) =>
-      fetchRepositoryCommitContributions(USERNAME, owner, repo),
-    ),
-  );
-
-  return mergeContributions(results);
+  const days = await fetchUserContributions(USERNAME);
+  return days;
 }


### PR DESCRIPTION
## 概要

トップページの「開発の足あと」グラフのデータソースを、`contributionCalendar` クエリに置き換えました。

## 動機

これまでは `k8o` リポジトリと artifacts に登録された GitHub URL を列挙し、リポジトリごとに `commitContributionsByRepository` を叩いていました。新規開発中のリポジトリは artifacts に登録するまでグラフに乗らず、対象リポジトリの指定そのものも管理コストになっていました。

ユーザー単位の `contributionCalendar` に切り替えることで、

- リポジトリ allowlist が不要になり、新規開発中のリポジトリも自動で反映される
- GraphQL リクエストが repo 数ぶんから 1 回に減る
- artifacts 機能とコントリビューション機能の結合が解ける

## 詳細

- `fetchRepositoryCommitContributions(username, owner, repo)` を `fetchUserContributions(username)` に置き換え
- リポジトリ単位のページング、`createRepoContributionsIterator`、`mergeContributions`、`parseGitHubRepo`、`@/features/artifacts` 依存を削除
- interface 層のキャッシュエントリを `getUserContributions` にリネーム（`'use cache'` + `cacheLife('minutes')` は維持）
- グラフのツールチップ表記を「件のコミット」→「件のコントリビューション」、説明を「k8o・artifactsリポジトリへのコミット履歴」→「GitHub上のコントリビューション履歴（commit / PR / issue / review）」に変更
- 既存テストを新しいレスポンス shape に合わせて書き直し（3件パス）

## 気をつけるポイント

- グラフの値の意味が「commit 数」から GitHub プロフィールと同じ「コントリビューション数（commit + PR + issue + review）」に変わります。表示文言もそれに合わせています
- private リポジトリの貢献は GitHub プロフィール側の "Include private contributions" 設定に従います

## 影響範囲

- `apps/main` トップの `GitHubContributionGraph`
- artifacts 機能側はインポート関係が解消されるだけで、機能変更はありません

## テスト

- `pnpm -F main test contributions.test` パス
- `pnpm -F main type-check` パス