### PR TITLE
feat(blog): Baseline 2026 の SharedWorker 記事と Playground を追加

### DIFF
--- a/apps/main/.storybook/main.ts
+++ b/apps/main/.storybook/main.ts
@@ -26,7 +26,7 @@ const config: StorybookConfig = {
   features: {
     experimentalRSC: true,
   },
-  staticDirs: ['./public'],
+  staticDirs: ['./public', '../public'],
 };
 
 export default config;

--- a/apps/main/public/playgrounds/shared-worker.worker.js
+++ b/apps/main/public/playgrounds/shared-worker.worker.js
@@ -1,0 +1,37 @@
+const STARTED_AT = Date.now();
+let count = 0;
+const ports = new Set();
+
+const broadcast = (message) => {
+  for (const p of ports) {
+    p.postMessage(message);
+  }
+};
+
+self.addEventListener('connect', (event) => {
+  const port = event.ports[0];
+  ports.add(port);
+
+  port.postMessage({
+    type: 'init',
+    startedAt: STARTED_AT,
+    count,
+    connections: ports.size,
+  });
+  broadcast({ type: 'connections', connections: ports.size });
+
+  port.addEventListener('message', (msg) => {
+    const data = msg.data;
+    if (data && data.type === 'increment') {
+      count += 1;
+      broadcast({ type: 'count', count });
+      return;
+    }
+    if (data && data.type === 'disconnect') {
+      ports.delete(port);
+      broadcast({ type: 'connections', connections: ports.size });
+    }
+  });
+
+  port.start();
+});

--- a/apps/main/src/app/_components/playgrounds/index.ts
+++ b/apps/main/src/app/_components/playgrounds/index.ts
@@ -24,6 +24,7 @@ export * from './screen-wake-lock';
 export * from './scrollbar-color';
 export * from './scrollend';
 export * from './shape-function';
+export * from './shared-worker';
 export * from './spelling-grammar-error';
 export * from './suspense-list';
 export * from './text-indent-keywords';
@@ -52,6 +53,7 @@ import { screenWakeLockSection } from './screen-wake-lock';
 import { scrollbarColorSection } from './scrollbar-color';
 import { scrollendSection } from './scrollend';
 import { shapeFunctionSection } from './shape-function';
+import { sharedWorkerSection } from './shared-worker';
 import { spellingGrammarErrorSection } from './spelling-grammar-error';
 import { suspenseListSection } from './suspense-list';
 import { textIndentKeywordsSection } from './text-indent-keywords';
@@ -79,6 +81,7 @@ export const playgroundSections: PlaygroundSection[] = [
   screenWakeLockSection,
   scrollbarColorSection,
   scrollendSection,
+  sharedWorkerSection,
   suspenseListSection,
   absSignSection,
   highlightSection,

--- a/apps/main/src/app/_components/playgrounds/shared-worker/index.ts
+++ b/apps/main/src/app/_components/playgrounds/shared-worker/index.ts
@@ -1,0 +1,19 @@
+import type { PlaygroundSection } from '../types';
+import { SharedWorkerDemo } from './shared-worker-demo';
+
+export { SharedWorkerDemo } from './shared-worker-demo';
+
+export const sharedWorkerSection: PlaygroundSection = {
+  id: 'shared-worker',
+  title: 'SharedWorker',
+  description:
+    '同一オリジンの複数タブから共有できるWorkerです。タブをまたいで状態を共有できます。',
+  type: 'blog',
+  slug: 'shared-worker',
+  demos: [
+    {
+      component: SharedWorkerDemo,
+      title: 'タブ間カウンタ',
+    },
+  ],
+};

--- a/apps/main/src/app/_components/playgrounds/shared-worker/shared-worker-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/shared-worker/shared-worker-demo.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Playground } from '../playground';
+import { SharedWorkerDemo } from './shared-worker-demo';
+
+const playgroundTitle = SharedWorkerDemo.name;
+
+const meta: Meta<typeof SharedWorkerDemo> = {
+  title: 'playgrounds/shared-worker/SharedWorkerDemo',
+  component: SharedWorkerDemo,
+  decorators: [
+    (Story) => (
+      <Playground title={playgroundTitle}>
+        <Story />
+      </Playground>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SharedWorkerDemo>;
+
+export const Default: Story = {};

--- a/apps/main/src/app/_components/playgrounds/shared-worker/shared-worker-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/shared-worker/shared-worker-demo.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button, Code } from '@k8o/arte-odyssey';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 // publicに置いた静的Worker script。全タブで同じURLになるためSharedWorkerが共有される
 const WORKER_URL = '/playgrounds/shared-worker.worker.js';
@@ -21,7 +21,7 @@ export function SharedWorkerDemo() {
   const [startedAt, setStartedAt] = useState<number | null>(null);
   const [count, setCount] = useState(0);
   const [connections, setConnections] = useState(0);
-  const [port, setPort] = useState<MessagePort | null>(null);
+  const port = useRef<MessagePort | null>(null);
 
   useEffect(() => {
     if (typeof SharedWorker === 'undefined') {
@@ -50,7 +50,7 @@ export function SharedWorkerDemo() {
     });
     worker.port.start();
 
-    setPort(worker.port);
+    port.current = worker.port;
 
     // useEffectのcleanupはページ遷移・リロードでは発火しないため、
     // pagehideイベントでもdisconnectを送ってWorker側のports Setから外す
@@ -67,12 +67,12 @@ export function SharedWorkerDemo() {
       // oxlint-disable-next-line require-post-message-target-origin -- MessagePort.postMessageはtargetOrigin非対応
       worker.port.postMessage({ type: 'disconnect' });
       worker.port.close();
-      setPort(null);
+      port.current = null;
     };
   }, []);
 
   const handleIncrement = () => {
-    port?.postMessage({ type: 'increment' });
+    port.current?.postMessage({ type: 'increment' });
   };
 
   if (!supported) {

--- a/apps/main/src/app/_components/playgrounds/shared-worker/shared-worker-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/shared-worker/shared-worker-demo.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import { Button, Code } from '@k8o/arte-odyssey';
+import { useEffect, useState } from 'react';
+
+// publicに置いた静的Worker script。全タブで同じURLになるためSharedWorkerが共有される
+const WORKER_URL = '/playgrounds/shared-worker.worker.js';
+
+type WorkerMessage =
+  | { type: 'init'; startedAt: number; count: number; connections: number }
+  | { type: 'count'; count: number }
+  | { type: 'connections'; connections: number };
+
+const formatTime = (ms: number): string => {
+  const date = new Date(ms);
+  return date.toLocaleTimeString('ja-JP', { hour12: false });
+};
+
+export function SharedWorkerDemo() {
+  const [supported, setSupported] = useState(true);
+  const [startedAt, setStartedAt] = useState<number | null>(null);
+  const [count, setCount] = useState(0);
+  const [connections, setConnections] = useState(0);
+  const [port, setPort] = useState<MessagePort | null>(null);
+
+  useEffect(() => {
+    if (typeof SharedWorker === 'undefined') {
+      setSupported(false);
+      return undefined;
+    }
+
+    const worker = new SharedWorker(WORKER_URL, {
+      name: 'k8o-shared-worker-demo',
+    });
+
+    worker.port.addEventListener('message', (event) => {
+      const data = event.data as WorkerMessage;
+      switch (data.type) {
+        case 'init':
+          setStartedAt(data.startedAt);
+          setCount(data.count);
+          setConnections(data.connections);
+          return;
+        case 'count':
+          setCount(data.count);
+          return;
+        case 'connections':
+          setConnections(data.connections);
+      }
+    });
+    worker.port.start();
+
+    setPort(worker.port);
+
+    // useEffectのcleanupはページ遷移・リロードでは発火しないため、
+    // pagehideイベントでもdisconnectを送ってWorker側のports Setから外す
+    // bfcacheに入る (event.persisted === true) ときはポートを生かしたまま離脱する
+    const handlePageHide = (event: PageTransitionEvent) => {
+      if (event.persisted) return;
+      // oxlint-disable-next-line require-post-message-target-origin -- MessagePort.postMessageはtargetOrigin非対応
+      worker.port.postMessage({ type: 'disconnect' });
+    };
+    window.addEventListener('pagehide', handlePageHide);
+
+    return () => {
+      window.removeEventListener('pagehide', handlePageHide);
+      // oxlint-disable-next-line require-post-message-target-origin -- MessagePort.postMessageはtargetOrigin非対応
+      worker.port.postMessage({ type: 'disconnect' });
+      worker.port.close();
+      setPort(null);
+    };
+  }, []);
+
+  const handleIncrement = () => {
+    port?.postMessage({ type: 'increment' });
+  };
+
+  if (!supported) {
+    return (
+      <p className="text-fg-mute text-sm">
+        このブラウザはSharedWorkerをサポートしていません。
+      </p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-fg-mute text-xs">
+        このページを別タブでもう一度開くと、Worker起動時刻が両タブで一致し、
+        どちらかのタブで「+1」を押すと両タブのカウンタが同期するのが見えます。
+      </p>
+      <div className="bg-bg-base rounded-xl p-6 shadow-sm">
+        <p className="text-fg-mute text-xs">共有カウンタ</p>
+        <div className="mt-2 flex items-baseline gap-4">
+          <span className="text-primary-fg text-5xl font-bold tabular-nums">
+            {count}
+          </span>
+          <Button onClick={handleIncrement} size="sm" type="button">
+            +1
+          </Button>
+        </div>
+      </div>
+      <dl className="bg-bg-mute flex flex-col gap-2 rounded-xl p-4 text-sm">
+        <div className="flex items-center justify-between">
+          <dt className="text-fg-mute">Worker起動時刻</dt>
+          <dd>
+            <Code>{startedAt === null ? '...' : formatTime(startedAt)}</Code>
+          </dd>
+        </div>
+        <div className="flex items-center justify-between">
+          <dt className="text-fg-mute">接続中のタブ数</dt>
+          <dd className="flex items-center gap-2">
+            <span aria-hidden className="flex gap-1">
+              {Array.from({ length: connections }, (_, index) => (
+                <span
+                  className="bg-primary-fg inline-block size-2 rounded-full"
+                  key={index}
+                />
+              ))}
+            </span>
+            <Code>{String(connections)}</Code>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  );
+}

--- a/apps/main/src/app/blog/(articles)/shared-worker/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/shared-worker/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+const slug = 'shared-worker';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt,
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/shared-worker'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/shared-worker/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/shared-worker/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+export const alt = 'SharedWorker';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const blog = await getBlogContent('shared-worker');
+
+  return OgImage({
+    category: 'Blog',
+    title: blog.title,
+  });
+}

--- a/apps/main/src/app/blog/(articles)/shared-worker/page.mdx
+++ b/apps/main/src/app/blog/(articles)/shared-worker/page.mdx
@@ -1,0 +1,210 @@
+---
+title: 'SharedWorkerでブラウジングコンテキスト間にWorkerを共有する'
+description: 'SharedWorkerは、同一オリジンの複数のタブやiframeから接続できるWorkerです。タブ間で永続接続や状態を共有でき、type: moduleでES Modulesも使えるようになりました。Baseline 2026で全モダンブラウザでサポートされたSharedWorkerの基本と使い分けを解説します。'
+createdAt: 2026-05-15
+updatedAt: 2026-05-15
+featureIds:
+  - shared-workers
+  - js-modules-shared-workers
+---
+
+import { BaselineStatus } from '@k8o/arte-odyssey';
+import { Playground, SharedWorkerDemo } from '@/app/_components/playgrounds';
+
+# SharedWorkerでブラウジングコンテキスト間にWorkerを共有する
+
+<BaselineStatus featureId="shared-workers" />
+
+## はじめに
+
+通常の`Worker`（Dedicated Worker）はそれを生成したドキュメント1つにだけ紐づき、別のタブやiframeから直接アクセスすることはできません。同じオリジンの複数の画面から同じバックグラウンド処理を使い回したい場合、それぞれの画面でWorkerを起動し直すか、`BroadcastChannel`などで橋渡しする必要がありました。
+
+Baseline 2026に追加されたSharedWorkerは、1つのWorkerインスタンスを同一オリジンの複数のブラウジングコンテキストから共有できる仕組みです。デスクトップ向けブラウザは早くから対応していましたが、Chrome for Androidが長らく未実装で、Chrome 148で揃って2026年5月にBaseline 2026入りしました。
+
+## SharedWorkerの基本
+
+SharedWorkerはページ側とWorker側のコードがペアで動きます。
+
+ページ側では`new SharedWorker(url)`でWorkerに接続し、返ってきた`worker.port`の`MessagePort`を経由してWorkerと通信します。`MessagePort`はデフォルトでメッセージを受け取らない設計で、受信を始めるためのきっかけが必要です。`onmessage`プロパティに代入する場合は自動でポートが開始されます。
+
+```js
+// page.js
+const worker = new SharedWorker('./worker.js');
+
+worker.port.onmessage = (event) => {
+  console.log('count:', event.data);
+};
+worker.port.postMessage({ type: 'increment' });
+```
+
+`addEventListener('message', ...)`でリスナーを登録する場合は自動開始されないので、`worker.port.start()`を明示的に呼ぶ必要があります。
+
+```js
+// page.js
+const worker = new SharedWorker('./worker.js');
+
+worker.port.addEventListener('message', (event) => {
+  console.log('count:', event.data);
+});
+// [!hl]
+worker.port.start();
+worker.port.postMessage({ type: 'increment' });
+```
+
+Worker側は`SharedWorkerGlobalScope`の`connect`イベントで、各接続から渡される`MessagePort`を受け取ります。
+
+```js
+// worker.js
+let count = 0;
+const ports = new Set();
+
+self.addEventListener('connect', (event) => {
+  // [!callout: 各接続専用のMessagePort]
+  const port = event.ports[0];
+  ports.add(port);
+
+  port.addEventListener('message', (msg) => {
+    if (msg.data.type === 'increment') {
+      count += 1;
+      for (const p of ports) {
+        p.postMessage(count);
+      }
+    }
+  });
+
+  port.start();
+});
+```
+
+`connect`イベントは新しいブラウジングコンテキストが接続するたびに発火します。`event.ports[0]`がそのコンテキスト専用のポートで、これを通じて双方向にメッセージをやり取りします。すべてのポートを集めておけば、いずれかのページで起きた変化を全タブにブロードキャストすることもできます。
+
+`event.ports`は仕様で「要素1個の凍結配列」と決まっているので、`event.ports[1]`以降は常に`undefined`です。接続後に追加のチャネルが必要になったら、`port.postMessage(data, [extraPort])`のように第2引数のtransferリストで`MessagePort`を送り、受け取り側の`message`イベントの`event.ports`から取り出します。`MessageChannel`で作った2本のポートのうち片方をWorkerに渡せば、独立した通信レーンを後付けで張れます。
+
+## 同一性とインスタンス共有
+
+SharedWorkerはURLと`name`の組み合わせで同一性が判定されます。同じURL（と同じ`name`）で複数回`new SharedWorker(...)`しても、起動済みのWorkerが再利用され、`connect`イベントが既存のWorkerに対して新しいポートを通知するだけです。
+
+```js
+const a = new SharedWorker('./worker.js');
+const b = new SharedWorker('./worker.js'); // 同じWorkerインスタンスに接続
+```
+
+別の`name`を渡すと、同じスクリプトから独立したインスタンスを起動できます。
+
+```js
+const realtime = new SharedWorker('./worker.js', { name: 'realtime' });
+const analytics = new SharedWorker('./worker.js', { name: 'analytics' });
+```
+
+ライフタイムは、いずれかの接続が生きている限り維持されます。すべての接続元ドキュメントが閉じられるとWorkerも終了します。
+
+スクリプトのトップレベルコードは、SharedWorkerが起動するときに一度だけ実行されます。以降は同じURL・`name`で`new SharedWorker(...)`しても再実行されず、`connect`イベントだけが追加で発火して新しい`MessagePort`が渡されます。先ほどの`worker.js`の`let count = 0;`や`const ports = new Set();`が1回だけ評価される一方で、`connect`ハンドラが接続のたびに走るのはこのためです。タブをまたいだ状態をWorker側のグローバルに置けるのが、SharedWorkerの旨味でもあります。
+
+## タブ間で同期するカウンタを作ってみる
+
+ここまでの動きを実際に試せるPlaygroundを置いておきます。
+
+<Playground title="タブ間カウンタ">
+  <SharedWorkerDemo />
+</Playground>
+
+このPlaygroundのWorker側コードは次の通りです。
+
+```js
+// /playgrounds/shared-worker.worker.js
+// [!hl]
+const STARTED_AT = Date.now();
+let count = 0;
+const ports = new Set();
+
+const broadcast = (message) => {
+  for (const p of ports) {
+    p.postMessage(message);
+  }
+};
+
+self.addEventListener('connect', (event) => {
+  const port = event.ports[0];
+  ports.add(port);
+
+  port.postMessage({
+    type: 'init',
+    startedAt: STARTED_AT,
+    count,
+    connections: ports.size,
+  });
+  broadcast({ type: 'connections', connections: ports.size });
+
+  port.addEventListener('message', (msg) => {
+    if (msg.data?.type === 'increment') {
+      count += 1;
+      broadcast({ type: 'count', count });
+      return;
+    }
+    if (msg.data?.type === 'disconnect') {
+      ports.delete(port);
+      broadcast({ type: 'connections', connections: ports.size });
+    }
+  });
+
+  port.start();
+});
+```
+
+ハイライトした`STARTED_AT`はWorkerが起動した瞬間のタイムスタンプで、トップレベルが一度しか実行されないことを目視で確認するために置いています。タブを追加で開いても同じ時刻が両タブに表示されるので、`let count = 0`や`ports`のSetがタブごとには初期化されないことが見て取れます。
+
+## ES Modulesとして読み込む
+
+<BaselineStatus featureId="js-modules-shared-workers" />
+
+Baseline 2026では`type: 'module'`オプションも揃い、SharedWorkerをES Modulesとして実行できるようになりました。
+
+```js
+// page.js
+// [!hl]
+const worker = new SharedWorker('./worker.js', { type: 'module' });
+```
+
+Worker側では`import`文がそのまま使えるため、メインスレッドと同じモジュールをWorkerから読み込んでロジックを共有できます。
+
+```js
+// worker.js
+// [!hl]
+import { calculate } from './shared-logic.js';
+
+self.addEventListener('connect', (event) => {
+  const port = event.ports[0];
+  port.addEventListener('message', (msg) => {
+    port.postMessage(calculate(msg.data));
+  });
+  port.start();
+});
+```
+
+モジュールWorkerにはいくつか挙動の違いがあります。
+
+- `importScripts()`はモジュールWorker内で呼び出すと失敗する。代わりに`import`を使う
+- スクリプトは自動的にStrict modeで実行される
+- トップレベルのvar / function宣言はモジュールスコープに閉じ、Worker全体のグローバルを汚染しない
+- `credentials`オプション（`'omit'` / `'same-origin'` / `'include'`）が有効になり、モジュールのフェッチに使う認証情報を制御できる
+
+なお、起動中のSharedWorkerに対して異なる`type`や`credentials`で`new SharedWorker(...)`しようとするとエラーになります。`classic`モードと`module`モードを同居させたいときは、別の`name`を指定して別インスタンスとして扱います。
+
+`type: 'module'`の挙動はService Workerの場合とほぼ同じです。Service Worker側の解説は[Service WorkerでES Modulesを使う](/blog/js-modules-service-workers)を参照してください。
+
+## 使いどころ
+
+SharedWorkerが効くのは、同一オリジンの複数の画面が同じバックエンド処理を共有したい場面です。
+
+- WebSocketなどの永続接続をタブごとに張らずWorker側で1本にまとめる
+- リアルタイム更新やプッシュ通知の受信ポイントを集約し、開いている全タブへ配信する
+- 重い計算やキャッシュをタブ間で共有して、二重実行を避ける
+- ログイン状態やフィーチャーフラグなど、タブをまたいだ状態の単一の窓口を作る
+
+逆に、ページの裏でちょっとした処理を回したいだけならDedicated Workerで十分です。SharedWorkerは1つの状態を複数のタブが共有することで初めて効果が出るので、共有する価値のあるリソースがあるかを最初に確認するとよいでしょう。
+
+## おわりに
+
+SharedWorkerはタブ間で1つのWorkerを共有できる仕組みで、ようやくBaseline 2026で全モダンブラウザに揃いました。同じタイミングで`type: 'module'`もサポートされたので、メインスレッドと同じES ModulesをWorkerからも読み込めて、コード共有のしやすさが一段引き上がっています。
+
+タブをまたいで共有したいリソースがある場面では、`BroadcastChannel`との組み合わせも検討しつつ、SharedWorkerを引き出しに加えてみてください。

--- a/packages/database/migrations/0043_careless_archangel.sql
+++ b/packages/database/migrations/0043_careless_archangel.sql
@@ -1,0 +1,11 @@
+-- 新しいタグの追加
+INSERT INTO tags (id, name) VALUES (130, 'shared-worker');--> statement-breakpoint
+-- ブログレコードの追加
+INSERT INTO blogs (id, slug, published, created_at)
+VALUES (67, 'shared-worker', 1, '2026-05-15T00:00:00.000Z');--> statement-breakpoint
+-- ビューカウント初期化
+INSERT INTO blog_views (blog_id, views) VALUES (67, 0);--> statement-breakpoint
+-- タグ紐付け (JavaScript: 10, Baseline 2026: 99, shared-worker: 130)
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (67, 10);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (67, 99);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (67, 130);

--- a/packages/database/migrations/meta/0043_snapshot.json
+++ b/packages/database/migrations/meta/0043_snapshot.json
@@ -1,0 +1,1315 @@
+{
+  "id": "ba2f4991-3dc3-4550-82d4-3db5273592ff",
+  "prevId": "f8f3180d-fd3d-46a5-92fc-a1ebd4a6256f",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "tableTo": "article_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_id_idx": {
+          "name": "comments_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_tag": {
+      "name": "slide_tag",
+      "columns": {
+        "slide_id": {
+          "name": "slide_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slide_tag_slide_id_idx": {
+          "name": "slide_tag_slide_id_idx",
+          "columns": [
+            "slide_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_tag_id_idx": {
+          "name": "slide_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_unique_idx": {
+          "name": "slide_tag_unique_idx",
+          "columns": [
+            "slide_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "slide_tag_slide_id_slides_id_fk": {
+          "name": "slide_tag_slide_id_slides_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "tableTo": "slides",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "slide_tag_tag_id_tags_id_fk": {
+          "name": "slide_tag_tag_id_tags_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slides": {
+      "name": "slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slides_slug_idx": {
+          "name": "slides_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_id_idx": {
+          "name": "talks_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -302,6 +302,13 @@
       "when": 1778838171212,
       "tag": "0042_sample_slide",
       "breakpoints": true
+    },
+    {
+      "idx": 43,
+      "version": "6",
+      "when": 1778849374750,
+      "tag": "0043_careless_archangel",
+      "breakpoints": true
     }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,7 @@ const ignorePatterns = [
   '.agents/**',
   '**/mockServiceWorker.js',
   '**/migrations/meta/**',
+  '**/public/**',
   '**/*.md',
   '**/*.mdx',
   '.claude/worktrees/**',


### PR DESCRIPTION
## 概要

Baseline 2026 で newly available になった `Shared worker` (`featureId: shared-workers`) と `JavaScript modules in shared workers` (`featureId: js-modules-shared-workers`) を1記事にまとめて追加する。タブ間でWorkerを共有するデモPlaygroundも同梱。

Closes #1741
Closes #1742

## 動機

両機能とも `2026-05-05` 揃いの新顔で、内容も密接（後者は前者の `type: 'module'` オプション）。別記事に分けると重複が増えるので統合した方が読みやすい。

## 詳細

### 記事 (`apps/main/src/app/blog/(articles)/shared-worker/`)

- `## SharedWorkerの基本` — ページ側 (`new SharedWorker(url)` + `worker.port`) と Worker 側 (`connect` イベント + `event.ports[0]`) のペア
  - `onmessage` 自動開始版と `addEventListener` + `port.start()` 明示版の両コードを併記
  - `event.ports` は length=1 固定であることと、追加チャネルを `postMessage` の transfer リストで送る話を明記
- `## 同一性とインスタンス共有` — URL+name で同一性が決まる、ライフタイム、トップレベルコードは1回だけ実行される非対称性
- `## タブ間で同期するカウンタを作ってみる` — Playgroundとそれを動かしているWorker側コードの提示
- `## ES Modulesとして読み込む` — `type: 'module'` オプション、`importScripts()` が失敗する点、`credentials` オプション、type違いインスタンスは別 `name` 必要、Service Worker 版記事へのリンク
- `## 使いどころ` — WebSocket等の永続接続集約、リアルタイム配信の集約、計算結果共有、ログイン状態の単一窓口
- frontmatter `featureIds: [shared-workers, js-modules-shared-workers]` 両方を載せ、/baseline 側からどちらのfeatureエントリでも本記事へリンク

### Playground (`apps/main/src/app/_components/playgrounds/shared-worker/`)

- `/playgrounds/shared-worker.worker.js` (publicに置く静的Workerスクリプト) を `new SharedWorker(WORKER_URL, { name: 'k8o-shared-worker-demo' })` で読み込む
  - Blob URL は `createObjectURL` のたびに別URLが生成され SharedWorker の同一性キーに使えないため、静的ファイル経由にしている（理由はコードコメントにも記載）
- UI: 大きな共有カウンタ + `+1` ボタン / Worker起動時刻 / 接続中のタブ数（数だけドット表示）
- `pagehide` で disconnect 送信、`event.persisted === true` の bfcache 復帰時は除外
- Storybook `staticDirs` に `'../public'` (= `apps/main/public`) を追加して、Story でも worker スクリプトが解決されるようにした

### マイグレーション

- tag id=130 `shared-worker` を追加
- blog id=67 `shared-worker` を紐付け (JavaScript / Baseline 2026 / shared-worker タグ)

### Lint設定

- `vite.config.ts` の `ignorePatterns` に `**/public/**` を追加。public 配下は project source ではなく、type-aware lint で worker の `self` 等が unknown 扱いになりノイズが多いため

## 気をつけるポイント

- Worker側コードは静的アセットとして `apps/main/public/playgrounds/shared-worker.worker.js` に置いている。記事本文のコードブロックと内容が一致するよう、変更時は両方更新が必要
- 接続数カウンタはブラウザクラッシュや強制終了では `pagehide` も発火しないため、孤立ポートが残る可能性がある（heartbeat実装は入れていない）

## 影響範囲

- 新規ブログ記事 `/blog/shared-worker`
- 新規Playground `SharedWorkerDemo` (Storybookにも自動的に追加される)
- `apps/main/public/playgrounds/` ディレクトリが新設される
- Storybook の `staticDirs` 変更で `apps/main/public` の他ファイルも将来Storybookから参照可能になる
- `/baseline` ツールは `baseline_snapshots` の同期後に両 featureId と本記事が紐付く

## テスト

- ローカルで `pnpm run dev` を立ち上げて記事描画を確認
- BaselineStatus widget が `shared-workers` / `js-modules-shared-workers` の両方で Baseline 2026 NEWLY AVAILABLE を表示することを確認
- Playgroundを2タブで開いて、Worker起動時刻一致 / カウンタ同期 / 接続数が両タブで2になることを確認
- リロード時に接続数が増えないこと（`pagehide` 経由の disconnect）を確認
- Codex CLI のレビューで `pagehide` の bfcache 対応・Storybook static dir 不足を指摘 → 反映済み