### PR TITLE
chore(ci): install Pavo for AI PR review

### DIFF
--- a/.github/workflows/pavo.yml
+++ b/.github/workflows/pavo.yml
@@ -1,0 +1,31 @@
+name: Pavo
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  pavo:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+    steps:
+      - id: app-token
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        with:
+          client-id: ${{ secrets.K35O_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.K35O_BOT_PRIVATE_KEY }}
+
+      - uses: k35o/pavo@1296c1e9ae03789c0e87f187fb8321f61f694890 # main
+        with:
+          github_token: ${{ steps.app-token.outputs.token }}
+          app_slug: ${{ steps.app-token.outputs.app-slug }}
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          instructions: default,nextjs
+          extra_prompt: |
+            Next.js App Router + oxlint のモノレポです。
+            apps/main / apps/admin の 2 アプリ + packages/ 配下の共有パッケージで構成。

--- a/.github/workflows/pavo.yml
+++ b/.github/workflows/pavo.yml
@@ -6,13 +6,22 @@ on:
   pull_request_review_comment:
     types: [created]
 
+# Same-PR pushes cancel earlier in-flight reviews so only the latest commit is reviewed.
+# event_name in the group keeps review and reply jobs from cancelling each other.
+concurrency:
+  group: pavo-${{ github.event_name }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   pavo:
+    # Skip on PRs from forks: secrets are not exposed to fork workflows so the App
+    # token step would fail anyway, and we don't want a permanent red Actions run.
+    if: ${{ github.event.pull_request.head.repo.fork != true }}
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
-      id-token: write
     steps:
       - id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
@@ -20,7 +29,7 @@ jobs:
           client-id: ${{ secrets.K35O_BOT_CLIENT_ID }}
           private-key: ${{ secrets.K35O_BOT_PRIVATE_KEY }}
 
-      - uses: k35o/pavo@1296c1e9ae03789c0e87f187fb8321f61f694890 # main
+      - uses: k35o/pavo@ee23767cfa7706afbc7f9d1e7af7e2f7e4c9a087 # main
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           app_slug: ${{ steps.app-token.outputs.app-slug }}


### PR DESCRIPTION
## Summary

[k35o/pavo](https://github.com/k35o/pavo) を caller として組み込み、PR のオープン・更新・再オープンと、Pavo bot のインラインコメントへの返信に反応してレビュー / 会話を行うようにする。

## 動作

- **review path**: `pull_request` (`opened` / `synchronize` / `reopened`) で起動 → Pavo が `default,nextjs` の観点で diff をレビューし、PR Review として 1 件にバンドルして投稿する
- **conversation path**: `pull_request_review_comment` (`created`) で起動 → Pavo の inline コメントへ k35o が返信したスレッドにのみ反応して返答する
- `pavo:skip` label を PR に付ければ両 path とも起動前にスキップ

## 必要な secret

caller repo or org に以下 3 つ。すでに本リポジトリに設定済み:

- `CLAUDE_CODE_OAUTH_TOKEN`
- `K35O_BOT_CLIENT_ID`
- `K35O_BOT_PRIVATE_KEY`

## 動作確認

- [x] Pavo 自身の repo (`k35o/pavo` PR #1, #2) で dogfood テスト済み
- [ ] このリポジトリで初回 review が走るか確認
- [ ] inline コメントへの返信が会話 path をトリガするか確認