### PR TITLE
chore(claude): refine Claude Code settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,16 +1,28 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "permissions": {
+    "deny": [
+      "Bash(pnpm publish:*)",
+      "Bash(turso db destroy:*)",
+      "Bash(turso db delete:*)",
+      "Bash(turso db rotate:*)",
+      "Bash(vercel --prod:*)",
+      "Bash(vercel deploy --prod:*)",
+      "Bash(vercel rm:*)",
+      "Bash(vercel remove:*)",
+      "Bash(vercel project rm:*)",
+      "Bash(drizzle-kit drop:*)",
+      "Bash(chromatic:*)",
+      "Bash(pnpm exec chromatic:*)"
+    ]
+  },
   "hooks": {
-    "PostToolUse": [
+    "Stop": [
       {
-        "matcher": "Write|Edit",
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path' | xargs -r pnpm biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off --unsafe"
-          },
-          {
-            "type": "command",
-            "command": "pnpm ls-lint"
+            "command": "[ -z \"$(git status --porcelain 2>/dev/null)\" ] && exit 0; pnpm run check && pnpm run type-check && pnpm run test && pnpm run ls-lint"
           }
         ]
       }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -13,10 +13,22 @@
       "Bash(vercel project rm:*)",
       "Bash(drizzle-kit drop:*)",
       "Bash(chromatic:*)",
-      "Bash(pnpm exec chromatic:*)"
+      "Bash(pnpm exec chromatic:*)",
+      "Read(**/.next/**)",
+      "Read(**/.turbo/**)"
     ]
   },
   "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "b=$(git symbolic-ref --short HEAD 2>/dev/null); { [ \"$b\" = \"main\" ] || [ -z \"$b\" ]; } && exit 0; echo \"=== Commits on $b (not in main) ===\"; git log main..HEAD --oneline 2>/dev/null | head -20; echo; echo \"=== Files changed vs main ===\"; git diff main...HEAD --stat 2>/dev/null | tail -20"
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [


### PR DESCRIPTION
## 概要

`.claude/settings.json` の見直し。プロジェクト固有の破壊系コマンドを `permissions.deny` で塞ぎ、PostToolUse の per-edit な lint/format を撤去して、代わりに Stop hook と SessionStart hook で「終了時にCIが通る」「再開時に branch 文脈が分かる」を実現する。

## 動機

- Claude Codeの大規模コードベースベストプラクティスを読み、ガードレールとコンテキスト供給を分けて設計し直すため
- 旧 PostToolUse は `biome check` を呼んでいたが、リポジトリは既に oxc に移行済みで dead config になっていた
- 編集のたびに lint/ls-lint を回すより、終了時にCI相当を一括で回す方が体感が良い
- featureブランチ再開時、デフォルトの `gitStatus` には main からの差分が含まれず、毎回 `git log main..HEAD` を打っていた

## 詳細

### `permissions.deny` を新設

プロジェクトに固有の破壊系コマンドを deny:

- `Bash(pnpm publish:*)` — 内部パッケージの誤公開防止
- `Bash(turso db destroy:*)` / `delete:*` / `rotate:*` — 本番DB破壊・トークン揺らし防止
- `Bash(vercel --prod:*)` / `deploy --prod:*` / `rm:*` / `remove:*` / `project rm:*` — 本番デプロイ・削除は手動でやらせない
- `Bash(drizzle-kit drop:*)` — マイグレーションジャーナル破壊防止
- `Bash(chromatic:*)` / `Bash(pnpm exec chromatic:*)` — Storybook 誤upload防止

generated dir の Read deny:

- `Read(**/.next/**)` / `Read(**/.turbo/**)` — ビルド成果物の流し込みでコンテキストを汚さない

### hooks の刷新

旧: `PostToolUse` (Write|Edit) で biome check --write + ls-lint
新: `Stop` で `pnpm run check && type-check && test && ls-lint`(作業ツリーが clean ならスキップ)
追加: `SessionStart` で `git log main..HEAD` と `git diff main...HEAD --stat` を流し込む(main または HEAD 取得不能時はスキップ)

### Stop hook の guard

```sh
[ -z "$(git status --porcelain 2>/dev/null)" ] && exit 0
```

ツリーが clean なターン(何も編集しなかった応答)では何も走らない。

## 気をつけるポイント

- Stop hook は1ターンごとに走る。turbo キャッシュで2回目以降は秒で返るが、変更直後のターンだけは check + type-check + test が回る分の待ち時間がある
- SessionStart hook は HEAD が `main` または detached のときは何も出さない
- `Read(**/.next/**)` deny は `apps/main/.next` `apps/admin/.next` の両方に効く glob。`dist/**` は ArteOdyssey の `node_modules/.../dist/components` 読み取りと衝突するため対象外

## 影響範囲

- Claude Code 経由で本リポジトリを触る作業全般
- 本番DB・本番デプロイ・publish 系コマンドはガードレールに守られる
- セッション開始 / 終了の体感が変わる

## テスト

- `.vite-hooks/pre-commit` 経由で staged file commit が通ることをローカル確認
- SessionStart hook のコマンドを手動実行し、feature branch では log と diff stat が出力されること、main では何も出ないことを確認
- Stop hook の guard を手動実行し、dirty tree で checks に進むことを確認