### PR TITLE
fix: getMetadata 内で fetch 失敗を catch して本番ビルド失敗を解消

### DIFF
--- a/apps/main/src/app/_components/link-card/metadata.ts
+++ b/apps/main/src/app/_components/link-card/metadata.ts
@@ -14,8 +14,13 @@ export async function getMetadata(href: string) {
   'use cache';
   cacheLife('days');
 
-  const res = await fetch(href, { signal: AbortSignal.timeout(5000) });
-  const html = (await res.text()).trim();
+  let html: string;
+  try {
+    const res = await fetch(href, { signal: AbortSignal.timeout(5000) });
+    html = (await res.text()).trim();
+  } catch {
+    return { title: undefined, description: undefined, image: undefined };
+  }
   const rawTitle = /<title>(.*?)<\/title>/i.exec(html)?.[1];
   const rawOgTitle = /<meta\s+property="og:title"\s+content="(.*?)"/i.exec(
     html,


### PR DESCRIPTION
## 緊急 hotfix
本番デプロイ ([dpl_7S9RLA2VUuiYTuuLaPLHRNwEBw3A](https://vercel.com/k8o/k8o/7S9RLA2VUuiYTuuLaPLHRNwEBw3A)) が ERROR 状態。前 PR #1732 で取り込まれた `Content` 側 try/catch だけでは prerender error を解消できず `/reading-list` で `fetch failed (ECONNRESET)` が build を落としていた。

## Summary
`getMetadata` 内でも try/catch して空オブジェクトを返すように戻す。

## 経緯
- 608bdf75: `getMetadata` の try/catch を外して失敗時のキャッシュ汚染を防ぐ意図
- PR #1732 (f14d326c): `Content` (Server Component) 内で try/catch する方針 → 修正不十分、`/reading-list` で prerender 失敗
- このPR (b18aabc2): `getMetadata` 内 try/catch も復活

## 仮説
`'use cache'` 関数が throw すると、Next.js Cache Components はそれを通常の Server Component 上位 try/catch とは別経路で扱い、Static Page Generation の build error として記録するため、呼び出し側 try/catch をすり抜ける挙動になっていた可能性。

## トレードオフ
- 失敗時に空オブジェクトが `cacheLife('days')` で 1 日キャッシュされる問題は再発（608bdf75 が解消した内容）
- しかし build 落ち >>> 1 日キャッシュ汚染、なので当面は build を通すことを優先
- 失敗時のキャッシュ汚染回避は別途対応する

## 動作確認
- [x] Preview deployment [dpl_8KBy8xn6pgzcHkiuqPDAZu6w2mDw](https://vercel.com/k8o/k8o/8KBy8xn6pgzcHkiuqPDAZu6w2mDw) が READY (Static Page Generation 成功)
- [x] `pnpm run type-check` 全パッケージ成功
- [x] `pnpm run check` エラー 0
- [x] `pnpm -F main run test --project=storybook` 241 tests pass

## Test plan
- [ ] マージ後 main の本番デプロイが READY になることを確認
- [ ] `/reading-list` 等で link-card が正常表示されることを確認