### PR TITLE
chore(ci): bump pavo SHA to enable APPROVE on clean PRs

### DIFF
--- a/.github/workflows/pavo.yml
+++ b/.github/workflows/pavo.yml
@@ -29,7 +29,7 @@ jobs:
           client-id: ${{ secrets.K35O_BOT_CLIENT_ID }}
           private-key: ${{ secrets.K35O_BOT_PRIVATE_KEY }}
 
-      - uses: k35o/pavo@ee23767cfa7706afbc7f9d1e7af7e2f7e4c9a087 # main
+      - uses: k35o/pavo@42636a821024e801b5a0acda2ef97608634306df # main
         with:
           github_token: ${{ steps.app-token.outputs.token }}
           app_slug: ${{ steps.app-token.outputs.app-slug }}


### PR DESCRIPTION
## Summary

[k35o/pavo PR #4](https://github.com/k35o/pavo/pull/4) で `event: APPROVE` 対応が入ったので SHA を bump する。

## 変更

`k35o/pavo@ee23767c` → `k35o/pavo@42636a82`

## 挙動

- inline 指摘 0 件 + Pavo が確信できる場合 → APPROVED で投稿
- 1 件でも指摘がある or 確信が持てない → 従来通り COMMENT で投稿

branch protection で「N 承認必須」を設定している場合、Pavo の APPROVE がそのカウントに加わる。意図しなければ branch protection 側で除外設定を入れる。