### PR TITLE
fix(main): tooltip/popover が sticky header の下に潜る問題を解消

### DIFF
--- a/apps/main/src/app/_components/global-layout/global-layout.tsx
+++ b/apps/main/src/app/_components/global-layout/global-layout.tsx
@@ -8,36 +8,41 @@ import { Background } from './background';
 import { Footer } from './footer';
 import { Header } from './header';
 import { LlmLink } from './llm-link';
+import { PortalRoot } from './portal-root';
 
 export const GlobalLayout: FC<{ children: ReactNode }> = ({ children }) => (
-  <div className="flex min-h-svh flex-col">
-    <Background />
-    <Header>
-      <Link href="/">
-        <h1>
-          <span className="sr-only">k8o</span>
-          <Logo className="h-10" />
-        </h1>
-      </Link>
-      <div className="flex items-center gap-1">
-        <Suspense fallback={null}>
-          <ContactToMe />
-        </Suspense>
-        <ToggleTheme />
-        <LlmLink />
-      </div>
-    </Header>
-    <main className="flex grow justify-center px-4 pt-10 pb-4">{children}</main>
-    <Suspense
-      fallback={
-        <footer className="flex items-center justify-center p-4">
-          <p className="text-fg-mute md:text-lg">
-            ©︎ 2024〜2026 k8o. All Rights Reserved.
-          </p>
-        </footer>
-      }
-    >
-      <Footer />
-    </Suspense>
-  </div>
+  <PortalRoot>
+    <div className="flex min-h-svh flex-col">
+      <Background />
+      <Header>
+        <Link href="/">
+          <h1>
+            <span className="sr-only">k8o</span>
+            <Logo className="h-10" />
+          </h1>
+        </Link>
+        <div className="flex items-center gap-1">
+          <Suspense fallback={null}>
+            <ContactToMe />
+          </Suspense>
+          <ToggleTheme />
+          <LlmLink />
+        </div>
+      </Header>
+      <main className="flex grow justify-center px-4 pt-10 pb-4">
+        {children}
+      </main>
+      <Suspense
+        fallback={
+          <footer className="flex items-center justify-center p-4">
+            <p className="text-fg-mute md:text-lg">
+              ©︎ 2024〜2026 k8o. All Rights Reserved.
+            </p>
+          </footer>
+        }
+      >
+        <Footer />
+      </Suspense>
+    </div>
+  </PortalRoot>
 );

--- a/apps/main/src/app/_components/global-layout/portal-root/index.ts
+++ b/apps/main/src/app/_components/global-layout/portal-root/index.ts
@@ -1,0 +1,1 @@
+export { PortalRoot } from './portal-root';

--- a/apps/main/src/app/_components/global-layout/portal-root/portal-root.tsx
+++ b/apps/main/src/app/_components/global-layout/portal-root/portal-root.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { PortalRootProvider } from '@k8o/arte-odyssey';
+import { type FC, type ReactNode, useRef } from 'react';
+
+export const PortalRoot: FC<{ children: ReactNode }> = ({ children }) => {
+  const portalRef = useRef<HTMLDivElement>(null);
+  return (
+    <PortalRootProvider value={portalRef}>
+      {children}
+      <div className="relative z-100" ref={portalRef} />
+    </PortalRootProvider>
+  );
+};


### PR DESCRIPTION
## 概要

`apps/main` のグローバルヘッダー（`sticky top-0 z-50`）配下で、ArteOdyssey の `Tooltip` / `Popover` / `Dialog` / `DropdownMenu` のフロート要素が **header の下に潜って表示される** 不具合を修正する。`@k8o/arte-odyssey@9.0.0` で公開された `PortalRootProvider` を使い、全フロート要素を `z-100` の portal root に集約する。

## 動機

ArteOdyssey のフロート系コンポーネントは内部で `FloatingPortal` を使い body 直下に portal レンダーするが、**z-index を明示していない**。一方 `<Header>` は `sticky top-0 z-50` であり、これは sticky header の本来要件（main 内 in-flow の `z-*` 要素より上に出す）として必須。結果として:

- root stacking context 内で `header (z-50)` > `portal (z-auto)` となる
- header と重なる位置に出るフロート要素（特に IconButton のホバーツールチップ）が **header の下に隠れる**

`apps/admin` には sticky header がないため再現せず、影響範囲は `apps/main` のみ。

## 詳細

### 1. `PortalRoot` Client Component を新設

[apps/main/src/app/_components/global-layout/portal-root/portal-root.tsx](https://github.com/k35o/k8o/blob/fix/tooltip-portal-stacking/apps/main/src/app/_components/global-layout/portal-root/portal-root.tsx)

```tsx
'use client';

import { PortalRootProvider } from '@k8o/arte-odyssey';
import { type FC, type ReactNode, useRef } from 'react';

export const PortalRoot: FC<{ children: ReactNode }> = ({ children }) => {
  const portalRef = useRef<HTMLDivElement>(null);
  return (
    <PortalRootProvider value={portalRef}>
      {children}
      <div className="relative z-100" ref={portalRef} />
    </PortalRootProvider>
  );
};
```

- 最小の Client 境界：`useRef` 1 つだけ。`GlobalLayout` 自体は Server Component のまま
- portal root に `relative z-100` を当てて header (`z-50`) より上の stacking context を作る
- ArteOdyssey 側の `usePortalRoot` は `RefObject<HTMLElement | null>` を返す API なので、`useState` ではなく `useRef` を渡す（`FloatingPortal` は ref object をそのまま受け付け、内部で `.current` を読む）

### 2. `GlobalLayout` で `<PortalRoot>` でラップ

[apps/main/src/app/_components/global-layout/global-layout.tsx](https://github.com/k35o/k8o/blob/fix/tooltip-portal-stacking/apps/main/src/app/_components/global-layout/global-layout.tsx)

ツリー構造変更:

```
PortalRoot (PortalRootProvider)
└── div (flex flex-col)
    ├── Background     ← -z-10
    ├── Header         ← sticky z-50
    ├── main           ← z-auto
    └── Footer
└── div ref={portalRef}  ← relative z-100  ← 追加
```

これにより:
- `header (z-50)` > `main の z-* in-flow content` の stacking 関係は維持
- `portal-root (z-100)` > `header (z-50)` で全フロート要素が最前面に
- ArteOdyssey の `Toast` も同じ portal にレンダー（既存の `z-50` が `z-100` 配下になり、相対的には変化なし）

## 気をつけるポイント

- 初回 mount 直後は `portalRef.current` がまだ `null` の瞬間があるが、フロート要素は user interaction（hover/focus/click）で開くため、その時点では ref は確実に set されている。FloatingPortal の `root` prop は ref object をそのまま渡す API なので、`current` を実行時に解決して問題ない。
- `<div ref={portalRef}>` 自体は空要素で `position: relative` のまま flow 内にいるが、子は `position: fixed/absolute` でレンダーされるため layout には影響しない。
- 既存の Storybook story (`global-layout.stories.tsx`) は構造変更に追従。

## 影響範囲

- `apps/main` 全ページ（`GlobalLayout` 配下）の Tooltip / Popover / Dialog / DropdownMenu / Toast の z-stacking
- `apps/admin` は対象外（sticky header なし、本問題が発生しない）

## テスト

- `pnpm run type-check` ✅
- `pnpm run check` ✅（0 errors / 既存 72 warnings、本 PR とは無関係）
- `pnpm run ls-lint` ✅
- `pnpm run test` ✅（102 files / 241 tests）
- **実機ブラウザ検証は未実施**: ローカル dev は `portless` HTTPS proxy セットアップが必要なため、本ランでは動作確認していない。レビュー時に `pnpm run dev` で sticky header と重なる位置の IconButton（`/talks` や `/blog` 等のページ内）をホバーしてツールチップが header の上に出ることを確認していただきたい。

## 関連

- 元観察: PR #1746 のレビュー中に「tooltip が下に潜り込む」と確認
- 依存: [k8o#1746 (arte-odyssey v9.0.0)](https://github.com/k35o/k8o/pull/1746) で公開された `PortalRootProvider` を利用