### PR TITLE
refactor(blog): 一覧⇄記事間の ViewTransition を削除し scroll-to-top を修正

### DIFF
--- a/apps/main/src/app/blog/(articles)/view-transitions/page.mdx
+++ b/apps/main/src/app/blog/(articles)/view-transitions/page.mdx
@@ -2,7 +2,7 @@
 title: UIが遷移するアニメーションを簡単にするView Transition API
 description: View Transition APIがBaseline 2025に追加され、Web上のUI遷移を簡単にアニメーション化可能になりました。異なるページ間の遷移や同一ページ内のDOM更新時に、要素の位置やスタイルの変化をアニメーション化できます。CSSによるスタイル制御も豊富に用意されており、柔軟なカスタマイズが可能です。
 createdAt: 2025-11-08
-updatedAt: 2025-11-08
+updatedAt: 2026-05-13
 featureIds:
   - view-transitions
   - view-transition-class
@@ -23,9 +23,6 @@ import { Playground } from '@/app/_components/playgrounds';
 Web上のさまざまなUIの遷移を簡単にアニメーション化するView Transition APIがBaseline 2025に追加されました。
 
 異なる`Document`間（同一のオリジン）の遷移や、同一`Document`内のDOM更新時に、要素の位置やスタイルの変化に対するアニメーションを付与します。
-
-例として、当サイトではブログの一覧とブログ記事の遷移で、View Transition APIを利用したアニメーションを採用しています（Reactの`ViewTransition`コンポーネントを使っているので間接的な利用ではあります）。
-記事のタイトルや、タグ、作成・更新日時の位置が変化するアニメーションを確認できるかと思います。
 
 この記事では、そんなView Transition APIについて紹介します。この記事ではView Transition APIによって発生するアニメーションのことを「遷移アニメーション」と呼びます。
 

--- a/apps/main/src/app/blog/_components/blog-card/blog-card.tsx
+++ b/apps/main/src/app/blog/_components/blog-card/blog-card.tsx
@@ -10,7 +10,6 @@ import { formatDate } from '@repo/helpers/date/format';
 import type { Route } from 'next';
 import Link from 'next/link';
 import type { FC } from 'react';
-import { ViewTransition } from 'react';
 
 type BlogCardProps = {
   slug: string;
@@ -33,43 +32,35 @@ export const BlogCard: FC<BlogCardProps> = ({
     <Link className="group block h-full" href={`/blog/${slug}` as Route}>
       <div className="flex h-full flex-col justify-between gap-4 p-4">
         <div className="group-hover:text-primary-fg flex flex-col gap-1">
-          <ViewTransition name={`title-${slug}`}>
-            <Heading lineClamp={3} type="h3">
-              {title}
-            </Heading>
-          </ViewTransition>
+          <Heading lineClamp={3} type="h3">
+            {title}
+          </Heading>
           {description !== null && (
-            <ViewTransition name={`description-${slug}`}>
-              <p className="text-fg-mute line-clamp-3 text-sm">{description}</p>
-            </ViewTransition>
+            <p className="text-fg-mute line-clamp-3 text-sm">{description}</p>
           )}
         </div>
         <div className="flex flex-wrap items-center justify-between gap-4">
           {tags.length > 0 && (
-            <ViewTransition name={`tags-${slug}`}>
-              <div className="flex flex-wrap items-center gap-2">
-                <TagIcon size="sm" />
-                {tags.map((tag) => (
-                  <Badge key={tag} size="sm" text={tag} />
-                ))}
-              </div>
-            </ViewTransition>
+            <div className="flex flex-wrap items-center gap-2">
+              <TagIcon size="sm" />
+              {tags.map((tag) => (
+                <Badge key={tag} size="sm" text={tag} />
+              ))}
+            </div>
           )}
           <div className="text-fg-mute ml-auto flex items-center gap-4 text-xs">
-            <ViewTransition name={`date-${slug}`}>
-              <div className="flex items-center gap-1">
-                <PublishDateIcon size="sm" />
-                <span>
-                  公開: {formatDate(new Date(createdAt), 'yyyy年M月d日')}
-                </span>
-              </div>
-              <div className="flex items-center gap-1">
-                <UpdateDateIcon size="sm" />
-                <span>
-                  更新: {formatDate(new Date(updatedAt), 'yyyy年M月d日')}
-                </span>
-              </div>
-            </ViewTransition>
+            <div className="flex items-center gap-1">
+              <PublishDateIcon size="sm" />
+              <span>
+                公開: {formatDate(new Date(createdAt), 'yyyy年M月d日')}
+              </span>
+            </div>
+            <div className="flex items-center gap-1">
+              <UpdateDateIcon size="sm" />
+              <span>
+                更新: {formatDate(new Date(updatedAt), 'yyyy年M月d日')}
+              </span>
+            </div>
           </div>
         </div>
       </div>

--- a/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -11,7 +11,7 @@ import {
 import { formatDate } from '@repo/helpers/date/format';
 import { commalize } from '@repo/helpers/number/commalize';
 import Link from 'next/link';
-import { type FC, type ReactNode, Suspense, ViewTransition } from 'react';
+import { type FC, type ReactNode, Suspense } from 'react';
 
 import { SilentErrorBoundary } from '@/app/_components/error-boundary';
 import {
@@ -60,23 +60,17 @@ export const BlogLayoutContent: FC<BlogLayoutContentProps> = ({
           <article className="bg-bg-base/90 vertical:bg-transparent vertical:rounded-none rounded-xl px-3 py-8 sm:px-10">
             <div className="flex flex-col gap-3">
               <div className="flex items-start justify-between gap-2">
-                <ViewTransition name={`title-${slug}`}>
-                  <h2 className="text-xl font-bold sm:text-2xl">
-                    {blog.title}
-                  </h2>
-                </ViewTransition>
+                <h2 className="text-xl font-bold sm:text-2xl">{blog.title}</h2>
                 <div className="flex items-center gap-1">
                   <CopyMarkdownButton slug={slug} />
                 </div>
               </div>
               {blog.description !== null && (
-                <ViewTransition name={`description-${slug}`}>
-                  <div className="bg-bg-mute rounded-xl p-4 sm:mt-4">
-                    <p className="text-fg-base sm:text-md text-sm">
-                      {blog.description}
-                    </p>
-                  </div>
-                </ViewTransition>
+                <div className="bg-bg-mute rounded-xl p-4 sm:mt-4">
+                  <p className="text-fg-base sm:text-md text-sm">
+                    {blog.description}
+                  </p>
+                </div>
               )}
               {blog.slideUrl !== undefined && (
                 <div className="flex self-end">
@@ -85,16 +79,14 @@ export const BlogLayoutContent: FC<BlogLayoutContentProps> = ({
               )}
               <div className="text-fg-mute flex flex-col items-end gap-1 text-xs sm:flex-row sm:items-center sm:justify-end sm:gap-2 sm:text-sm">
                 <div className="flex flex-wrap items-center justify-end gap-1">
-                  <ViewTransition name={`date-${slug}`}>
-                    <div className="flex items-center gap-1">
-                      <PublishDateIcon size="sm" />
-                      <span>公開: {formatDate(new Date(blog.createdAt))}</span>
-                    </div>
-                    <div className="flex items-center gap-1">
-                      <UpdateDateIcon size="sm" />
-                      <span>更新: {formatDate(new Date(blog.updatedAt))}</span>
-                    </div>
-                  </ViewTransition>
+                  <div className="flex items-center gap-1">
+                    <PublishDateIcon size="sm" />
+                    <span>公開: {formatDate(new Date(blog.createdAt))}</span>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <UpdateDateIcon size="sm" />
+                    <span>更新: {formatDate(new Date(blog.updatedAt))}</span>
+                  </div>
                 </div>
                 <SilentErrorBoundary>
                   {viewCount === undefined ? (
@@ -116,18 +108,16 @@ export const BlogLayoutContent: FC<BlogLayoutContentProps> = ({
                   )}
                 </SilentErrorBoundary>
               </div>
-              <ViewTransition name={`tags-${slug}`}>
-                {blog.tags.length > 0 && (
-                  <div className="mb-4 flex flex-wrap items-center gap-2">
-                    <TagIcon size="sm" />
-                    {blog.tags.map((tag) => (
-                      <Link href={`/tags/${tag.id.toString()}`} key={tag.id}>
-                        <Badge interactive key={tag.id} text={tag.name} />
-                      </Link>
-                    ))}
-                  </div>
-                )}
-              </ViewTransition>
+              {blog.tags.length > 0 && (
+                <div className="mb-4 flex flex-wrap items-center gap-2">
+                  <TagIcon size="sm" />
+                  {blog.tags.map((tag) => (
+                    <Link href={`/tags/${tag.id.toString()}`} key={tag.id}>
+                      <Badge interactive key={tag.id} text={tag.name} />
+                    </Link>
+                  ))}
+                </div>
+              )}
             </div>
             <div className="m-2 sm:mt-4">
               <Separator />

--- a/apps/main/src/app/blog/_components/scroll-to-top-on-path-change/index.ts
+++ b/apps/main/src/app/blog/_components/scroll-to-top-on-path-change/index.ts
@@ -1,0 +1,1 @@
+export * from './scroll-to-top-on-path-change';

--- a/apps/main/src/app/blog/_components/scroll-to-top-on-path-change/scroll-to-top-on-path-change.tsx
+++ b/apps/main/src/app/blog/_components/scroll-to-top-on-path-change/scroll-to-top-on-path-change.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { useEffect, useRef } from 'react';
+
+export const ScrollToTopOnPathChange = () => {
+  const pathname = usePathname();
+  const prevPathname = useRef<string | null>(null);
+  const isPopState = useRef(false);
+
+  useEffect(() => {
+    const handler = () => {
+      isPopState.current = true;
+    };
+    window.addEventListener('popstate', handler);
+    return () => {
+      window.removeEventListener('popstate', handler);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (prevPathname.current === null) {
+      prevPathname.current = pathname;
+      return;
+    }
+    if (prevPathname.current === pathname) return;
+    prevPathname.current = pathname;
+
+    if (isPopState.current) {
+      isPopState.current = false;
+      return;
+    }
+
+    if (window.location.hash) return;
+
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};

--- a/apps/main/src/app/blog/layout.tsx
+++ b/apps/main/src/app/blog/layout.tsx
@@ -7,6 +7,7 @@ import {
   WritingModeSwitcher,
 } from './_components/blog-layout/writing-mode';
 import { ExternalBlog } from './_components/external-blog';
+import { ScrollToTopOnPathChange } from './_components/scroll-to-top-on-path-change';
 
 import './_styles/katex-vertical.css';
 
@@ -36,6 +37,7 @@ export default function Layout({ children }: LayoutProps<'/blog'>) {
         href="https://cdn.jsdelivr.net/npm/katex@0.16.8/dist/katex.min.css"
         rel="stylesheet"
       />
+      <ScrollToTopOnPathChange />
       <WritingModeProvider>
         <div className="mx-auto w-full max-w-5xl">
           <div className="flex flex-col gap-6">


### PR DESCRIPTION
## 概要

ブログ一覧⇄記事間のナビゲーション周りで 2 点修正する。

1. 一覧と記事の間で利用していた React の `<ViewTransition>` を削除
2. 一覧でスクロールしたあと記事に遷移すると、記事ページが先頭から始まらない問題を修正

## 1. ViewTransition 削除 (refactor)

### 詳細

- `apps/main/src/app/blog/_components/blog-card/blog-card.tsx`
  - `title-/description-/tags-/date-${slug}` を `name` に持つ 4 つの `<ViewTransition>` ラッパーと `react` からの import を除去
- `apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx`
  - 同様に 4 つのラッパーと import を除去
- `apps/main/src/app/blog/(articles)/view-transitions/page.mdx`
  - 当サイトでの利用例として記載していた段落を削除（実体が無くなったため）
  - `updatedAt` を `2026-05-13` に更新

## 2. scroll-to-top 修正 (fix)

### 動機

`cacheComponents: true` + `cacheLife('max')` の環境では Next.js の `<Link>` クリック時の scroll-to-top が発火しないことを確認。`document.documentElement.scrollTop` / `window.scrollTo` / `Element.scrollIntoView` をすべてモンキーパッチして遷移中の呼び出しを観測したが一度も呼ばれなかった。

これは Next.js 側の既知バグ ([vercel/next.js#49427](https://github.com/vercel/next.js/issues/49427) NEXT-1130, Next.js チームが `linear: next` ラベルで認知済み）で、関連する複数の issue ([#88030](https://github.com/vercel/next.js/issues/88030) / [#80615](https://github.com/vercel/next.js/issues/80615) / [#64441](https://github.com/vercel/next.js/issues/64441) / [#79571](https://github.com/vercel/next.js/issues/79571)) でも報告されている。issue 内で挙がっている標準的な回避策 (`usePathname` + `useEffect` で `window.scrollTo(0, 0)`) を採用する。

### 詳細

- `apps/main/src/app/blog/_components/scroll-to-top-on-path-change/scroll-to-top-on-path-change.tsx` 新規（Client Component）
  - `usePathname` で pathname の変化を検知して `window.scrollTo(0, 0)` を実行
  - 初回マウントは skip（`useRef` で前回 pathname を保持）
  - `popstate`（戻る／進む）は skip → ブラウザの scroll restoration に任せる
  - `window.location.hash` が付いている遷移は skip → Next.js のアンカー scroll を壊さない
- `apps/main/src/app/blog/_components/scroll-to-top-on-path-change/index.ts` 新規
- `apps/main/src/app/blog/layout.tsx` で `<ScrollToTopOnPathChange />` を blog 配下にのみ配置

### 動作確認（dev server で実測）

- `/blog` で scrollY=5000 → 記事カードクリック → 記事ページ scrollY=**0** ✅
  （修正前: scrollY=2199 で記事末尾に着地していた）
- 記事ページから「戻る」 → `/blog` scrollY=**5000** に復元 ✅
  （popstate は除外しているのでブラウザの scroll restoration が効く）

## 気をつけるポイント

- 適用範囲は blog 配下のみ。他のサブツリーでも同じ問題は起きうるが、本 PR では blog の挙動だけを直す
- ViewTransition そのものの解説記事 (`view-transitions/page.mdx`) と playground、`globals.css` の `prefers-reduced-motion` 用ルールは残しているので、API の説明やデモ自体は引き続き機能する

## 影響範囲

- `/blog`（一覧）
- `/blog/[slug]`（各記事）
- `/blog/tags/[id]` などの blog 配下のルート全般

## テスト

- [x] `pnpm run type-check`
- [x] `pnpm run check`（0 errors / 既存の 71 warnings のみ、本 PR と無関係）
- [x] dev server でブラウザ実機検証（scroll 復元 / 先頭着地、popstate 挙動）