### PR TITLE
feat: add contrast-color() blog post and align color tools

### DIFF
--- a/apps/main/src/app/_components/playgrounds/contrast-color/contrast-color-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/contrast-color/contrast-color-demo.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Playground } from '../playground';
+import { ContrastColorDemo } from './contrast-color-demo';
+
+const playgroundTitle = ContrastColorDemo.name;
+
+const meta: Meta<typeof ContrastColorDemo> = {
+  title: 'playgrounds/contrast-color/ContrastColorDemo',
+  component: ContrastColorDemo,
+  decorators: [
+    (Story) => (
+      <Playground title={playgroundTitle}>
+        <Story />
+      </Playground>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ContrastColorDemo>;
+
+export const Default: Story = {};

--- a/apps/main/src/app/_components/playgrounds/contrast-color/contrast-color-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/contrast-color/contrast-color-demo.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { FormControl, TextField } from '@k8o/arte-odyssey';
+import { useState } from 'react';
+
+const isHexColor = (value: string) => /^#[0-9a-fA-F]{6}$/.test(value);
+
+export function ContrastColorDemo() {
+  const [backgroundColor, setBackgroundColor] = useState('#2563eb');
+
+  return (
+    <div className="flex flex-col gap-6">
+      <FormControl
+        label="背景色"
+        renderInput={({ labelId: _, ...props }) => (
+          <div className="flex items-center gap-3">
+            <label
+              className="border-border-base relative size-10 shrink-0 cursor-pointer overflow-hidden rounded-full border-2"
+              style={{
+                backgroundColor: isHexColor(backgroundColor)
+                  ? backgroundColor
+                  : '#2563eb',
+              }}
+            >
+              <input
+                aria-label="カラーピッカー"
+                className="absolute inset-0 size-full cursor-pointer opacity-0"
+                onChange={(e) => {
+                  setBackgroundColor(e.target.value);
+                }}
+                type="color"
+                value={
+                  isHexColor(backgroundColor) ? backgroundColor : '#2563eb'
+                }
+              />
+            </label>
+            <TextField
+              onChange={(e) => {
+                setBackgroundColor(e.currentTarget.value);
+              }}
+              value={backgroundColor}
+              {...props}
+            />
+          </div>
+        )}
+      />
+
+      <div
+        className="flex h-40 items-center justify-center rounded-xl p-8 text-xl font-bold shadow-sm"
+        style={{
+          backgroundColor,
+          color: `contrast-color(${backgroundColor})`,
+        }}
+      >
+        この文字色は contrast-color() で決まっています
+      </div>
+
+      <div className="bg-bg-subtle rounded-xl p-4">
+        <p className="font-mono text-sm">
+          color: contrast-color({backgroundColor})&#x3B;
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/app/_components/playgrounds/contrast-color/index.ts
+++ b/apps/main/src/app/_components/playgrounds/contrast-color/index.ts
@@ -1,0 +1,19 @@
+import type { PlaygroundSection } from '../types';
+import { ContrastColorDemo } from './contrast-color-demo';
+
+export { ContrastColorDemo } from './contrast-color-demo';
+
+export const contrastColorSection: PlaygroundSection = {
+  id: 'contrast-color',
+  title: 'contrast-color',
+  description:
+    '背景色に対してコントラストの高い色（黒または白）を自動で返すCSS関数です。',
+  type: 'blog',
+  slug: 'contrast-color',
+  demos: [
+    {
+      component: ContrastColorDemo,
+      title: 'contrast-color()のデモ',
+    },
+  ],
+};

--- a/apps/main/src/app/_components/playgrounds/index.ts
+++ b/apps/main/src/app/_components/playgrounds/index.ts
@@ -6,6 +6,7 @@ export * from './async-clipboard';
 export * from './caret-position-from-point';
 export * from './composed-ranges';
 export * from './content-visibility';
+export * from './contrast-color';
 export * from './details-content';
 export * from './event-timing';
 export * from './font-family-math';
@@ -34,6 +35,7 @@ import { asyncClipboardSection } from './async-clipboard';
 import { caretPositionFromPointSection } from './caret-position-from-point';
 import { composedRangesSection } from './composed-ranges';
 import { contentVisibilitySection } from './content-visibility';
+import { contrastColorSection } from './contrast-color';
 import { detailsContentSection } from './details-content';
 import { eventTimingSection } from './event-timing';
 import { fontFamilyMathSection } from './font-family-math';
@@ -62,6 +64,7 @@ export const playgroundSections: PlaygroundSection[] = [
   caretPositionFromPointSection,
   composedRangesSection,
   contentVisibilitySection,
+  contrastColorSection,
   detailsContentSection,
   eventTimingSection,
   fontFamilyMathSection,

--- a/apps/main/src/app/blog/(articles)/contrast-color/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/contrast-color/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+const slug = 'contrast-color';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt,
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/contrast-color'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/contrast-color/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/contrast-color/opengraph-image.tsx
@@ -1,0 +1,20 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+export const alt =
+  'contrast-color()で背景色に応じた読みやすい文字色を自動で割り当てる';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const blog = await getBlogContent('contrast-color');
+
+  return OgImage({
+    category: 'Blog',
+    title: blog.title,
+  });
+}

--- a/apps/main/src/app/blog/(articles)/contrast-color/page.mdx
+++ b/apps/main/src/app/blog/(articles)/contrast-color/page.mdx
@@ -1,0 +1,85 @@
+---
+title: 'contrast-color()で背景色に応じた読みやすい文字色を自動で割り当てる'
+description: 'contrast-color()は背景色に対してコントラストの高い色（黒または白）を返すCSS関数です。Baseline 2026に到達し、テーマカラーやユーザー入力で背景色が動的に変わる場面でも、文字色をCSS側で導出して読みやすさを担保できます。'
+createdAt: 2026-05-03
+updatedAt: 2026-05-03
+featureIds:
+  - contrast-color
+---
+
+import { BaselineStatus } from '@k8o/arte-odyssey';
+import { ContrastColorDemo } from '@/app/_components/playgrounds/contrast-color';
+import { Playground } from '@/app/_components/playgrounds';
+import { LinkCard } from '@/app/_components/link-card';
+
+# contrast-color()で背景色に応じた読みやすい文字色を自動で割り当てる
+
+<BaselineStatus featureId="contrast-color"></BaselineStatus>
+
+## はじめに
+
+ボタンの背景色やテーマカラーをユーザーが選べる場面では、背景色に対して文字色が読みづらくなることがあります。
+これまでは背景色ごとにコントラスト比の高い文字色を選定し、背景色とペアにしてデザイントークンや CSS カスタムプロパティで持ち回る必要がありました。
+
+`contrast-color()`は、与えた色に対してコントラストが高い色（黒または白）を返す CSS 関数です。
+Safari 26、Firefox 146、Chrome 147 と一通り揃い、Baseline 2026 に到達しました。背景色さえ決めれば、ペアの文字色を毎回用意せずに済むようになります。
+
+## 文法
+
+引数に背景色相当の`<color>`値を 1 つ渡すだけです。返り値は`white`か`black`のいずれかで、背景色とのコントラストが高い方が選ばれます。両者のコントラストが等しい場合は`white`になります。
+
+```css
+.button {
+  background-color: lightblue;
+  color: contrast-color(lightblue);
+}
+```
+
+CSS カスタムプロパティと組み合わせると、背景色と文字色の対応関係を一箇所で管理できます。
+
+```css
+.button {
+  --button-bg: #2563eb;
+  background-color: var(--button-bg);
+  color: contrast-color(var(--button-bg));
+}
+```
+
+<Playground title="contrast-color()のデモ">
+  <ContrastColorDemo />
+</Playground>
+
+## 中間トーンの背景色は注意が必要
+
+候補が黒と白しかないため、`contrast-color()`が返せるコントラスト比には上限があります。[色のコントラスト比](/blog/color-contrast)の記事で紹介した WCAG 2.1 の式に当てはめると、背景色 $X$ の相対輝度 $L$ ($0 \leqq L \leqq 1$) について、黒・白それぞれとのコントラスト比 $C_b$、$C_w$ は次のようになります。
+
+```math
+C_b = \frac{L + 0.05}{0.05}, \quad C_w = \frac{1.05}{L + 0.05}
+```
+
+両者の積を取ると $L + 0.05$ が打ち消し合い、$L$ に依存しない定数になります。
+
+```math
+C_b \cdot C_w = \frac{1.05}{0.05} = 21
+```
+
+積が固定値なので、相加相乗平均の不等式より、$C_b$ と $C_w$ の大きい方は常に $\sqrt{21}$ 以上になります。
+
+```math
+\max(C_b, C_w) \geqq \sqrt{C_b \cdot C_w} = \sqrt{21} \approx 4.58
+```
+
+等号成立は $C_b = C_w$ のとき、すなわち $L \approx 0.179$ のときです。`contrast-color()`の返り値は最悪ケースでも 4.58:1 を確保しますが、これ以上の比は引き出せません。
+
+たとえば`#2277d3`では黒で 4.65:1、白で 4.52:1 となり、WCAG AA（4.5:1）をぎりぎり満たす程度です。上限が約 4.58:1 なので、AAA の 7:1 は中間トーンの背景色全般で達成できません。
+`contrast-color()`によってある程度安定した文字色を確保する手段があるとはいえ、読みやすさのマージンを取るには背景色そのものを明るい側か暗い側のどちらかに振った設計にしておく方が確実です。もっとも、これは`contrast-color()`に限った話ではなく、文字と背景の関係全般に当てはまる設計指針です。
+
+<LinkCard href="https://drafts.csswg.org/css-color-5/#contrast-color" />
+
+## おわりに
+
+`contrast-color()`を紹介しました。背景色から文字色を導出する処理を CSS 側に閉じ込められるので、テーマカラーやユーザー設定で背景色が変わるコンポーネントを書くときに役立ちます。
+
+なお、今回紹介したのは黒・白の二択しか返さない最小版です。CSS Color Module Level 6 では、複数の候補色と目標コントラスト比を引数に取れる発展版も議論されています。実装されれば、ブランドカラーの候補から条件を満たす色を選ばせるような使い方も視野に入ってきます。
+
+<LinkCard href="https://drafts.csswg.org/css-color-6/#funcdef-contrast-color" />

--- a/apps/main/src/app/color-converter/_components/color-converter/color-tip.tsx
+++ b/apps/main/src/app/color-converter/_components/color-converter/color-tip.tsx
@@ -1,36 +1,18 @@
 import type { FC } from 'react';
 
-// 色の明るさを判定してテキストカラーを決定する
-const getOverlayColor = (hex: string): string | undefined => {
-  const clean = hex.replace('#', '');
-  if (clean.length < 6) return undefined;
-  const r = Number.parseInt(clean.slice(0, 2), 16);
-  const g = Number.parseInt(clean.slice(2, 4), 16);
-  const b = Number.parseInt(clean.slice(4, 6), 16);
-  if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) {
-    return undefined;
-  }
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luminance > 0.5 ? '#000000' : '#ffffff';
-};
-
 export const ColorTip: FC<{ color: string; hex: string }> = ({
   color,
   hex,
-}) => {
-  const overlayColor = getOverlayColor(color);
-
-  return (
-    <div
-      className="bg-bg-mute flex h-36 w-full items-center justify-center rounded-xl transition-colors duration-200"
-      style={{ backgroundColor: color }}
+}) => (
+  <div
+    className="bg-bg-mute flex h-36 w-full items-center justify-center rounded-xl transition-colors duration-200"
+    style={{ backgroundColor: color }}
+  >
+    <p
+      className="text-2xl font-bold tracking-wider select-all"
+      style={{ color: `contrast-color(${color})` }}
     >
-      <p
-        className="text-2xl font-bold tracking-wider select-all"
-        style={overlayColor === undefined ? undefined : { color: overlayColor }}
-      >
-        #{hex}
-      </p>
-    </div>
-  );
-};
+      #{hex}
+    </p>
+  </div>
+);

--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
@@ -3,7 +3,6 @@
 import { Badge, Button } from '@k8o/arte-odyssey';
 import type { FC } from 'react';
 
-import { getContrastTextColor } from '../../_utils/color-quiz';
 import { useColorQuiz } from './use-color-quiz';
 
 export const ColorToHex: FC = () => {
@@ -27,7 +26,7 @@ export const ColorToHex: FC = () => {
         {phase === 'result' && (
           <p
             className="text-lg font-bold tracking-wider"
-            style={{ color: getContrastTextColor(targetHex) }}
+            style={{ color: `contrast-color(#${targetHex})` }}
           >
             #{targetHex}
           </p>
@@ -49,7 +48,7 @@ export const ColorToHex: FC = () => {
                   <p
                     className="text-sm font-bold tracking-wider"
                     style={{
-                      color: getContrastTextColor(selectedHex),
+                      color: `contrast-color(#${selectedHex})`,
                     }}
                   >
                     #{selectedHex}
@@ -65,7 +64,7 @@ export const ColorToHex: FC = () => {
                   <p
                     className="text-sm font-bold tracking-wider"
                     style={{
-                      color: getContrastTextColor(targetHex),
+                      color: `contrast-color(#${targetHex})`,
                     }}
                   >
                     #{targetHex}

--- a/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
@@ -3,7 +3,6 @@
 import { Badge, Button } from '@k8o/arte-odyssey';
 import type { FC } from 'react';
 
-import { getContrastTextColor } from '../../_utils/color-quiz';
 import { useColorQuiz } from './use-color-quiz';
 
 export const HexToColor: FC = () => {
@@ -63,7 +62,7 @@ export const HexToColor: FC = () => {
                 <p
                   className="text-sm font-bold tracking-wider"
                   style={{
-                    color: getContrastTextColor(hex),
+                    color: `contrast-color(#${hex})`,
                   }}
                 >
                   #{hex}

--- a/apps/main/src/app/color-quiz/_utils/color-quiz.ts
+++ b/apps/main/src/app/color-quiz/_utils/color-quiz.ts
@@ -18,16 +18,6 @@ const colorDistance = (hex1: string, hex2: string): number => {
   return Math.hypot(c1.r - c2.r, c1.g - c2.g, c1.b - c2.b);
 };
 
-// 色の明るさを判定してテキストカラーを決定する
-const getOverlayColor = (hex: string): string => {
-  const { r, g, b } = hexToRgb(hex);
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luminance > 0.5 ? '#000000' : '#ffffff';
-};
-
-export const getContrastTextColor = (hex: string): string =>
-  getOverlayColor(hex);
-
 const MIN_DISTANCE_FROM_CORRECT = 40;
 const MIN_DISTANCE_BETWEEN_OPTIONS = 25;
 

--- a/packages/database/migrations/0039_busy_prodigy.sql
+++ b/packages/database/migrations/0039_busy_prodigy.sql
@@ -1,0 +1,13 @@
+-- 新しいタグの追加
+INSERT INTO tags (id, name) VALUES (128, 'contrast-color');--> statement-breakpoint
+-- ブログレコードの追加
+INSERT INTO blogs (id, slug, published, created_at)
+VALUES (65, 'contrast-color', 1, '2026-05-03T00:00:00.000Z');--> statement-breakpoint
+-- ビューカウント初期化
+INSERT INTO blog_views (blog_id, views) VALUES (65, 0);--> statement-breakpoint
+-- タグ紐付け (color contrast: 4, color: 8, CSS: 30, Baseline 2026: 99, contrast-color: 128)
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (65, 4);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (65, 8);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (65, 30);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (65, 99);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (65, 128);

--- a/packages/database/migrations/meta/0039_snapshot.json
+++ b/packages/database/migrations/meta/0039_snapshot.json
@@ -1,0 +1,1195 @@
+{
+  "id": "4cc7c374-eac4-4be9-99d8-4e597a758930",
+  "prevId": "b2925a30-8506-4318-b525-05f13e228dab",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "tableTo": "article_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_id_idx": {
+          "name": "comments_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_id_idx": {
+          "name": "talks_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1776924816680,
       "tag": "0038_flippant_sasquatch",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "6",
+      "when": 1777806384144,
+      "tag": "0039_busy_prodigy",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

Baseline 2026 に到達した CSS 関数 `contrast-color()` のブログ記事を追加し、関連する既存ツール（color-converter / color-quiz）の文字色決定ロジックを `contrast-color()` ベースに揃える。

## 動機

- `contrast-color()` が Safari 26 / Firefox 146 / Chrome 147 で揃い Baseline 2026 入りしたので紹介記事を書く
- 既存の color-converter / color-quiz では JS 側で輝度計算 (0.299R + 0.587G + 0.114B) して黒/白を選んでいたが、CSS の `contrast-color()` にそのまま置き換えられるので寄せる

## 詳細

### feat: contrast-color() 記事 + playground + migration

- `apps/main/src/app/blog/(articles)/contrast-color/` を新規追加（page.mdx、layout.tsx、opengraph-image.tsx）
- playground は `apps/main/src/app/_components/playgrounds/contrast-color/`：丸型カラーピッカー（label + 透明 input でWebKitスウォッチを回避）と TextField による自由入力で任意の CSS カラー (`oklch(...)`、名前付き色など) を試せる
- 数学的に `contrast(X, #000) × contrast(X, #fff) = 21` が常に成り立つことから `max ≥ √21 ≈ 4.58` を導出し、`#2277d3` での具体値（黒 4.65:1 / 白 4.52:1）も示す
- Baseline 2026 記事として未対応ブラウザ向けフォールバックには触れない方針
- L6 で議論されている発展版（複数候補色 + 目標コントラスト比）への言及を closing で追加
- migration は contrast-color タグ + ブログレコード + タグ紐付け

### refactor: color-converter ColorTip

- `getOverlayColor` の輝度計算を削除し、`style={{ color: \`contrast-color(${color})\` }}` に置換

### refactor: color-quiz options

- `getContrastTextColor` (= `getOverlayColor` ラッパー) を全 4 箇所で `contrast-color(#hex)` に置換
- `_utils/color-quiz.ts` から不要になった `getOverlayColor` / `getContrastTextColor` を削除

## 気をつけるポイント

- `contrast-color()` 未対応ブラウザでは `color` 宣言全体が無効化され文字色は親要素から継承される。Baseline 2026 達成済みのため許容する方針（今までの JS 輝度計算は黒/白を確実に返すフォールバック相当だったため、ここは regression）
- playground のカラーピッカーは `<label>` + `opacity-0` の `<input type="color">` を重ねる構成。クリックでネイティブピッカーが開く

## テスト

- `pnpm run type-check` 通過
- `pnpm run check` 0 errors（既存の test 関連 warnings のみ）
- 該当する Storybook テスト (ContrastColorDemo / ColorConverter / ColorQuiz) パス
- ローカル `https://main.localhost/blog/contrast-color` / `/color-converter` / `/color-quiz` が 200 で描画