### PR TITLE
fix: link-card の fetch 失敗を ErrorBoundary に伝搬させる

### DIFF
--- a/apps/main/src/app/_components/link-card/metadata.ts
+++ b/apps/main/src/app/_components/link-card/metadata.ts
@@ -14,13 +14,8 @@ export async function getMetadata(href: string) {
   'use cache';
   cacheLife('days');
 
-  let html: string;
-  try {
-    const res = await fetch(href, { signal: AbortSignal.timeout(5000) });
-    html = (await res.text()).trim();
-  } catch {
-    return { title: undefined, description: undefined, image: undefined };
-  }
+  const res = await fetch(href, { signal: AbortSignal.timeout(5000) });
+  const html = (await res.text()).trim();
   const rawTitle = /<title>(.*?)<\/title>/i.exec(html)?.[1];
   const rawOgTitle = /<meta\s+property="og:title"\s+content="(.*?)"/i.exec(
     html,


### PR DESCRIPTION
## 概要

reading-list の OGP 画像が読み込まれないことが多い問題を修正。

## 動機

本番 https://www.k8o.me/reading-list を確認したところ、502件のカードのうち **188件 (約37%) で画像が表示されていない**状態だった。Cloudflare、Frontend Masters、Vercel、Node.js など主要メディアの記事でも欠落しており、それらの URL を Node の fetch で直接取得すると og:image は正常に取れる。

原因は `metadata.ts` の `try/catch` にある。

```ts
'use cache';
cacheLife('days');
try {
  const res = await fetch(href, { signal: AbortSignal.timeout(5000) });
  html = (await res.text()).trim();
} catch {
  return { title: undefined, description: undefined, image: undefined };
}
```

Vercel ランタイムからの fetch が一時的に失敗 (5秒タイムアウト・コールドスタート・upstream の瞬間的なエラーなど) すると、空のオブジェクトが返却される。これが `'use cache'` + `cacheLife('days')` によって**1日キャッシュ**されるため、一度失敗したカードは翌日まで画像が出ない。

## 詳細

`try/catch` を削除して fetch 失敗を throw として伝搬させる。`'use cache'` は throw された結果をキャッシュしないため、次回リクエストで自動的に再フェッチされる。エラー時のフォールバック表示は既存の `LinkCardErrorBoundary` (`fallback={<LinkCardFallback />}`) が引き続き担当する。

## 気をつけるポイント

- ユーザーから見える挙動は変わらない (失敗時のフォールバック表示は同じ)
- 失敗ケースが Suspense 境界 → ErrorBoundary に到達するため、観測可能なエラーが増える可能性あり
- 画像が出ないケースは依然として残る (og:image 自体がないサイト・相対 URL のサイトなど) — これらは別途対応

## 影響範囲

- `/reading-list`
- ブログ本文中の `LinkCard` (記事中の外部リンクカード)

## 残課題 (本 PR のスコープ外)

- og:image が相対 URL のサイトで壊れる (絶対 URL 化していない)
- 正規表現が `name="og:image"` / 属性順違い / シングルクォートに非対応
- 5秒タイムアウトはサーバーサイド fetch にしてはやや短い