### PR TITLE
docs: split AGENTS.md per app and package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,80 +35,24 @@ pnpm run -F @repo/database migrate  # マイグレーション実行
 ## モノレポ構成
 
 ```
-apps/main/          → Next.jsアプリ（メイン）
-apps/admin/         → 管理サイト（Better Auth + GitHub OAuth）
-packages/database/  → Drizzle ORM + Turso (libSQL)
-packages/helpers/   → 共有ユーティリティ（in-source testing）
+apps/main/          → Next.jsアプリ（メイン）            → apps/main/AGENTS.md
+apps/admin/         → 管理サイト（Better Auth）          → apps/admin/AGENTS.md
+packages/database/  → Drizzle ORM + Turso (libSQL)       → packages/database/AGENTS.md
+packages/helpers/   → 共有ユーティリティ                  → packages/helpers/AGENTS.md
 packages/typescript-config/ → 共有TS設定
+packages/code-highlight/    → コードハイライト
 ```
+
+各 app / package 固有の規約は、対応する `AGENTS.md` を参照すること。
 
 パッケージ間依存:
 
 - `apps/main` → `@repo/database`, `@repo/helpers`
 - `apps/admin` → `@repo/database`, `@repo/helpers`
 
-## アーキテクチャ
-
-### レイヤー構成（apps/main/src/, apps/admin/src/）
-
-- **app/** - Next.js App RouterのルーティングとUI composition
-  - `page.tsx`, `layout.tsx`, `route.ts`, `opengraph-image.tsx`, `sitemap.ts` などのNext.js entryを置く
-  - UIコンポーネントは `app/**/_components` に置く。route専用ならroute配下、複数routeで使うなら `app/_components`
-  - route localな状態・型・純粋utilityは `app/**/_state`, `app/**/_types`, `app/**/_utils` に置いてよい
-  - `_api` は新規作成しない。Next.js entryからは `features/*/interface` を読む
-  - `(articles)/` のような括弧はNext.jsルートグループ
-  - `apps/admin` でも `_actions` は新規作成せず、Server Actions は `features/*/interface` に置く
-- **features/** - 機能単位の非UIロジック
-  - `features/<feature>/interface/` - Next.jsとの境界。`cacheLife`, `'use server'`, `FormData`, `Request`/`Response`向けのvalidationを置く
-  - `features/<feature>/application/` - ユースケース・整形・機能固有の組み立て。小さい読み取り処理はここに置いてよい
-  - `features/<feature>/infrastructure/` - DB、外部API、ファイルシステムなど外部接続の詳細。処理が太くなったら application からここへ切り出す
-  - UIコンポーネントは置かない。UIは必ず `app/**/_components`
-- **shared/** - `apps/main` 内で横断利用する非UI共通処理
-  - app固有の認証、MDX、OGP、browser API、validation初期化、site metadataなど
-  - UIコンポーネントや `cn` は置かない
-- **mocks/** - MSWモック定義
-
-依存方向:
-
-```txt
-app -> features/*/interface -> features/*/application
-features/*/application -> features/*/infrastructure
-app -> app/**/_components
-features/shared -> packages/helpers
-```
-
-`packages/helpers` はアプリ非依存の純粋helperを置く。`cn` はclassName文字列を合成するhelperなので `packages/helpers` に残す。
-
 `@repo/database` の import 境界は現時点では規約で運用する。機械的な禁止ルールは、今後 Biome から oxc に置き換えるタイミングで導入する。
 
-### Cache 方針
-
-Next.js の `cacheLife` は `features/*/interface` に置く。`app` のUIコンポーネントや `application` 層には原則として置かない。
-
-- `cacheLife('minutes')` - dashboard、admin の一覧、外部データ同期後に再検証される読み取りなど、短時間で鮮度が必要なもの
-- `cacheLife('max')` - MDX metadata、静的な site metadata、ビルド時に近い安定データ
-
-キャッシュを変更する Server Action / Route Handler は、更新対象の route に `revalidatePath` を明示する。
-
-### データベース（packages/database/）
-
-Drizzle ORM + Turso (libSQL)。Conditional Export Mapsで環境切り替え:
-- `storybook` → `__mocks__/db.ts`（モックDB）
-- `node` / `default` → 実DBクライアント
-
-## コーディング規約
-
-### TailwindCSS：ArteOdysseyカスタムトークンのみ使用
-
-ArteOdysseyのドキュメントは `apps/main/node_modules/@k8o/arte-odyssey/docs/` を参照すること。
-
-```tsx
-// ✅ Good
-<div className="text-fg-base bg-bg-base">
-
-// ❌ Bad（標準Tailwind禁止）
-<div className="text-gray-900 bg-white">
-```
+## 共通コーディング規約
 
 ### TypeScript
 
@@ -116,27 +60,6 @@ ArteOdysseyのドキュメントは `apps/main/node_modules/@k8o/arte-odyssey/do
 - `enum` 禁止: OXC `typescript/no-enum` / `oxc/no-const-enum` で強制
 - `any` 禁止、戻り値型は明示
 - `forEach` 禁止（`for...of` を使う）
-
-### React/Next.js
-
-- Next.jsの機能やAPIについては `apps/main/node_modules/next/dist/docs/` のバンドルドキュメントを参照すること
-- Server Componentsがデフォルト、必要な場合のみ `'use client'`
-- 関数コンポーネントのみ
-- `forwardRef` 禁止
-
-### UIコンポーネント作業時のStorybook MCP利用
-
-- UIコンポーネントを扱う作業では、回答や実装に入る前に必ず対象アプリに対応するStorybook MCPを使い、Storybook上のコンポーネント情報とドキュメントを確認すること
-- `apps/main` のStorybookは `main-storybook-mcp` を使うこと
-- `apps/admin` のStorybookは `admin-storybook-mcp` を使うこと
-- **重要: コンポーネントのpropsを推測で使わないこと。** デザインシステムのコンポーネントでpropsを1つでも使う前に、`shadow` のような一般的に見える名前であっても、MCPツールでそのpropsが実際に定義されているか確認すること
-- まず `list-all-documentation` を実行して、利用可能なコンポーネント一覧を取得すること
-- 次に対象コンポーネントに対して `get-documentation` を実行し、利用可能なprops、説明、サンプルを確認すること
-- 明示的にドキュメント化されているprops、またはサンプルStory内で使用されているpropsだけを使うこと
-- propsがドキュメントに存在しない場合、命名規則や他ライブラリの慣習から推測して使ってはいけない。その場合はユーザーに確認すること
-- Storyの新規作成や更新を行う前に、必ず `get-storybook-story-instructions` を実行して最新の作成ルールと推奨事項を確認すること
-- 作業後は `run-story-tests` を実行して検証すること
-- Story名と実際のprops名が一致しない場合があるため、Story名だけで判断せず、必ずドキュメントまたはサンプル実装でpropsを確認すること
 
 ### ファイル命名
 

--- a/apps/admin/AGENTS.md
+++ b/apps/admin/AGENTS.md
@@ -35,7 +35,17 @@ ArteOdysseyのドキュメントは `apps/admin/node_modules/@k8o/arte-odyssey/d
 
 ## UIコンポーネント作業時のStorybook MCP利用
 
-apps/admin のStorybookは **`admin-storybook-mcp`** を使うこと。利用ルールは apps/main と同じ（`list-all-documentation` → `get-documentation` → 推測せず確認、Storyの新規作成・更新前に `get-storybook-story-instructions`、作業後に `run-story-tests`）。
+apps/admin のStorybookは **`admin-storybook-mcp`** を使うこと。
+
+- UIコンポーネントを扱う作業では、回答や実装に入る前に必ず `admin-storybook-mcp` を使い、Storybook上のコンポーネント情報とドキュメントを確認すること
+- **重要: コンポーネントのpropsを推測で使わないこと。** デザインシステムのコンポーネントでpropsを1つでも使う前に、`shadow` のような一般的に見える名前であっても、MCPツールでそのpropsが実際に定義されているか確認すること
+- まず `list-all-documentation` を実行して、利用可能なコンポーネント一覧を取得すること
+- 次に対象コンポーネントに対して `get-documentation` を実行し、利用可能なprops、説明、サンプルを確認すること
+- 明示的にドキュメント化されているprops、またはサンプルStory内で使用されているpropsだけを使うこと
+- propsがドキュメントに存在しない場合、命名規則や他ライブラリの慣習から推測して使ってはいけない。その場合はユーザーに確認すること
+- Storyの新規作成や更新を行う前に、必ず `get-storybook-story-instructions` を実行して最新の作成ルールと推奨事項を確認すること
+- 作業後は `run-story-tests` を実行して検証すること
+- Story名と実際のprops名が一致しない場合があるため、Story名だけで判断せず、必ずドキュメントまたはサンプル実装でpropsを確認すること
 
 ## 認証
 

--- a/apps/admin/AGENTS.md
+++ b/apps/admin/AGENTS.md
@@ -1,0 +1,44 @@
+# apps/admin AGENTS.md
+
+管理サイト。Better Auth + GitHub OAuth で認証する。
+
+## レイヤー構成（src/）
+
+apps/main と同じ `app / features / shared` 構成。Server-side処理の置き場所も同じく `features/*/interface`（Next.jsとの境界）と `features/*/application` / `features/*/infrastructure` に分ける。
+
+- **app/** - Next.js App Router の entry と UI composition。UIは `app/**/_components`
+- **features/** - 非UIロジック。`interface / application / infrastructure` の3層
+- **shared/** - apps/admin 内で横断利用する非UI共通処理。UIや `cn` は置かない
+
+### Server Actions の置き場所
+
+`_actions` は新規作成しない。Server Actions（`'use server'`）は `features/*/interface` に置くこと。
+
+## React/Next.js
+
+- Next.jsの機能やAPIについては `apps/admin/node_modules/next/dist/docs/` のバンドルドキュメントを参照すること
+- Server Componentsがデフォルト、必要な場合のみ `'use client'`
+- 関数コンポーネントのみ
+- `forwardRef` 禁止
+
+## TailwindCSS：ArteOdysseyカスタムトークンのみ使用
+
+ArteOdysseyのドキュメントは `apps/admin/node_modules/@k8o/arte-odyssey/docs/` を参照すること。
+
+```tsx
+// ✅ Good
+<div className="text-fg-base bg-bg-base">
+
+// ❌ Bad（標準Tailwind禁止）
+<div className="text-gray-900 bg-white">
+```
+
+## UIコンポーネント作業時のStorybook MCP利用
+
+apps/admin のStorybookは **`admin-storybook-mcp`** を使うこと。利用ルールは apps/main と同じ（`list-all-documentation` → `get-documentation` → 推測せず確認、Storyの新規作成・更新前に `get-storybook-story-instructions`、作業後に `run-story-tests`）。
+
+## 認証
+
+Better Auth + GitHub OAuth。ローカル開発URL は `http://admin.localhost:1355/`。
+
+設定や運用上の注意は Better Auth のスキル（`better-auth-best-practices` / `better-auth-security-best-practices`）を参照すること。

--- a/apps/admin/CLAUDE.md
+++ b/apps/admin/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/apps/main/AGENTS.md
+++ b/apps/main/AGENTS.md
@@ -40,7 +40,7 @@ features/shared -> packages/helpers
 
 Next.js の `cacheLife` は `features/*/interface` に置く。`app` のUIコンポーネントや `application` 層には原則として置かない。
 
-- `cacheLife('minutes')` - dashboard、admin の一覧、外部データ同期後に再検証される読み取りなど、短時間で鮮度が必要なもの
+- `cacheLife('minutes')` - 外部データ同期後に再検証される読み取りなど、短時間で鮮度が必要な一覧系
 - `cacheLife('max')` - MDX metadata、静的な site metadata、ビルド時に近い安定データ
 
 キャッシュを変更する Server Action / Route Handler は、更新対象の route に `revalidatePath` を明示する。

--- a/apps/main/AGENTS.md
+++ b/apps/main/AGENTS.md
@@ -1,0 +1,72 @@
+# apps/main AGENTS.md
+
+メインのNext.jsアプリ。ブログ(MDX)、トーク、開発者向けツール群。
+
+## レイヤー構成（src/）
+
+- **app/** - Next.js App RouterのルーティングとUI composition
+  - `page.tsx`, `layout.tsx`, `route.ts`, `opengraph-image.tsx`, `sitemap.ts` などのNext.js entryを置く
+  - UIコンポーネントは `app/**/_components` に置く。route専用ならroute配下、複数routeで使うなら `app/_components`
+  - route localな状態・型・純粋utilityは `app/**/_state`, `app/**/_types`, `app/**/_utils` に置いてよい
+  - `_api` は新規作成しない。Next.js entryからは `features/*/interface` を読む
+  - `(articles)/` のような括弧はNext.jsルートグループ
+- **features/** - 機能単位の非UIロジック
+  - `features/<feature>/interface/` - Next.jsとの境界。`cacheLife`, `'use server'`, `FormData`, `Request`/`Response`向けのvalidationを置く
+  - `features/<feature>/application/` - ユースケース・整形・機能固有の組み立て。小さい読み取り処理はここに置いてよい
+  - `features/<feature>/infrastructure/` - DB、外部API、ファイルシステムなど外部接続の詳細。処理が太くなったら application からここへ切り出す
+  - UIコンポーネントは置かない。UIは必ず `app/**/_components`
+- **shared/** - apps/main 内で横断利用する非UI共通処理
+  - app固有の認証、MDX、OGP、browser API、validation初期化、site metadataなど
+  - UIコンポーネントや `cn` は置かない
+- **mocks/** - MSWモック定義
+
+依存方向:
+
+```txt
+app -> features/*/interface -> features/*/application
+features/*/application -> features/*/infrastructure
+app -> app/**/_components
+features/shared -> packages/helpers
+```
+
+## React/Next.js
+
+- Next.jsの機能やAPIについては `apps/main/node_modules/next/dist/docs/` のバンドルドキュメントを参照すること
+- Server Componentsがデフォルト、必要な場合のみ `'use client'`
+- 関数コンポーネントのみ
+- `forwardRef` 禁止
+
+## Cache 方針
+
+Next.js の `cacheLife` は `features/*/interface` に置く。`app` のUIコンポーネントや `application` 層には原則として置かない。
+
+- `cacheLife('minutes')` - dashboard、admin の一覧、外部データ同期後に再検証される読み取りなど、短時間で鮮度が必要なもの
+- `cacheLife('max')` - MDX metadata、静的な site metadata、ビルド時に近い安定データ
+
+キャッシュを変更する Server Action / Route Handler は、更新対象の route に `revalidatePath` を明示する。
+
+## TailwindCSS：ArteOdysseyカスタムトークンのみ使用
+
+ArteOdysseyのドキュメントは `apps/main/node_modules/@k8o/arte-odyssey/docs/` を参照すること。
+
+```tsx
+// ✅ Good
+<div className="text-fg-base bg-bg-base">
+
+// ❌ Bad（標準Tailwind禁止）
+<div className="text-gray-900 bg-white">
+```
+
+## UIコンポーネント作業時のStorybook MCP利用
+
+apps/main のStorybookは **`main-storybook-mcp`** を使うこと。
+
+- UIコンポーネントを扱う作業では、回答や実装に入る前に必ず `main-storybook-mcp` を使い、Storybook上のコンポーネント情報とドキュメントを確認すること
+- **重要: コンポーネントのpropsを推測で使わないこと。** デザインシステムのコンポーネントでpropsを1つでも使う前に、`shadow` のような一般的に見える名前であっても、MCPツールでそのpropsが実際に定義されているか確認すること
+- まず `list-all-documentation` を実行して、利用可能なコンポーネント一覧を取得すること
+- 次に対象コンポーネントに対して `get-documentation` を実行し、利用可能なprops、説明、サンプルを確認すること
+- 明示的にドキュメント化されているprops、またはサンプルStory内で使用されているpropsだけを使うこと
+- propsがドキュメントに存在しない場合、命名規則や他ライブラリの慣習から推測して使ってはいけない。その場合はユーザーに確認すること
+- Storyの新規作成や更新を行う前に、必ず `get-storybook-story-instructions` を実行して最新の作成ルールと推奨事項を確認すること
+- 作業後は `run-story-tests` を実行して検証すること
+- Story名と実際のprops名が一致しない場合があるため、Story名だけで判断せず、必ずドキュメントまたはサンプル実装でpropsを確認すること

--- a/apps/main/CLAUDE.md
+++ b/apps/main/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/packages/database/AGENTS.md
+++ b/packages/database/AGENTS.md
@@ -1,0 +1,24 @@
+# @repo/database AGENTS.md
+
+Drizzle ORM + Turso (libSQL) のDBクライアントとスキーマを提供する。
+
+## Conditional Export Maps による環境切り替え
+
+`package.json` の `exports` で実行環境ごとにクライアントを切り替えている:
+
+- `storybook` → `__mocks__/db.ts`（モックDB）
+- `node` / `default` → 実DBクライアント
+
+新規モジュールを追加するときは、Storybook 実行時にDBへ接続しないよう、必要に応じて `__mocks__/` 側にも対応する mock を用意すること。
+
+## マイグレーション
+
+```bash
+pnpm run -F @repo/database migrate
+```
+
+## import 境界
+
+`@repo/database` を直接 import するのは `apps/*/src/features/*/infrastructure/` を基本とする。`app/` や `features/*/interface` から直接読まない。
+
+現時点ではこの境界は規約運用。今後 Biome から oxc に置き換える際に機械的なルールを導入予定。

--- a/packages/database/CLAUDE.md
+++ b/packages/database/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md

--- a/packages/helpers/AGENTS.md
+++ b/packages/helpers/AGENTS.md
@@ -1,0 +1,23 @@
+# @repo/helpers AGENTS.md
+
+アプリ非依存の純粋ヘルパーを置く。
+
+## 置くもの / 置かないもの
+
+- 置く: Next.js / React / DB / 認証などに依存しない汎用ロジック。`cn`（className文字列の合成）もここ
+- 置かない: app固有のロジック、UIコンポーネント、外部サービス接続
+
+## テスト方針: in-source testing
+
+`if (import.meta.vitest)` ブロックで同ファイル内にテストを書く。
+
+```ts
+export const add = (a: number, b: number) => a + b;
+
+if (import.meta.vitest) {
+  const { describe, expect, test } = import.meta.vitest;
+  describe('add', () => {
+    test('正常系', () => expect(add(1, 2)).toBe(3));
+  });
+}
+```

--- a/packages/helpers/CLAUDE.md
+++ b/packages/helpers/CLAUDE.md
@@ -1,0 +1,3 @@
+# CLAUDE.md
+
+@AGENTS.md


### PR DESCRIPTION
## 概要

ルート `AGENTS.md` をモノレポ全体像と共通規約だけに絞り、各 app / package 固有の規約をサブディレクトリの `AGENTS.md` に分割。`CLAUDE.md` は各サブディレクトリでも `@AGENTS.md` を import する形を踏襲。

## 動機

- Claude Code の large-codebase ベストプラクティスにある「root for the big picture, subdirectory files for local conventions」パターンに沿う
- ルート `AGENTS.md` がレイヤー構成 / Cache 方針 / Tailwind / Storybook MCP まで全部抱えていて常時ロードコストが高かった
- ArteOdyssey や Storybook MCP の参照先は app ごとに違うのに、ルート1ファイルで「両app向け」と書くのが回りくどかった

## 詳細

### ルート `AGENTS.md`

- モノレポ全体像、コマンド、パッケージ間依存、共通TypeScript規約、ファイル命名、テスト戦略テーブル、コミット、ブランチ、Git Hooks のみ残す
- レイヤー構成・Cache方針・TailwindCSS・React/Next.js・Storybook MCP・データベース項は各サブAGENTS.mdへ移譲
- 「各 app / package 固有の規約は対応する `AGENTS.md` を参照」と明示

### `apps/main/`

- レイヤー構成（app / features / shared / mocks）
- 依存方向
- Cache 方針（`cacheLife('minutes')` / `cacheLife('max')`）
- TailwindCSS ArteOdysseyトークン規約（参照パス `apps/main/node_modules/@k8o/arte-odyssey/docs/`）
- React/Next.js 規約
- Storybook MCP は **`main-storybook-mcp`** を使う

### `apps/admin/`

- レイヤー構成（main と同じ3層）
- `_actions` は新規作成しない / Server Actions は `features/*/interface`
- TailwindCSS ArteOdysseyトークン規約（参照パスは `apps/admin/node_modules/...`）
- React/Next.js 規約（同上）
- Storybook MCP は **`admin-storybook-mcp`** を使う
- Better Auth + GitHub OAuth、ローカル開発URL

### `packages/database/`

- Drizzle ORM + Turso (libSQL)
- Conditional Export Maps（storybook / node / default）
- マイグレーションコマンド
- import 境界

### `packages/helpers/`

- 置くもの / 置かないもの（`cn` の置き場所根拠も）
- in-source testing パターン (`if (import.meta.vitest)`) の例

### スキップしたもの

- `packages/typescript-config/` — pure JSON設定なのでAGENTS.md不要
- `packages/code-highlight/` — 構造が自明なのでAGENTS.md不要

## 気をつけるポイント

- `CLAUDE.md` → `@AGENTS.md` のimportパターンを各サブディレクトリでも踏襲。Codex CLI など他agentからも読めるように
- 共通規約（TypeScript / ファイル命名 / コミット / Git Hooks）はルートに残し、サブには重複させない
- React/Next.js 規約は両appに同じ内容を載せている（参照パスだけapp別）。完全な共通項目だが、ルートに残すと「両app向け」と書く必要があって読みづらいので app 側に置いた

## 影響範囲

- AIエージェント（Claude Code / Codex CLI）が読むコンテキストの構造のみ
- ランタイム・ビルド・テストへの影響なし

## テスト

- ls-lint が通ること
- 各 AGENTS.md / CLAUDE.md のフォーマットと内部リンクを目視確認