### PR TITLE
refactor: drop skills entry from artifacts

### DIFF
--- a/apps/main/src/features/artifacts/application/artifacts.test.ts
+++ b/apps/main/src/features/artifacts/application/artifacts.test.ts
@@ -4,7 +4,7 @@ describe('getArtifacts', () => {
   it('公開している制作物一覧を返す', () => {
     const projects = getArtifacts();
 
-    expect(projects).toHaveLength(10);
+    expect(projects).toHaveLength(9);
     expect(projects).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -18,12 +18,6 @@ describe('getArtifacts', () => {
           githubUrl: 'https://github.com/k35o/oxc-config',
           websiteUrl: null,
           npmPackageName: '@k8o/oxc-config',
-        }),
-        expect.objectContaining({
-          name: 'skills',
-          githubUrl: 'https://github.com/k35o/skills',
-          websiteUrl: null,
-          npmPackageName: null,
         }),
         expect.objectContaining({
           name: 'patrol-board',

--- a/apps/main/src/features/artifacts/application/artifacts.ts
+++ b/apps/main/src/features/artifacts/application/artifacts.ts
@@ -34,14 +34,6 @@ export const getArtifacts = (): Artifact[] => [
     tags: ['Dotfiles', 'Shell', 'Config', 'Personal'],
   },
   {
-    name: 'skills',
-    description: 'ClaudeやCodexなどで使う自分用のAIエージェント向けskills集。',
-    githubUrl: 'https://github.com/k35o/skills',
-    websiteUrl: null,
-    npmPackageName: null,
-    tags: ['AI Agent', 'Skills', 'Config', 'Personal'],
-  },
-  {
     name: 'better-css-modules',
     description: 'CSS Modulesを扱いやすくするための実験的なツール。',
     githubUrl: 'https://github.com/k35o/better-css-modules',

--- a/apps/main/src/shared/site/page-metadata.ts
+++ b/apps/main/src/shared/site/page-metadata.ts
@@ -6,7 +6,7 @@ type LlmMetadata = {
 export const pageMetadata = {
   artifacts: {
     title: 'Artifacts',
-    description: 'dotfilesやskills、自作ツールなどの制作物をまとめています。',
+    description: 'dotfilesや自作ツールなどの制作物をまとめています。',
   },
   baseConverter: {
     title: '基数チェンジャー',


### PR DESCRIPTION
## Summary

- skillsはdotfilesに統合する方針のため、Artifacts一覧から `skills` エントリを削除
- それに伴い `getArtifacts` のテスト件数を 10 → 9 に更新し、skillsに対する `expect.objectContaining` も削除
- Artifactsページの description から「skills」の言及を削除

## Test plan

- [x] `pnpm vitest run src/features/artifacts/application/artifacts.test.ts --project="features test"` がパスすることを確認