### PR TITLE
chore: drop version pin from knip schema URL

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://unpkg.com/knip@5/schema.json",
+  "$schema": "https://unpkg.com/knip/schema.json",
   "ignore": [
     "apps/main/src/app/_components/coming-soon/index.ts",
     "apps/main/src/app/_components/development-only/development-only.tsx",


### PR DESCRIPTION
## 概要

`knip.json` の `\$schema` から版数ピン (`@5`) を外して `https://unpkg.com/knip/schema.json` に変える。knip 本体のメジャー版アップ時に追随して手動で URL を書き換える運用を不要にする。

## 動機

unpkg は版数を省略すると最新版を返してくれる。knip のスキーマは互換維持が前提なので、最新を引いておけば常に最新仕様で IDE 補完が効く。版数を固定する積極的な理由が現状無いので外す。

## 詳細

```diff
-  "\$schema": "https://unpkg.com/knip@5/schema.json",
+  "\$schema": "https://unpkg.com/knip/schema.json",
```

## 影響範囲

- `knip.json` の \$schema のみ
- ランタイム動作には影響なし（IDE のスキーマ補完だけ）

## テスト

- `pnpm run knip` が通ることを確認