### PR TITLE
fix: link-card prerender 時のタイムアウトでビルドが落ちないようにする

### DIFF
--- a/apps/main/src/app/_components/link-card/link-card.stories.tsx
+++ b/apps/main/src/app/_components/link-card/link-card.stories.tsx
@@ -79,3 +79,12 @@ export const NoImage: Story = {
     });
   },
 };
+
+export const FetchFailure: Story = {
+  args: {
+    href: 'https://example.com',
+  },
+  beforeEach: () => {
+    mocked(getMetadata).mockRejectedValue(new Error('fetch failed'));
+  },
+};

--- a/apps/main/src/app/_components/link-card/link-card.tsx
+++ b/apps/main/src/app/_components/link-card/link-card.tsx
@@ -36,7 +36,12 @@ const Content: FC<{
   publishedAt?: Date | string | undefined;
   appearance?: LinkCardAppearance;
 }> = async ({ href, publishedAt, appearance = 'shadow' }) => {
-  const metaData = await getMetadata(href);
+  let metaData;
+  try {
+    metaData = await getMetadata(href);
+  } catch {
+    return <LinkCardFallback appearance={appearance} href={href} />;
+  }
 
   if (
     metaData.title === undefined &&


### PR DESCRIPTION
## Summary
- prerender (Static Page Generation) 時に link-card の外部 fetch が `AbortSignal.timeout(5000)` で失敗すると Vercel 本番ビルドが落ちる問題を修正
- `Content` (Server Component) 内で try/catch して `LinkCardFallback` を返すようにする

## 背景
[deploy 8e6BUMMRdJsWEqUEBD5HULibwQFb](https://vercel.com/k8o/k8o/8e6BUMMRdJsWEqUEBD5HULibwQFb) で本番デプロイが Static Page Generation 中に `TimeoutError (code: 23)` で失敗していた。

`608bdf75` で `getMetadata` の try/catch を外し、失敗時のキャッシュ汚染を防ぐ意図でエラーを伝搬させる変更を入れたが、`LinkCardErrorBoundary` (`unstable_catchError`) が `'use client'` でクライアント側 boundary のため、prerender (Server) で投げられた error を catch できず Static Page Generation が落ちる構造になっていた。

## 修正方針
- `getMetadata` の throw 挙動は維持 (失敗結果の `'use cache'` 汚染を防ぐ意図を保つ)
- `Content` (Server Component) 内で try/catch して `LinkCardFallback` を返すことで Server レイヤーで吸収
- `LinkCardErrorBoundary` は `getMetadata` 以外の予期せぬ error 用のセーフティネットとして残す
- 失敗ケースをカバーする `FetchFailure` story を追加

## 動作確認
- [x] `pnpm run type-check` 全パッケージ成功
- [x] `pnpm run check` エラー0
- [x] `pnpm -F main run test --project=storybook` 241 tests 全 pass (FetchFailure story 含む)

## Test plan
- [ ] Vercel Preview で `next build` の Static Page Generation が成功することを確認
- [ ] Vercel 本番デプロイ後に `/reading-list` 等で link-card が正常表示されることを確認