### PR TITLE
fix(security): decode &amp; last to prevent double-unescaping in link-card metadata

### DIFF
--- a/apps/main/src/app/_components/link-card/metadata.ts
+++ b/apps/main/src/app/_components/link-card/metadata.ts
@@ -2,13 +2,13 @@ import { cacheLife } from 'next/cache';
 
 const decodeHtmlEntities = (text: string): string =>
   text
-    .replaceAll(/&amp;/gi, '&')
     .replaceAll(/&lt;/gi, '<')
     .replaceAll(/&gt;/gi, '>')
     .replaceAll(/&quot;/gi, '"')
     .replaceAll(/&#39;/gi, "'")
     .replaceAll(/&nbsp;/gi, ' ')
-    .replaceAll(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)));
+    .replaceAll(/&#(\d+);/g, (_, code) => String.fromCodePoint(Number(code)))
+    .replaceAll(/&amp;/gi, '&');
 
 export async function getMetadata(href: string) {
   'use cache';


### PR DESCRIPTION
## 概要

[CodeQL alert #2](https://github.com/k35o/k8o/security/code-scanning/2) (`js/double-escaping`, severity: high) の対応。

`apps/main/src/app/_components/link-card/metadata.ts` の `decodeHtmlEntities` で `&amp;` を最初にデコードしていたため、`&amp;lt;` のような入力が `&lt;` → `<` と二重にアンエスケープされる問題があった。CodeQL の推奨どおり、エスケープ文字 `&` のデコードを最後に移動する。

## 動機

link-cardは外部ページから取得したHTMLの `<title>` / `og:title` / `og:description` / `og:image` をそのまま `decodeHtmlEntities` に通している。悪意あるサイトが `&amp;lt;script&amp;gt;` のように細工したメタタグを返してきた場合、二重デコードによってサニタイズの意図が崩れる可能性がある。

## 詳細

- `&amp;` の置換を `replaceAll` チェーンの末尾に移動
- 他のエンティティ（`&lt;`, `&gt;`, `&quot;`, `&#39;`, `&nbsp;`, `&#NN;`）は既存の順序のまま
- 数値文字参照 `&#(\d+);` は `&amp;` の前に置いているが、`&#38;` (`&`) が他のエンティティ文字列を新たに作り出すことはないため安全

## 気をつけるポイント

- 動作変更があるのは `&amp;` を含む入力のみ。今までは `&amp;lt;` → `<` になっていたが、修正後は `&lt;` のまま残る（こちらが正しい挙動）
- link-card の表示文字列にしか影響しない

## 影響範囲

- `apps/main/src/app/_components/link-card/` (link-card のメタデータ表示のみ)

## 検証

- `vp check`: pass
- `tsgo --noEmit`: pass