### PR TITLE
chore: arte-odyssey v9.0.0 に追従

### DIFF
--- a/apps/main/src/app/japanese-text-fixer/_state/provider.tsx
+++ b/apps/main/src/app/japanese-text-fixer/_state/provider.tsx
@@ -1,19 +1,24 @@
 'use client';
 
+import { createSafeContext } from '@k8o/arte-odyssey';
 import {
-  createContext,
   type Dispatch,
   type FC,
   type PropsWithChildren,
-  use,
   useReducer,
 } from 'react';
 
 import { initialState, reducer } from './reducer';
 import type { Action, State } from './types';
 
-const StateContext = createContext<State | undefined>(undefined);
-const DispatchContext = createContext<Dispatch<Action> | undefined>(undefined);
+const [StateContext, useProofreadState] = createSafeContext<State>(
+  'useProofreadState must be used within a ProofreadProvider',
+);
+const [DispatchContext, useProofreadDispatch] = createSafeContext<
+  Dispatch<Action>
+>('useProofreadDispatch must be used within a ProofreadProvider');
+
+export { useProofreadState, useProofreadDispatch };
 
 type ProofreadProviderProps = PropsWithChildren<{
   initialState?: State;
@@ -33,24 +38,4 @@ export const ProofreadProvider: FC<ProofreadProviderProps> = ({
       <DispatchContext value={dispatch}>{children}</DispatchContext>
     </StateContext>
   );
-};
-
-export const useProofreadState = (): State => {
-  const state = use(StateContext);
-  if (state === undefined) {
-    throw new Error(
-      'useProofreadState must be used within a ProofreadProvider',
-    );
-  }
-  return state;
-};
-
-export const useProofreadDispatch = (): Dispatch<Action> => {
-  const dispatch = use(DispatchContext);
-  if (dispatch === undefined) {
-    throw new Error(
-      'useProofreadDispatch must be used within a ProofreadProvider',
-    );
-  }
-  return dispatch;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@k8o/arte-odyssey':
-      specifier: 8.0.1
-      version: 8.0.1
+      specifier: 9.0.0
+      version: 9.0.0
     '@storybook/addon-a11y':
       specifier: 10.3.6
       version: 10.3.6
@@ -136,7 +136,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 8.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)(typescript@6.0.3)
+        version: 9.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)(typescript@6.0.3)
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -227,7 +227,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 8.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)(typescript@6.0.3)
+        version: 9.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)(typescript@6.0.3)
       '@mdx-js/loader':
         specifier: 3.1.1
         version: 3.1.1
@@ -463,8 +463,9 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@antfu/ni@0.23.2':
-    resolution: {integrity: sha512-FSEVWXvwroExDXUu8qV6Wqp2X3D1nJ0Li4LFymCyvCVrm7I3lNfG0zZWSWvGU1RE7891eTnFTyh31L3igOwNKQ==}
+  '@antfu/ni@30.1.0':
+    resolution: {integrity: sha512-3VuAbPjgY52rQNn4wABaXMhBU2Oq91uy6L8nX49eJ35OLI68CyckGU+HZxcaHix4ymuGM2nFL1D6sLpgODK5xw==}
+    engines: {node: '>=20.19.0'}
     hasBin: true
 
   '@babel/code-frame@7.29.0':
@@ -1622,8 +1623,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@k8o/arte-odyssey@8.0.1':
-    resolution: {integrity: sha512-2/UlYYZ6sRCw43ro/GtO778OXDciHxvnjRwUmHF+IsU+UpUwgmmSjP8fTPBzV2ub288aeDye33LJLaARcda7bg==}
+  '@k8o/arte-odyssey@9.0.0':
+    resolution: {integrity: sha512-xz//Zit22qIbQYNFMD18vum3uQus+h3GyJKosnRlK+1xKNGHvcChAETuI8EocrZ6E9IbdycmumoZNYr4zA5ewA==}
     peerDependencies:
       '@types/react': '>=19.0.0'
       '@types/react-dom': '>=19.0.0'
@@ -2558,8 +2559,8 @@ packages:
   '@prisma/schema-files-loader@6.8.2':
     resolution: {integrity: sha512-JRXJ08xfA1cP30kgP15AMCOKZchy2ss2oN6nSHxN745euh2tijpzvW4yCD4Q/1ZtnDkfKae45Tcpx0Ytab7RPA==}
 
-  '@react-grab/cli@0.1.32':
-    resolution: {integrity: sha512-TI4SHATLH2yM1DMRXgH3dt/8b3Rj51BplDOqOQiHQKAMOuKVAR9WE2WGWJRT3LwFpl8BXR9ytAM9vrGDrB7QGw==}
+  '@react-grab/cli@0.1.33':
+    resolution: {integrity: sha512-UOc3PwN11Osw0NzaxRLK8trP4X+5iW1Dst3gvHRCafe3wXHyadzHYH8H1hdkcXdlIx3gsoD9ASJ+G/JH+A/jqA==}
     hasBin: true
 
   '@reduxjs/toolkit@2.11.2':
@@ -3898,9 +3899,9 @@ packages:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
 
-  cli-spinners@2.9.2:
-    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
-    engines: {node: '>=6'}
+  cli-spinners@3.4.0:
+    resolution: {integrity: sha512-bXfOC4QcT1tKXGorxL3wbJm6XJPDqEnij2gQ2m7ESQuE+/z9YFIWnl/5RpTiKWbMq3EVKR4fRLJGn6DVfu0mpw==}
+    engines: {node: '>=18.20'}
 
   cli-truncate@4.0.0:
     resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
@@ -4502,6 +4503,9 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  fzf@0.5.2:
+    resolution: {integrity: sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==}
+
   gaxios@6.7.1:
     resolution: {integrity: sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==}
     engines: {node: '>=14'}
@@ -4789,10 +4793,6 @@ packages:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
 
-  is-unicode-supported@1.3.0:
-    resolution: {integrity: sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ==}
-    engines: {node: '>=12'}
-
   is-unicode-supported@2.1.0:
     resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
     engines: {node: '>=18'}
@@ -5053,8 +5053,8 @@ packages:
   lit@3.3.2:
     resolution: {integrity: sha512-NF9zbsP79l4ao2SNrH3NkfmFgN/hBYSQo90saIVI1o5GpjAdCPVstVzO1MrLOakHoEhYkrtRjPK6Ob521aoYWQ==}
 
-  log-symbols@6.0.0:
-    resolution: {integrity: sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw==}
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
     engines: {node: '>=18'}
 
   longest-streak@3.1.0:
@@ -5444,9 +5444,9 @@ packages:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
 
-  ora@8.2.0:
-    resolution: {integrity: sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw==}
-    engines: {node: '>=18'}
+  ora@9.4.0:
+    resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
+    engines: {node: '>=20'}
 
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
@@ -5485,6 +5485,9 @@ packages:
 
   package-json-from-dist@1.0.1:
     resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
+  package-manager-detector@1.6.0:
+    resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
   parse-entities@4.0.2:
     resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
@@ -5652,8 +5655,8 @@ packages:
     peerDependencies:
       react: ^19.2.6
 
-  react-grab@0.1.32:
-    resolution: {integrity: sha512-ODZkzu4zjwX/5a1VxTdIkagPD6uPnp8IkSN2v5FDgFMZkH5r/YEMq43hIsdpHV5/R2ymqS9zLxp4H7SNSRx5ng==}
+  react-grab@0.1.33:
+    resolution: {integrity: sha512-ER919JMsE4TTrb2CpEivqsIjNMSycD4HtS8v7mS3pq67U7WL1K3+C8m9AYOwW4dpuYh+EanC2eJBmfuczHJZ0A==}
     hasBin: true
     peerDependencies:
       react: '>=17.0.0'
@@ -5982,8 +5985,8 @@ packages:
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
-  stdin-discarder@0.2.2:
-    resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
+  stdin-discarder@0.3.2:
+    resolution: {integrity: sha512-eCPu1qRxPVkl5605OTWF8Wz40b4Mf45NY5LQmVPQ599knfs5QhASUm9GbJ5BDMDOXgrnh0wyEdvzmL//YMlw0A==}
     engines: {node: '>=18'}
 
   storybook-addon-mock-date@2.0.0:
@@ -6014,6 +6017,10 @@ packages:
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
+
+  string-width@8.2.1:
+    resolution: {integrity: sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==}
+    engines: {node: '>=20'}
 
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
@@ -6100,6 +6107,10 @@ packages:
 
   tinyexec@1.0.2:
     resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
+  tinyexec@1.1.2:
+    resolution: {integrity: sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.16:
@@ -6583,7 +6594,12 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@antfu/ni@0.23.2': {}
+  '@antfu/ni@30.1.0':
+    dependencies:
+      fzf: 0.5.2
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.2
+      tinyglobby: 0.2.16
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -7379,7 +7395,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@k8o/arte-odyssey@8.0.1(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)(typescript@6.0.3)':
+  '@k8o/arte-odyssey@9.0.0(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.2.4)(typescript@6.0.3)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/react': 19.2.14
@@ -8137,13 +8153,13 @@ snapshots:
       '@prisma/prisma-schema-wasm': 6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e
       fs-extra: 11.3.0
 
-  '@react-grab/cli@0.1.32':
+  '@react-grab/cli@0.1.33':
     dependencies:
-      '@antfu/ni': 0.23.2
+      '@antfu/ni': 30.1.0
       commander: 14.0.3
       ignore: 7.0.5
       jsonc-parser: 3.3.1
-      ora: 8.2.0
+      ora: 9.4.0
       picocolors: 1.1.1
       prompts: 2.4.2
       smol-toml: 1.6.1
@@ -9380,7 +9396,7 @@ snapshots:
     dependencies:
       restore-cursor: 5.1.0
 
-  cli-spinners@2.9.2: {}
+  cli-spinners@3.4.0: {}
 
   cli-truncate@4.0.0:
     dependencies:
@@ -9938,6 +9954,8 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  fzf@0.5.2: {}
+
   gaxios@6.7.1:
     dependencies:
       extend: 3.0.2
@@ -10327,8 +10345,6 @@ snapshots:
 
   is-stream@2.0.1: {}
 
-  is-unicode-supported@1.3.0: {}
-
   is-unicode-supported@2.1.0: {}
 
   is-wsl@3.1.1:
@@ -10566,10 +10582,10 @@ snapshots:
       lit-element: 4.2.2
       lit-html: 3.3.2
 
-  log-symbols@6.0.0:
+  log-symbols@7.0.1:
     dependencies:
-      chalk: 5.6.2
-      is-unicode-supported: 1.3.0
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
 
   longest-streak@3.1.0: {}
 
@@ -11197,17 +11213,16 @@ snapshots:
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
 
-  ora@8.2.0:
+  ora@9.4.0:
     dependencies:
       chalk: 5.6.2
       cli-cursor: 5.0.0
-      cli-spinners: 2.9.2
+      cli-spinners: 3.4.0
       is-interactive: 2.0.0
       is-unicode-supported: 2.1.0
-      log-symbols: 6.0.0
-      stdin-discarder: 0.2.2
-      string-width: 7.2.0
-      strip-ansi: 7.2.0
+      log-symbols: 7.0.1
+      stdin-discarder: 0.3.2
+      string-width: 8.2.1
 
   outvariant@1.4.3: {}
 
@@ -11325,6 +11340,8 @@ snapshots:
       oxlint-tsgolint: 0.22.0
 
   package-json-from-dist@1.0.1: {}
+
+  package-manager-detector@1.6.0: {}
 
   parse-entities@4.0.2:
     dependencies:
@@ -11493,9 +11510,9 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-grab@0.1.32(react@19.2.6):
+  react-grab@0.1.33(react@19.2.6):
     dependencies:
-      '@react-grab/cli': 0.1.32
+      '@react-grab/cli': 0.1.33
       bippy: 0.5.39(react@19.2.6)
     optionalDependencies:
       react: 19.2.6
@@ -11531,7 +11548,7 @@ snapshots:
       prompts: 2.4.2
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-grab: 0.1.32(react@19.2.6)
+      react-grab: 0.1.33(react@19.2.6)
     optionalDependencies:
       esbuild: 0.27.7
       unplugin: 2.1.0
@@ -11962,7 +11979,7 @@ snapshots:
 
   std-env@4.0.0: {}
 
-  stdin-discarder@0.2.2: {}
+  stdin-discarder@0.3.2: {}
 
   storybook-addon-mock-date@2.0.0(storybook@10.3.6(@testing-library/dom@10.4.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(vite-plus@0.1.20(@types/node@24.12.2)(@vitest/coverage-v8@4.1.5)(@vitest/ui@4.1.5)(esbuild@0.27.7)(jiti@2.6.1)(tsx@4.21.0)(typescript@6.0.3)(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)(yaml@2.8.3))(yaml@2.8.3))):
     dependencies:
@@ -12003,6 +12020,11 @@ snapshots:
   string-width@7.2.0:
     dependencies:
       emoji-regex: 10.6.0
+      get-east-asian-width: 1.5.0
+      strip-ansi: 7.2.0
+
+  string-width@8.2.1:
+    dependencies:
       get-east-asian-width: 1.5.0
       strip-ansi: 7.2.0
 
@@ -12080,6 +12102,8 @@ snapshots:
   tinycolor2@1.6.0: {}
 
   tinyexec@1.0.2: {}
+
+  tinyexec@1.1.2: {}
 
   tinyglobby@0.2.16:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ allowBuilds:
 blockExoticSubdeps: true
 
 catalog:
-  '@k8o/arte-odyssey': 8.0.1
+  '@k8o/arte-odyssey': 9.0.0
   '@storybook/addon-a11y': 10.3.6
   '@storybook/addon-docs': 10.3.6
   '@storybook/addon-mcp': '0.6.0'


### PR DESCRIPTION
## 概要

`@k8o/arte-odyssey` を **8.0.1 → 9.0.0** に更新し、ついでに新しく公開された `createSafeContext` helper を 1 箇所で活用する。

[v9.0.0 リリースノート](https://github.com/k35o/arte-odyssey/releases/tag/%40k8o%2Farte-odyssey%409.0.0) のメインの破壊的変更は「公開 Helpers の整理」だが、k8o 側は元々 `between` / `findAllColors` / `isInternalRoute` / `cast` / `toPrecision` / `uuidV4` / `commalize` を arte-odyssey から直接 import していなかった（同等のものは `@repo/helpers` 側に独自実装が存在）ため、コンシューマー側の対応は不要。

## 詳細

### 1. `chore(deps)`: `@k8o/arte-odyssey` を 9.0.0 へ

`pnpm-workspace.yaml` の catalog エントリだけを更新（lockfile 自動更新）。

8.0.1 から 9.0.0 までに含まれる変更:

- **v8.0.2**: pnpm v11 native publish への移行（CI 内部の話、利用側影響なし）
- **v8.0.3**: `IconButton.tooltipPlacement` のデフォルトが `'bottom'` → `'top'` に変更。
  - k8o 側で `tooltipPlacement` を明示している箇所は 0 件のため、すべての IconButton ツールチップがボタン上側に出るようになる。下にあるコンテンツが隠れにくくなるため、そのまま受け入れる方針。
- **v9.0.0**:
  - 公開 Helpers を `cn` / `mergeRefs` / `mergeProps` / `chain` / `createSafeContext` の 5 つに整理（k8o 側は元々 `cn` 以外を arte-odyssey から import していなかったので影響なし）。
  - `Tooltip` がホバー非対応デバイス（タッチデバイス）では非表示。`(hover: hover)` メディアクエリを `useSyncExternalStore` で監視。フォーカス起因の開閉は引き続き動くため、キーボード/スクリーンリーダー操作には影響なし。`IconButton` 等の Tooltip 内蔵コンポーネントも同様の挙動。
  - 内部で `useControllableState` / `createSafeContext` / `useDisclosure` / `chain` を dogfood 採用（外部 API 変更なし）。

### 2. `refactor(japanese-text-fixer)`: `createSafeContext` の採用

[apps/main/src/app/japanese-text-fixer/_state/provider.tsx](https://github.com/k35o/k8o/blob/chore/arte-odyssey-v9/apps/main/src/app/japanese-text-fixer/_state/provider.tsx) は \`createContext + use + null check + throw\` の定型コードを 2 つの Context （State / Dispatch）で書いていた。これを `createSafeContext` で置き換え、~15 行のボイラープレートを削減。

挙動は同一。Provider 外で hook を呼ぶと従来どおりエラーが投げられる（メッセージも維持）。

### 新公開 helper の他の利用候補について

参考までに、`mergeRefs` / `mergeProps` / `chain` の利用候補もコードベースで探したが該当なし:
- `chain`: `triggerProps` を spread している 5 ファイルを精査したが、ユーザー定義の onClick/onKeyDown を併せて呼ぶ箇所が無く、出番無し
- `mergeRefs`: `useImperativeHandle` や ref 合成パターンが未使用
- `mergeProps`: props 合成パターンが未使用
- `cn`: 11 箇所で `@repo/helpers/cn` を使用中。AGENTS.md の「`cn` は `packages/helpers` に残す」明記方針に従ってそのまま。

## 気をつけるポイント

- `IconButton` のツールチップ位置がデフォルトで `'top'` になる（v8.0.3 由来）。各 IconButton 利用箇所のレイアウト的に問題ないかは Chromatic で要確認。
- タッチデバイスでは `Tooltip` が hover 起因で表示されなくなる（v9.0.0 由来）。フォーカス時には依然表示される。
- `createSafeContext` の戻り値の Context は `Context<T | null>` を返すので、Provider の `value` に `null` を渡してしまうと「Provider が存在するのに throw される」状態になる。本 PR の `provider.tsx` は `useReducer` の戻り値をそのまま流すため `null` は入らないが、将来同 helper を他所で使う際の注意点としてメモ。

## 影響範囲

- 全 IconButton（apps/main, apps/admin 横断、計 23 箇所）の Tooltip 配置
- `/japanese-text-fixer` の状態管理（リファクタのみ、UI/フロー変更なし）

## テスト

- `pnpm run type-check` ✅
- `pnpm run check` ✅（0 errors / 既存 71 warnings、本 PR とは無関係）
- `pnpm run test` ✅（102 files / 241 tests）
- `pnpm run build` は DB 環境変数（`TURSO_DATABASE_URL` 等）未設定のため未検証。Compile 段階は両 app ともに ✓ で、build エラーは「ビルド時に DB クエリ収集を行う Page で URL 空文字」起因のため本 PR とは無関係。

## 関連

- 元 release: [@k8o/arte-odyssey@9.0.0](https://github.com/k35o/arte-odyssey/releases/tag/%40k8o%2Farte-odyssey%409.0.0)