### PR TITLE
feat(blog): Baseline 2026 の text-decoration-skip-ink: all 記事を追加

### DIFF
--- a/apps/main/src/app/_components/playgrounds/index.ts
+++ b/apps/main/src/app/_components/playgrounds/index.ts
@@ -27,6 +27,7 @@ export * from './shape-function';
 export * from './shared-worker';
 export * from './spelling-grammar-error';
 export * from './suspense-list';
+export * from './text-decoration-skip-ink-all';
 export * from './text-indent-keywords';
 export * from './view-transitions';
 
@@ -56,6 +57,7 @@ import { shapeFunctionSection } from './shape-function';
 import { sharedWorkerSection } from './shared-worker';
 import { spellingGrammarErrorSection } from './spelling-grammar-error';
 import { suspenseListSection } from './suspense-list';
+import { textDecorationSkipInkAllSection } from './text-decoration-skip-ink-all';
 import { textIndentKeywordsSection } from './text-indent-keywords';
 import type { PlaygroundSection } from './types';
 import { viewTransitionsSection } from './view-transitions';
@@ -87,6 +89,7 @@ export const playgroundSections: PlaygroundSection[] = [
   highlightSection,
   shapeFunctionSection,
   spellingGrammarErrorSection,
+  textDecorationSkipInkAllSection,
   textIndentKeywordsSection,
   viewTransitionsSection,
 ];

--- a/apps/main/src/app/_components/playgrounds/text-decoration-skip-ink-all/index.ts
+++ b/apps/main/src/app/_components/playgrounds/text-decoration-skip-ink-all/index.ts
@@ -1,0 +1,19 @@
+import type { PlaygroundSection } from '../types';
+import { TextDecorationSkipInkDemo } from './text-decoration-skip-ink-demo';
+
+export { TextDecorationSkipInkDemo } from './text-decoration-skip-ink-demo';
+
+export const textDecorationSkipInkAllSection: PlaygroundSection = {
+  id: 'text-decoration-skip-ink-all',
+  title: 'text-decoration-skip-ink: all',
+  description:
+    'allの値で下線・上線がすべてのグリフのインクと交差する箇所で必ず途切れます。CJK文字でも下線が突き刺さらず、読みやすくなります。',
+  type: 'blog',
+  slug: 'text-decoration-skip-ink-all',
+  demos: [
+    {
+      component: TextDecorationSkipInkDemo,
+      title: 'skip-ink値の比較',
+    },
+  ],
+};

--- a/apps/main/src/app/_components/playgrounds/text-decoration-skip-ink-all/text-decoration-skip-ink-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/text-decoration-skip-ink-all/text-decoration-skip-ink-demo.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Playground } from '../playground';
+import { TextDecorationSkipInkDemo } from './text-decoration-skip-ink-demo';
+
+const playgroundTitle = TextDecorationSkipInkDemo.name;
+
+const meta: Meta<typeof TextDecorationSkipInkDemo> = {
+  title: 'playgrounds/text-decoration-skip-ink-all/TextDecorationSkipInkDemo',
+  component: TextDecorationSkipInkDemo,
+  decorators: [
+    (Story) => (
+      <Playground title={playgroundTitle}>
+        <Story />
+      </Playground>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TextDecorationSkipInkDemo>;
+
+export const Default: Story = {};

--- a/apps/main/src/app/_components/playgrounds/text-decoration-skip-ink-all/text-decoration-skip-ink-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/text-decoration-skip-ink-all/text-decoration-skip-ink-demo.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { FormControl, Select } from '@k8o/arte-odyssey';
+import { useState } from 'react';
+
+type SkipInk = 'auto' | 'none' | 'all';
+
+const SAMPLE_TEXT =
+  '日本語の文章にunderlineを引くと、漢字の下端やぐ・ゆなどに線が触れて読みづらくなりがちです。Latin script: jumping typography.';
+
+export function TextDecorationSkipInkDemo() {
+  const [value, setValue] = useState<SkipInk>('all');
+
+  return (
+    <div className="flex flex-col gap-6">
+      <FormControl
+        label="text-decoration-skip-ink"
+        renderInput={({ 'aria-labelledby': _, ...props }) => (
+          <Select
+            {...props}
+            onChange={(e) => {
+              setValue(e.target.value as SkipInk);
+            }}
+            options={[
+              { value: 'auto', label: 'auto (既定)' },
+              { value: 'none', label: 'none' },
+              { value: 'all', label: 'all (Baseline 2026)' },
+            ]}
+            value={value}
+          />
+        )}
+      />
+
+      <div className="bg-bg-base rounded-xl p-6 text-lg shadow-sm">
+        <p
+          style={{
+            textDecoration: 'underline',
+            textDecorationSkipInk: value,
+          }}
+        >
+          {SAMPLE_TEXT}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/app/blog/(articles)/text-decoration-skip-ink-all/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/text-decoration-skip-ink-all/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+const slug = 'text-decoration-skip-ink-all';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt,
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/text-decoration-skip-ink-all'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/text-decoration-skip-ink-all/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/text-decoration-skip-ink-all/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+export const alt = 'text-decoration-skip-ink: all';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const blog = await getBlogContent('text-decoration-skip-ink-all');
+
+  return OgImage({
+    category: 'Blog',
+    title: blog.title,
+  });
+}

--- a/apps/main/src/app/blog/(articles)/text-decoration-skip-ink-all/page.mdx
+++ b/apps/main/src/app/blog/(articles)/text-decoration-skip-ink-all/page.mdx
@@ -1,0 +1,65 @@
+---
+title: 'text-decoration-skip-ink: allでunderlineをすべてのグリフの周りで途切れさせる'
+description: 'text-decoration-skip-ink: allは、underlineやoverlineがグリフを横切る箇所を必ず途切れさせるCSSの値です。CJKに対しては線を途切れさせない実装が多いautoとの挙動の差を、Baseline 2026で揃った3つ目の値allと合わせて見ていきます。'
+createdAt: 2026-05-16
+updatedAt: 2026-05-16
+featureIds:
+  - text-decoration-skip-ink-all
+---
+
+import { BaselineStatus } from '@k8o/arte-odyssey';
+import {
+  Playground,
+  TextDecorationSkipInkDemo,
+} from '@/app/_components/playgrounds';
+
+# text-decoration-skip-ink: allでunderlineをすべてのグリフの周りで途切れさせる
+
+<BaselineStatus featureId="text-decoration-skip-ink-all" />
+
+## はじめに
+
+underlineやoverlineは文字の上下を横切るときに、ディセンダのある`g`や`p`、`y`のような文字とぶつかってしまうことがあります。underlineを引いただけだとそうした文字のループの底に線が突き刺さって読みにくくなるので、ブラウザは標準でグリフのインクと交差する箇所では線を途切れさせてくれます。
+
+その制御を担うのが`text-decoration-skip-ink`プロパティです。これまでは`auto`と`none`の2つの値で、ブラウザに任せるか一切途切れさせないかを選べました。Baseline 2026では`all`という3つ目の値が揃いました。
+
+## プロパティの基本と3つの値
+
+`text-decoration-skip-ink`はunderlineやoverlineをグリフのインク（実際にレンダリングされる字の形）と交差させるかどうかを制御します。値は3つあります。
+
+- `auto`（既定値） - ブラウザの判断でグリフを避けるかどうかを決める。ラテン文字のディセンダは通常避けるが、CJK文字には適用しないユーザーエージェントが多い
+- `none` - 途切れさせない。常に1本の線として描画する
+- `all` - すべてのグリフのインクと交差する箇所で必ず途切れさせる
+
+`auto`では仕様上ブラウザに裁量があり、どこを避けてどこを避けないかは実装次第です。`all`を指定すると裁量を排除して、グリフがあれば必ず線を切る挙動になります。
+
+## auto と all の挙動の差
+
+ラテン文字のunderlineは`auto`でも実用上ほとんどのブラウザがディセンダを避けてくれるので、`auto`と`all`の差は目に見えません。差が出るのは主にCJKテキストのunderlineです。
+
+[仕様](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-ink-property)上、`auto`は
+
+> UAs may interrupt underlines and overlines where the line would cross glyph ink
+
+とUAに裁量を与えているだけです。CJKに対しては多くのUAが線を途切れさせない実装になっており、結果として日本語の文章にunderlineを引くと、漢字の下端や`ぐ`、`ゆ`のような字に線が突き刺さった見た目になりがちです。
+
+`all`は
+
+> UAs must interrupt underlines and overlines where the line would cross glyph ink
+
+と義務になります（`may`と`must`の部分が異なります）。CJK文字でもラテン文字と同じようにunderlineがグリフを避けて途切れるようになり、グリフごとに線が刻まれるような見え方に変わります。`auto`の連続したunderlineを前提に組んだデザインに後付けで入れると、印象が大きく変わる点には注意してください。
+
+```css
+p {
+  text-decoration: underline;
+  text-decoration-skip-ink: all;
+}
+```
+
+<Playground title="skip-ink値の比較">
+  <TextDecorationSkipInkDemo />
+</Playground>
+
+## おわりに
+
+`text-decoration-skip-ink: all`はChromiumに長く欠けていた値がようやく揃ったというだけのもので、CJK混じりのunderlineが必ず読みやすくなるとは限りません。グリフの周りで線が大きく途切れることで、かえって途切れが目立って違和感が出る場面もあります。`auto`の挙動が物足りない箇所だけを狙って、実際の文章で見栄えを確認しながら使うかどうか決めるのがよさそうです。

--- a/packages/database/migrations/0044_lush_white_queen.sql
+++ b/packages/database/migrations/0044_lush_white_queen.sql
@@ -1,0 +1,11 @@
+-- 新しいタグの追加
+INSERT INTO tags (id, name) VALUES (131, 'text-decoration-skip-ink');--> statement-breakpoint
+-- ブログレコードの追加
+INSERT INTO blogs (id, slug, published, created_at)
+VALUES (68, 'text-decoration-skip-ink-all', 1, '2026-05-16T00:00:00.000Z');--> statement-breakpoint
+-- ビューカウント初期化
+INSERT INTO blog_views (blog_id, views) VALUES (68, 0);--> statement-breakpoint
+-- タグ紐付け (CSS: 30, Baseline 2026: 99, text-decoration-skip-ink: 131)
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (68, 30);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (68, 99);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (68, 131);

--- a/packages/database/migrations/meta/0044_snapshot.json
+++ b/packages/database/migrations/meta/0044_snapshot.json
@@ -1,0 +1,1315 @@
+{
+  "id": "0a283c4f-c24b-421e-8ce1-5d7e16d0e390",
+  "prevId": "ba2f4991-3dc3-4550-82d4-3db5273592ff",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "tableTo": "article_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_id_idx": {
+          "name": "comments_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_tag": {
+      "name": "slide_tag",
+      "columns": {
+        "slide_id": {
+          "name": "slide_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slide_tag_slide_id_idx": {
+          "name": "slide_tag_slide_id_idx",
+          "columns": [
+            "slide_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_tag_id_idx": {
+          "name": "slide_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_unique_idx": {
+          "name": "slide_tag_unique_idx",
+          "columns": [
+            "slide_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "slide_tag_slide_id_slides_id_fk": {
+          "name": "slide_tag_slide_id_slides_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "tableTo": "slides",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "slide_tag_tag_id_tags_id_fk": {
+          "name": "slide_tag_tag_id_tags_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slides": {
+      "name": "slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slides_slug_idx": {
+          "name": "slides_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_id_idx": {
+          "name": "talks_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1778849374750,
       "tag": "0043_careless_archangel",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "6",
+      "when": 1778892328781,
+      "tag": "0044_lush_white_queen",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

Baseline 2026 で newly available になった `text-decoration-skip-ink: all` (`featureId: text-decoration-skip-ink-all`) の記事と Playground を追加する。プロパティ自体は既に widely available だが、`all` 値だけが Chromium に長く欠けていて、Chrome 148 (2026-05-05) で揃った経緯がある。

Closes #1743

## 動機

- `all` を指定したときの挙動はラテン文字主体のサイトでは見えづらく、CJK で初めて差が出る。日本語で書く側にとって関心の高いトピックなので、auto との挙動差を中心に書く価値がある
- `all` を入れれば見た目が必ず良くなるわけではなく、`auto`連続を前提にしたデザインに後付けすると印象が大きく変わる。記事のトーンは「使えるようになった」ではなく「挙動の選択肢が一つ増えた、見た目は試してから判断」に寄せた

## 詳細

### 記事 (`apps/main/src/app/blog/(articles)/text-decoration-skip-ink-all/`)

- 構成: はじめに / プロパティの基本と3つの値 / auto と all の挙動の差 / Playground / おわりに
- `## auto と all の挙動の差` で[CSS Text Decoration Module Level 4の仕様](https://drafts.csswg.org/css-text-decor-4/#text-decoration-skip-ink-property)から auto / all 双方の文を引用し、差が `may` から `must` への1単語であることを括弧書きで示す
- frontmatter `featureIds: [text-decoration-skip-ink-all]`

### Playground (`apps/main/src/app/_components/playgrounds/text-decoration-skip-ink-all/`)

- Select で `auto` / `none` / `all` を切り替え、CJK と Latin 混在のサンプル文に underline を引いて比較
- `text-decoration-thickness` 等は指定せず、ブラウザ既定の underline 位置 (descender と交差する位置) で描画して、skip-ink の差が視覚的に確認できるようにしている

### マイグレーション

- tag id=131 `text-decoration-skip-ink`
- blog id=68 `text-decoration-skip-ink-all` (CSS / Baseline 2026 / text-decoration-skip-ink タグ)

## 気をつけるポイント

- 過去のCSP記事レビュー指摘を反映する形で、`text-underline-offset` を追加せずブラウザ既定に任せている。`text-decoration-skip-ink` の挙動を見せたい場面で underline を本文から離すと、descender と交差せず差が見えなくなる
- 本文のトーンは「all で必ず良くなる」とは書いていない。CJK で大きく変わることと、デザインによっては違和感が出ることを並べて書いている

## 影響範囲

- 新規ブログ記事 `/blog/text-decoration-skip-ink-all`
- 新規 Playground `TextDecorationSkipInkDemo` (Storybookにも追加)
- `/baseline` ツールは `baseline_snapshots` の同期後に featureId と本記事が紐付く

## テスト

- ローカルで `pnpm run dev` を立ち上げて記事描画 / Playground動作を確認
- BaselineStatus widget が `text-decoration-skip-ink-all` で Baseline 2026 NEWLY AVAILABLE を表示
- Playgroundで auto / none / all を切り替えて、Chromiumでも CJK 文字に対する skip-ink の差が見えることを確認
- Codex CLI のレビューでクリーン (.claude/worktrees/ の警告のみ、これは私の生成物ではない)