### PR TITLE
feat(slides): add MDX-based slide decks with presenter mode

### DIFF
--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -88,6 +88,11 @@ export default function Home() {
               title="Talks"
             />
             <AppCard
+              description="登壇や発表で使ったスライドをアプリ内で見られます。"
+              link="/slides"
+              title="Slides"
+            />
+            <AppCard
               description="ブログ記事や興味のある技術の試作品を集めています。"
               link="/playgrounds"
               title="Playgrounds"

--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -88,11 +88,6 @@ export default function Home() {
               title="Talks"
             />
             <AppCard
-              description="登壇や発表で使ったスライドをアプリ内で見られます。"
-              link="/slides"
-              title="Slides"
-            />
-            <AppCard
               description="ブログ記事や興味のある技術の試作品を集めています。"
               link="/playgrounds"
               title="Playgrounds"

--- a/apps/main/src/app/sitemap.ts
+++ b/apps/main/src/app/sitemap.ts
@@ -1,12 +1,17 @@
 import type { MetadataRoute } from 'next';
 
 import { getBlogContents } from '@/features/blog/interface/queries';
+import { getSlideContents } from '@/features/slides/interface/queries';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const blogs = await getBlogContents();
+  const slides = await getSlideContents();
 
   const blogMap = blogs.map((blog) => ({
     url: `https://k8o.me/blog/${blog.slug}`,
+  }));
+  const slideMap = slides.map((slide) => ({
+    url: `https://k8o.me/slides/${slide.slug}`,
   }));
 
   return [
@@ -18,6 +23,11 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'weekly',
     },
     ...blogMap,
+    {
+      url: 'https://k8o.me/slides',
+      changeFrequency: 'weekly',
+    },
+    ...slideMap,
     {
       url: 'https://k8o.me/base-converter',
     },

--- a/apps/main/src/app/slides/(decks)/sample-deck/content.mdx
+++ b/apps/main/src/app/slides/(decks)/sample-deck/content.mdx
@@ -1,0 +1,86 @@
+---
+title: サンプルスライド
+description: スライド機能の動作確認用デッキ。
+createdAt: 2026-05-15
+updatedAt: 2026-05-15
+---
+
+import {
+  Cover,
+  Image,
+  Notes,
+  SlideDeckShell,
+} from '@/app/slides/_components/slide-mdx';
+import k8oImage from '@/app/_images/k8o.jpg';
+
+<SlideDeckShell slug="sample-deck" title="サンプルスライド">
+
+<Cover>
+
+# k8o のスライド機能
+
+## サンプルプレゼンテーション
+
+2026年5月 / k8o
+
+</Cover>
+
+---
+
+## スライド機能のご紹介
+
+k8o.meに追加されたスライド機能のサンプルデッキです。
+
+<Notes>
+これは1枚目のノート。発表者モードでのみ表示される。
+</Notes>
+
+---
+
+## 操作
+
+- 矢印キー: 前後のスライドへ移動
+- スペース: 次のスライドへ
+- Home / End: 最初 / 最後へ
+
+<Notes>
+操作説明スライド。キーボード操作中心。
+</Notes>
+
+---
+
+## コードハイライト
+
+```ts
+const greet = (name: string): string => `Hello, ${name}!`;
+
+console.log(greet('k8o'));
+```
+
+`rehype` の `@repo/code-highlight` が効くので、ブログと同じ見た目でシンタックスハイライトされる。
+
+---
+
+## 発表者モード
+
+右上の「発表者モード」リンクから別タブで開ける。`BroadcastChannel`で観覧側と同期する。
+
+---
+
+## 画像の埋め込み
+
+<Image src={k8oImage} alt="k8oのアイコン" caption="ローカルの静的インポート画像を埋め込み" />
+
+`import` した `StaticImageData` を `<Image src={...} />` に渡せば、Next.js `Image` 経由で最適化される。
+
+---
+
+## おわり
+
+ご清聴ありがとうございました。
+
+<Notes>
+クロージング。質疑への誘導など。
+</Notes>
+
+</SlideDeckShell>

--- a/apps/main/src/app/slides/(decks)/sample-deck/layout.tsx
+++ b/apps/main/src/app/slides/(decks)/sample-deck/layout.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+
+import { getSlideContent } from '@/features/slides/interface/queries';
+
+const slug = 'sample-deck';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const slide = await getSlideContent(slug);
+  return {
+    title: slide.title,
+    description: slide.description,
+    openGraph: {
+      title: slide.title,
+      description: slide.description ?? undefined,
+      url: `https://k8o.me/slides/${slug}`,
+      publishedTime: slide.createdAt,
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: slide.title,
+      card: 'summary_large_image',
+      description: slide.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/slides/sample-deck'>) {
+  return <Suspense fallback={null}>{children}</Suspense>;
+}

--- a/apps/main/src/app/slides/(decks)/sample-deck/opengraph-image.tsx
+++ b/apps/main/src/app/slides/(decks)/sample-deck/opengraph-image.tsx
@@ -1,0 +1,18 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getSlideContent } from '@/features/slides/interface/queries';
+
+export const alt = 'サンプルスライド';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const slide = await getSlideContent('sample-deck');
+  return OgImage({
+    category: 'Slides',
+    title: slide.title,
+  });
+}

--- a/apps/main/src/app/slides/(decks)/sample-deck/page.tsx
+++ b/apps/main/src/app/slides/(decks)/sample-deck/page.tsx
@@ -1,0 +1,7 @@
+import { slideMDXComponents } from '@/app/slides/_components/mdx-parts';
+
+import Content from './content.mdx';
+
+export default function Page() {
+  return <Content components={slideMDXComponents} />;
+}

--- a/apps/main/src/app/slides/README.md
+++ b/apps/main/src/app/slides/README.md
@@ -1,0 +1,151 @@
+# Slides
+
+スライド機能の使い方ガイド。MDX でスライドを書き、`/slides/<slug>` で観覧できる。
+
+## 新しいスライドを追加する
+
+### 1. DB にレコードを追加
+
+`packages/database/migrations/` に custom migration を追加 (`drizzle-kit generate:custom`)。`slides` テーブルに 1 行 insert する。
+
+```sql
+INSERT INTO slides (id, slug, published, created_at)
+VALUES (2, 'my-talk', 1, '2026-05-15T00:00:00.000Z');
+```
+
+### 2. ルートディレクトリを作成
+
+```
+apps/main/src/app/slides/(decks)/<slug>/
+├── layout.tsx          # metadata, OG タグ
+├── page.tsx            # MDX を render
+├── content.mdx         # スライド本体
+└── opengraph-image.tsx # (任意) OG 画像
+```
+
+### 3. `page.tsx`
+
+```tsx
+import { slideMDXComponents } from '@/app/slides/_components/mdx-parts';
+
+import Content from './content.mdx';
+
+export default function Page() {
+  return <Content components={slideMDXComponents} />;
+}
+```
+
+### 4. `content.mdx`
+
+```mdx
+---
+title: My Talk
+description: 何の話か
+createdAt: 2026-05-15
+updatedAt: 2026-05-15
+---
+
+import {
+  Cover,
+  Image,
+  Notes,
+  SlideDeckShell,
+} from '@/app/slides/_components/slide-mdx';
+
+<SlideDeckShell slug="my-talk" title="My Talk">
+
+<Cover>
+
+# タイトル
+
+## サブタイトル
+
+2026年5月 / 自分の名前
+
+</Cover>
+
+---
+
+## 1枚目
+
+本文。
+
+<Notes>発表者向けメモ。発表者モードのみ表示。</Notes>
+
+---
+
+## まとめ
+
+ありがとうございました。
+
+</SlideDeckShell>
+```
+
+### 5. `layout.tsx`
+
+`(decks)/sample-deck/layout.tsx` を雛形に metadata を埋める。
+
+## 利用できるコンポーネント
+
+`@/app/slides/_components/slide-mdx` から import する。
+
+| Component | 用途 |
+|---|---|
+| `<SlideDeckShell slug title>` | デッキの最上位ラッパー (必須)。`slug` と `title` を渡す |
+| `<Cover>` | 表紙レイアウト。中央配置 + 大見出し用 |
+| `<Image src alt caption?>` | 静的インポート画像。`StaticImageData` を `src` に渡す |
+| `<Notes>` | 発表者ノート。観覧側には表示されない |
+
+## MDX 記法
+
+| 書く | 結果 |
+|---|---|
+| `---` (前後に空行) | スライド区切り |
+| `## 見出し` | スライドタイトル (primary teal + 下線) |
+| `` ```ts ``で囲ったブロック | シンタックスハイライト付きコード (`@repo/code-highlight`) |
+| `**bold**` | (slides の `<strong>` は primary teal) |
+| `> 引用` | blockquote (primary 縦線) |
+
+画像は markdown `![]()` ではなく `<Image src={...} />` を使う。リモート URL は受け付けない (`StaticImageData` のみ)。
+
+## キーボード操作
+
+| キー | 動作 |
+|---|---|
+| `→` / `↓` / `Space` / `PageDown` | 次のスライド |
+| `←` / `↑` / `PageUp` | 前のスライド |
+| `Home` | 1 枚目 |
+| `End` | 最後 |
+| `F` | フルスクリーン toggle |
+
+## 発表者モード
+
+`/slides/<slug>?mode=presenter` を別タブで開くと、現在スライド + 次スライド + Notes が同時に見える 3 枠レイアウトになる。`BroadcastChannel` で観覧側と双方向同期。
+
+想定運用: 別モニタで発表者モードを開きつつ、観覧モードのタブ (or ウィンドウ) を画面共有する。
+
+## 表示の中身
+
+- ステージは **16:9 固定**。タイポグラフィは container query 単位 (`cqi`) でステージ幅に追従
+- 背景に k8o ロゴ (クラゲ) の watermark
+- 右下に **`https://k8o.me/slides/<slug>` の QR コード**
+- 上端に teal の **進捗バー** (現在位置/総数)
+
+## ディレクトリ構成
+
+```
+apps/main/src/app/slides/
+├── (decks)/<slug>/             各スライドデッキ
+│   ├── content.mdx
+│   ├── layout.tsx
+│   └── page.tsx
+├── _components/
+│   ├── mdx-parts/              MDX タグの上書き (内部、page.tsx だけが利用)
+│   ├── slide-mdx/              writer 向け JSX 部品
+│   ├── slide-deck/             デッキ実装 (viewer / presenter / stage / hooks 等)
+│   └── slide-card/             /slides 一覧用カード
+├── feed/                       RSS feed
+├── layout.tsx                  /slides 共通レイアウト
+├── opengraph-image.tsx
+└── page.tsx                    /slides 一覧
+```

--- a/apps/main/src/app/slides/_components/mdx-parts/blockquote/blockquote.module.css
+++ b/apps/main/src/app/slides/_components/mdx-parts/blockquote/blockquote.module.css
@@ -1,0 +1,7 @@
+.blockquote {
+  font-size: 2.2cqi;
+  border-inline-start-style: solid;
+  border-inline-start-width: 0.3cqi;
+  padding-inline-start: 1.5cqi;
+  margin: 0 0 1.5cqi;
+}

--- a/apps/main/src/app/slides/_components/mdx-parts/blockquote/blockquote.tsx
+++ b/apps/main/src/app/slides/_components/mdx-parts/blockquote/blockquote.tsx
@@ -1,0 +1,12 @@
+import { cn } from '@repo/helpers/cn';
+import type { FC, ReactNode } from 'react';
+
+import styles from './blockquote.module.css';
+
+export const Blockquote: FC<{ children?: ReactNode }> = ({ children }) => (
+  <blockquote
+    className={cn(styles['blockquote'], 'text-fg-mute border-primary-border')}
+  >
+    {children}
+  </blockquote>
+);

--- a/apps/main/src/app/slides/_components/mdx-parts/blockquote/index.ts
+++ b/apps/main/src/app/slides/_components/mdx-parts/blockquote/index.ts
@@ -1,0 +1,1 @@
+export * from './blockquote';

--- a/apps/main/src/app/slides/_components/mdx-parts/heading/heading.module.css
+++ b/apps/main/src/app/slides/_components/mdx-parts/heading/heading.module.css
@@ -1,0 +1,34 @@
+.h1 {
+  font-size: 5.5cqi;
+  font-weight: 700;
+  margin: 0 0 2cqi;
+  line-height: 1.1;
+  color: var(--color-fg-base);
+}
+
+.h2 {
+  font-size: 4cqi;
+  margin: 0 0 1.5cqi;
+  padding-bottom: 0.5cqi;
+  border-bottom-width: 0.2cqi;
+  border-bottom-style: solid;
+  line-height: 1.2;
+  font-weight: 700;
+}
+
+.h3 {
+  font-size: 3.2cqi;
+  margin: 0 0 1.2cqi;
+  padding-bottom: 0.4cqi;
+  border-bottom-width: 0.15cqi;
+  border-bottom-style: solid;
+  line-height: 1.2;
+  font-weight: 700;
+}
+
+.h4 {
+  font-size: 2.6cqi;
+  margin: 0 0 0.8cqi;
+  line-height: 1.3;
+  font-weight: 700;
+}

--- a/apps/main/src/app/slides/_components/mdx-parts/heading/heading.tsx
+++ b/apps/main/src/app/slides/_components/mdx-parts/heading/heading.tsx
@@ -1,0 +1,26 @@
+import { cn } from '@repo/helpers/cn';
+import type { FC, ReactNode } from 'react';
+
+import styles from './heading.module.css';
+
+type Props = { children?: ReactNode };
+
+export const H1: FC<Props> = ({ children }) => (
+  <h1 className={styles['h1']}>{children}</h1>
+);
+
+export const H2: FC<Props> = ({ children }) => (
+  <h2 className={cn(styles['h2'], 'text-primary-fg border-primary-border')}>
+    {children}
+  </h2>
+);
+
+export const H3: FC<Props> = ({ children }) => (
+  <h3 className={cn(styles['h3'], 'text-primary-fg border-primary-border')}>
+    {children}
+  </h3>
+);
+
+export const H4: FC<Props> = ({ children }) => (
+  <h4 className={cn(styles['h4'], 'text-secondary-fg')}>{children}</h4>
+);

--- a/apps/main/src/app/slides/_components/mdx-parts/heading/index.ts
+++ b/apps/main/src/app/slides/_components/mdx-parts/heading/index.ts
@@ -1,0 +1,1 @@
+export * from './heading';

--- a/apps/main/src/app/slides/_components/mdx-parts/index.ts
+++ b/apps/main/src/app/slides/_components/mdx-parts/index.ts
@@ -1,0 +1,27 @@
+import type { MDXComponents } from 'mdx/types';
+
+import { Blockquote } from './blockquote';
+import { H1, H2, H3, H4 } from './heading';
+import { LI, OL, UL } from './list';
+import { P } from './paragraph';
+import { Pre } from './pre';
+import { Strong } from './strong';
+
+/**
+ * MDX が h1/h2/p/ul... 等のタグを描画する際に当てるコンポーネントマップ。
+ * page.tsx で `<Content components={slideMDXComponents} />` として渡す。
+ * MDX writer が直接 import して使う想定ではない。
+ */
+export const slideMDXComponents: MDXComponents = {
+  h1: H1,
+  h2: H2,
+  h3: H3,
+  h4: H4,
+  p: P,
+  ul: UL,
+  ol: OL,
+  li: LI,
+  strong: Strong,
+  pre: Pre,
+  blockquote: Blockquote,
+};

--- a/apps/main/src/app/slides/_components/mdx-parts/list/index.ts
+++ b/apps/main/src/app/slides/_components/mdx-parts/list/index.ts
@@ -1,0 +1,1 @@
+export * from './list';

--- a/apps/main/src/app/slides/_components/mdx-parts/list/list.module.css
+++ b/apps/main/src/app/slides/_components/mdx-parts/list/list.module.css
@@ -1,0 +1,20 @@
+.ul,
+.ol {
+  font-size: 2cqi;
+  line-height: 1.6;
+  padding-inline-start: 4cqi;
+  margin: 0 0 1.2cqi;
+}
+
+.ul {
+  list-style-type: disc;
+}
+
+.ol {
+  list-style-type: decimal;
+}
+
+.li {
+  font-size: 2cqi;
+  margin: 0.25em 0;
+}

--- a/apps/main/src/app/slides/_components/mdx-parts/list/list.tsx
+++ b/apps/main/src/app/slides/_components/mdx-parts/list/list.tsx
@@ -1,0 +1,18 @@
+import { cn } from '@repo/helpers/cn';
+import type { FC, ReactNode } from 'react';
+
+import styles from './list.module.css';
+
+type Props = { children?: ReactNode };
+
+export const UL: FC<Props> = ({ children }) => (
+  <ul className={styles['ul']}>{children}</ul>
+);
+
+export const OL: FC<Props> = ({ children }) => (
+  <ol className={styles['ol']}>{children}</ol>
+);
+
+export const LI: FC<Props> = ({ children }) => (
+  <li className={cn(styles['li'], 'marker:text-primary-border')}>{children}</li>
+);

--- a/apps/main/src/app/slides/_components/mdx-parts/paragraph/index.ts
+++ b/apps/main/src/app/slides/_components/mdx-parts/paragraph/index.ts
@@ -1,0 +1,1 @@
+export * from './paragraph';

--- a/apps/main/src/app/slides/_components/mdx-parts/paragraph/paragraph.module.css
+++ b/apps/main/src/app/slides/_components/mdx-parts/paragraph/paragraph.module.css
@@ -1,0 +1,5 @@
+.p {
+  font-size: 2cqi;
+  line-height: 1.6;
+  margin: 0 0 1.2cqi;
+}

--- a/apps/main/src/app/slides/_components/mdx-parts/paragraph/paragraph.tsx
+++ b/apps/main/src/app/slides/_components/mdx-parts/paragraph/paragraph.tsx
@@ -1,0 +1,7 @@
+import type { FC, ReactNode } from 'react';
+
+import styles from './paragraph.module.css';
+
+export const P: FC<{ children?: ReactNode }> = ({ children }) => (
+  <p className={styles['p']}>{children}</p>
+);

--- a/apps/main/src/app/slides/_components/mdx-parts/pre/index.ts
+++ b/apps/main/src/app/slides/_components/mdx-parts/pre/index.ts
@@ -1,0 +1,1 @@
+export * from './pre';

--- a/apps/main/src/app/slides/_components/mdx-parts/pre/pre.module.css
+++ b/apps/main/src/app/slides/_components/mdx-parts/pre/pre.module.css
@@ -1,0 +1,9 @@
+.pre {
+  font-size: 1.6cqi;
+  margin: 0 0 1.2cqi;
+  padding: 1.2cqi 1.6cqi;
+  border-radius: 0.5cqi;
+  overflow: auto;
+  max-width: 100%;
+  background-color: var(--color-bg-subtle);
+}

--- a/apps/main/src/app/slides/_components/mdx-parts/pre/pre.tsx
+++ b/apps/main/src/app/slides/_components/mdx-parts/pre/pre.tsx
@@ -1,0 +1,7 @@
+import type { FC, ReactNode } from 'react';
+
+import styles from './pre.module.css';
+
+export const Pre: FC<{ children?: ReactNode }> = ({ children }) => (
+  <pre className={styles['pre']}>{children}</pre>
+);

--- a/apps/main/src/app/slides/_components/mdx-parts/strong/index.ts
+++ b/apps/main/src/app/slides/_components/mdx-parts/strong/index.ts
@@ -1,0 +1,1 @@
+export * from './strong';

--- a/apps/main/src/app/slides/_components/mdx-parts/strong/strong.tsx
+++ b/apps/main/src/app/slides/_components/mdx-parts/strong/strong.tsx
@@ -1,0 +1,5 @@
+import type { FC, ReactNode } from 'react';
+
+export const Strong: FC<{ children?: ReactNode }> = ({ children }) => (
+  <strong className="text-primary-fg font-bold">{children}</strong>
+);

--- a/apps/main/src/app/slides/_components/slide-card/index.ts
+++ b/apps/main/src/app/slides/_components/slide-card/index.ts
@@ -1,0 +1,1 @@
+export * from './slide-card';

--- a/apps/main/src/app/slides/_components/slide-card/slide-card.stories.tsx
+++ b/apps/main/src/app/slides/_components/slide-card/slide-card.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { SlideCard } from './slide-card';
+
+const meta: Meta<typeof SlideCard> = {
+  title: 'app/slides/slide-card',
+  component: SlideCard,
+};
+
+export default meta;
+type Story = StoryObj<typeof SlideCard>;
+
+export const Primary: Story = {
+  args: {
+    slug: 'sample-deck',
+    tags: ['React', 'TypeScript'],
+    title: 'サンプルスライドデッキ',
+    description: 'カードに表示される説明文のサンプルです。',
+    createdAt: '2026-05-15T00:00:00.000Z',
+    updatedAt: '2026-05-15T00:00:00.000Z',
+  },
+};
+
+export const HasLinkToSlide: Story = {
+  args: {
+    slug: 'sample-deck',
+    tags: [],
+    title: 'リンクテスト',
+    description: null,
+    createdAt: '2026-05-15T00:00:00.000Z',
+    updatedAt: '2026-05-15T00:00:00.000Z',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const link = canvas.getByRole('link');
+    await expect(link).toHaveAttribute('href', '/slides/sample-deck');
+  },
+};

--- a/apps/main/src/app/slides/_components/slide-card/slide-card.tsx
+++ b/apps/main/src/app/slides/_components/slide-card/slide-card.tsx
@@ -1,0 +1,69 @@
+import {
+  Badge,
+  Heading,
+  InteractiveCard,
+  PublishDateIcon,
+  TagIcon,
+  UpdateDateIcon,
+} from '@k8o/arte-odyssey';
+import { formatDate } from '@repo/helpers/date/format';
+import type { Route } from 'next';
+import Link from 'next/link';
+import type { FC } from 'react';
+
+type SlideCardProps = {
+  slug: string;
+  tags: string[];
+  title: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export const SlideCard: FC<SlideCardProps> = ({
+  slug,
+  tags,
+  title,
+  description,
+  createdAt,
+  updatedAt,
+}) => (
+  <InteractiveCard>
+    <Link className="group block h-full" href={`/slides/${slug}` as Route}>
+      <div className="flex h-full flex-col justify-between gap-4 p-4">
+        <div className="group-hover:text-primary-fg flex flex-col gap-1">
+          <Heading lineClamp={3} type="h3">
+            {title}
+          </Heading>
+          {description !== null && (
+            <p className="text-fg-mute line-clamp-3 text-sm">{description}</p>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center justify-between gap-4">
+          {tags.length > 0 && (
+            <div className="flex flex-wrap items-center gap-2">
+              <TagIcon size="sm" />
+              {tags.map((tag) => (
+                <Badge key={tag} size="sm" text={tag} />
+              ))}
+            </div>
+          )}
+          <div className="text-fg-mute ml-auto flex items-center gap-4 text-xs">
+            <div className="flex items-center gap-1">
+              <PublishDateIcon size="sm" />
+              <span>
+                公開: {formatDate(new Date(createdAt), 'yyyy年M月d日')}
+              </span>
+            </div>
+            <div className="flex items-center gap-1">
+              <UpdateDateIcon size="sm" />
+              <span>
+                更新: {formatDate(new Date(updatedAt), 'yyyy年M月d日')}
+              </span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </Link>
+  </InteractiveCard>
+);

--- a/apps/main/src/app/slides/_components/slide-deck/deck-presenter/deck-presenter.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/deck-presenter/deck-presenter.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+import { useState, type FC } from 'react';
+
+import type { Slide } from '@/features/slides/application/split-slides';
+
+import { useDeckController } from '../hooks/use-deck-controller';
+import { useClosePresenterOnViewerStop } from '../hooks/use-presenter-lifecycle';
+import { NavButton } from '../nav-button';
+import { Stage } from '../stage';
+
+export const DeckPresenter: FC<{
+  slug: string;
+  title: string;
+  slides: Slide[];
+  qrUrl: string;
+}> = ({ slug, title, slides, qrUrl }) => {
+  const total = slides.length;
+  const { index, next, prev, isHydrated } = useDeckController({
+    total,
+    channelName: `slides:${slug}`,
+  });
+  const current = slides[index] ?? slides[0];
+  const nextSlide = slides[index + 1];
+  const [sessionId] = useState<string>(() => {
+    if (typeof window === 'undefined') return '';
+    return new URLSearchParams(window.location.search).get('session') ?? '';
+  });
+  useClosePresenterOnViewerStop({ slug, sessionId });
+
+  return (
+    <div
+      aria-label={`${title} - 発表者モード`}
+      className="bg-bg-mute text-fg-base fixed inset-0 z-50 flex flex-col gap-2 p-4"
+      role="region"
+    >
+      <header className="flex items-center justify-between gap-4">
+        <p className="text-fg-base truncate text-sm font-bold">
+          {title}{' '}
+          <span className="text-fg-mute font-medium">- 発表者モード</span>
+        </p>
+        <p
+          aria-live="polite"
+          className="text-primary-fg text-sm font-medium tabular-nums"
+        >
+          {index + 1} <span className="text-fg-mute">/ {total}</span>
+        </p>
+      </header>
+      <div className="grid min-h-0 flex-1 grid-cols-1 grid-rows-[1fr_auto] gap-4 lg:grid-cols-[2fr_1fr] lg:grid-rows-[2fr_1fr]">
+        <section
+          aria-label="現在のスライド"
+          className="flex min-h-0 min-w-0 flex-col gap-1 lg:row-span-2"
+        >
+          <p className="text-primary-fg text-xs font-medium tracking-wide uppercase">
+            Now
+          </p>
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+            <Stage key={`current-${index.toString()}`} qrUrl={qrUrl}>
+              {isHydrated ? current?.content : null}
+            </Stage>
+          </div>
+        </section>
+        <section
+          aria-label="次のスライド"
+          className="flex min-h-0 min-w-0 flex-col gap-1"
+        >
+          <p className="text-fg-mute text-xs font-medium tracking-wide uppercase">
+            Next
+          </p>
+          <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+            {nextSlide === undefined ? (
+              <div className="bg-bg-base text-fg-mute flex h-full items-center justify-center rounded-lg text-sm">
+                最終スライドです
+              </div>
+            ) : (
+              <Stage key={`next-${index.toString()}`}>
+                {isHydrated ? nextSlide.content : null}
+              </Stage>
+            )}
+          </div>
+        </section>
+        <section
+          aria-label="発表者ノート"
+          className="bg-bg-base flex min-h-0 min-w-0 flex-col gap-2 overflow-auto rounded-lg p-4"
+        >
+          <p className="text-secondary-fg text-xs font-medium tracking-wide uppercase">
+            Notes
+          </p>
+          <div className="text-fg-base text-sm leading-relaxed">
+            {current === undefined || current.notes.length === 0 ? (
+              <p className="text-fg-mute italic">ノートはありません</p>
+            ) : (
+              current.notes.map((note, i) => (
+                <div key={i.toString()}>{note}</div>
+              ))
+            )}
+          </div>
+        </section>
+      </div>
+      <footer className="flex items-center justify-between gap-2">
+        <NavButton direction="prev" disabled={index === 0} onAction={prev} />
+        <NavButton
+          direction="next"
+          disabled={index === total - 1}
+          onAction={next}
+        />
+      </footer>
+    </div>
+  );
+};

--- a/apps/main/src/app/slides/_components/slide-deck/deck-presenter/index.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/deck-presenter/index.ts
@@ -1,0 +1,1 @@
+export * from './deck-presenter';

--- a/apps/main/src/app/slides/_components/slide-deck/deck-viewer/deck-viewer.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/deck-viewer/deck-viewer.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { CloseIcon, IconButton } from '@k8o/arte-odyssey';
+import { cn } from '@repo/helpers/cn';
+import Link from 'next/link';
+import { useEffect, useState, type FC } from 'react';
+
+import type { Slide } from '@/features/slides/application/split-slides';
+
+import { useDeckController } from '../hooks/use-deck-controller';
+import { useBroadcastViewerHeartbeat } from '../hooks/use-presenter-lifecycle';
+import { NavButton } from '../nav-button';
+import { ProgressBar } from '../progress-bar';
+import { Stage } from '../stage';
+
+export const DeckViewer: FC<{
+  slug: string;
+  title: string;
+  slides: Slide[];
+  qrUrl: string;
+}> = ({ slug, title, slides, qrUrl }) => {
+  const total = slides.length;
+  const { index, next, prev, isFullscreen, isHydrated } = useDeckController({
+    total,
+    channelName: `slides:${slug}`,
+  });
+  const [isPresenting, setIsPresenting] = useState(false);
+  const isMaximized = isFullscreen || isPresenting;
+  const [sessionId] = useState<string>(() => {
+    if (
+      typeof crypto !== 'undefined' &&
+      typeof crypto.randomUUID === 'function'
+    ) {
+      return crypto.randomUUID();
+    }
+    return '';
+  });
+  useBroadcastViewerHeartbeat({ slug, sessionId });
+  const current = slides[index] ?? slides[0];
+  const presenterHref = `/slides/${slug}?mode=presenter&session=${encodeURIComponent(sessionId)}#${(index + 1).toString()}`;
+
+  useEffect(() => {
+    if (!isPresenting) return undefined;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setIsPresenting(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, [isPresenting]);
+
+  return (
+    <div
+      aria-label={title}
+      aria-roledescription="slide deck"
+      className="bg-bg-mute text-fg-base fixed inset-0 z-50 flex flex-col"
+      role="region"
+    >
+      {!isMaximized && (
+        <header className="flex items-center justify-between gap-4 px-4 py-2">
+          <div className="flex items-center gap-2">
+            <IconButton
+              bg="transparent"
+              label="Slides一覧へ戻る"
+              renderItem={({
+                className,
+                children: itemChildren,
+                'aria-label': ariaLabel,
+                triggerProps,
+              }) => (
+                <Link
+                  aria-label={ariaLabel}
+                  className={className}
+                  href="/slides"
+                  {...triggerProps}
+                >
+                  {itemChildren}
+                </Link>
+              )}
+            >
+              <CloseIcon />
+            </IconButton>
+            <p className="text-fg-base truncate text-sm font-bold">{title}</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <p
+              aria-live="polite"
+              className="text-primary-fg text-sm font-medium tabular-nums"
+            >
+              {index + 1} <span className="text-fg-mute">/ {total}</span>
+            </p>
+            <button
+              className="text-fg-mute hover:text-primary-fg cursor-pointer text-sm underline"
+              onClick={() => {
+                const opened = window.open(presenterHref, '_blank');
+                if (opened === null) return;
+                setIsPresenting(true);
+              }}
+              type="button"
+            >
+              発表者モード
+            </button>
+          </div>
+        </header>
+      )}
+      {!isMaximized && <ProgressBar current={index} total={total} />}
+      <div
+        className={cn('min-h-0 flex-1', isMaximized ? null : 'px-4 pt-2 pb-4')}
+      >
+        <Stage flush={isMaximized} key={index} qrUrl={qrUrl}>
+          {isHydrated ? current?.content : null}
+        </Stage>
+      </div>
+      {isPresenting && (
+        <div className="pointer-events-none absolute top-2 right-2 z-10">
+          <div className="pointer-events-auto">
+            <IconButton
+              bg="base"
+              label="発表者モードを終了"
+              onClick={() => {
+                setIsPresenting(false);
+              }}
+            >
+              <CloseIcon />
+            </IconButton>
+          </div>
+        </div>
+      )}
+      {!isMaximized && (
+        <footer className="flex items-center justify-between gap-2 px-4 py-2">
+          <NavButton direction="prev" disabled={index === 0} onAction={prev} />
+          <NavButton
+            direction="next"
+            disabled={index === total - 1}
+            onAction={next}
+          />
+        </footer>
+      )}
+    </div>
+  );
+};

--- a/apps/main/src/app/slides/_components/slide-deck/deck-viewer/deck-viewer.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/deck-viewer/deck-viewer.tsx
@@ -27,13 +27,14 @@ export const DeckViewer: FC<{
   const [isPresenting, setIsPresenting] = useState(false);
   const isMaximized = isFullscreen || isPresenting;
   const [sessionId] = useState<string>(() => {
-    if (
-      typeof crypto !== 'undefined' &&
-      typeof crypto.randomUUID === 'function'
-    ) {
-      return crypto.randomUUID();
-    }
-    return '';
+    if (typeof window === 'undefined') return '';
+    if (typeof crypto.randomUUID !== 'function') return '';
+    const storageKey = `slide-session:${slug}`;
+    const stored = window.sessionStorage.getItem(storageKey);
+    if (stored !== null) return stored;
+    const generated = crypto.randomUUID();
+    window.sessionStorage.setItem(storageKey, generated);
+    return generated;
   });
   useBroadcastViewerHeartbeat({ slug, sessionId });
   const current = slides[index] ?? slides[0];

--- a/apps/main/src/app/slides/_components/slide-deck/deck-viewer/index.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/deck-viewer/index.ts
@@ -1,0 +1,1 @@
+export * from './deck-viewer';

--- a/apps/main/src/app/slides/_components/slide-deck/hooks/use-broadcast-listener.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/hooks/use-broadcast-listener.ts
@@ -1,0 +1,60 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type ChannelMessage = { type: 'sync'; index: number };
+
+const isChannelMessage = (data: unknown): data is ChannelMessage => {
+  if (typeof data !== 'object' || data === null) return false;
+  const record = data as Record<string, unknown>;
+  return (
+    record['type'] === 'sync' &&
+    typeof record['index'] === 'number' &&
+    Number.isInteger(record['index'])
+  );
+};
+
+/**
+ * BroadcastChannel を購読し、受信時に `onReceive` を呼ぶ。
+ * 戻り値の `broadcast` 関数で送信する (event handler から呼ぶ想定)。
+ *
+ * 外部システム (BroadcastChannel) の購読は useEffect の正当な用途。
+ * 送信は event handler に任せて、state→送信の useEffect は持たない。
+ *
+ * 受信ペイロードは信頼境界の外なので shape を validation する。
+ */
+export const useBroadcastListener = ({
+  channelName,
+  onReceive,
+}: {
+  channelName: string;
+  onReceive: (index: number) => void;
+}): ((index: number) => void) => {
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const onReceiveRef = useRef(onReceive);
+  onReceiveRef.current = onReceive;
+
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return undefined;
+    const channel = new BroadcastChannel(channelName);
+    channelRef.current = channel;
+    const handler = (event: MessageEvent<unknown>) => {
+      if (!isChannelMessage(event.data)) return;
+      onReceiveRef.current(event.data.index);
+    };
+    channel.addEventListener('message', handler);
+    return () => {
+      channel.removeEventListener('message', handler);
+      channel.close();
+      channelRef.current = null;
+    };
+  }, [channelName]);
+
+  return (index: number) => {
+    const channel = channelRef.current;
+    if (channel === null) return;
+    // BroadcastChannel.postMessage は targetOrigin を取らない
+    // oxlint-disable-next-line unicorn/require-post-message-target-origin
+    channel.postMessage({ type: 'sync', index } satisfies ChannelMessage);
+  };
+};

--- a/apps/main/src/app/slides/_components/slide-deck/hooks/use-broadcast-listener.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/hooks/use-broadcast-listener.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
 type ChannelMessage = { type: 'sync'; index: number };
 
@@ -50,11 +50,11 @@ export const useBroadcastListener = ({
     };
   }, [channelName]);
 
-  return (index: number) => {
+  return useCallback((index: number) => {
     const channel = channelRef.current;
     if (channel === null) return;
     // BroadcastChannel.postMessage は targetOrigin を取らない
     // oxlint-disable-next-line unicorn/require-post-message-target-origin
     channel.postMessage({ type: 'sync', index } satisfies ChannelMessage);
-  };
+  }, []);
 };

--- a/apps/main/src/app/slides/_components/slide-deck/hooks/use-deck-controller.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/hooks/use-deck-controller.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import { useCallback } from 'react';
+
+import { useBroadcastListener } from './use-broadcast-listener';
+import { useHashIndex, writeHashIndex } from './use-hash-index';
+import { toggleFullscreen, useIsFullscreen } from './use-is-fullscreen';
+import { useIsHydrated } from './use-is-hydrated';
+import { useKeyboardNav } from './use-keyboard-nav';
+
+const clamp = (value: number, max: number) => Math.max(0, Math.min(value, max));
+
+/**
+ * スライドデッキの現在位置とナビゲーション操作を提供する。
+ *
+ * index の単一情報源は URL ハッシュ (useHashIndex)。state→hash の同期 useEffect は持たず、
+ * 操作 handler 内で writeHashIndex と broadcast を呼ぶ。
+ * useEffect を直接書くのは BroadcastChannel と keydown listener、
+ * useLayoutEffect は useIsHydrated のみ。hash / fullscreen は useSyncExternalStore で購読。
+ */
+export const useDeckController = ({
+  total,
+  channelName,
+}: {
+  total: number;
+  channelName: string;
+}) => {
+  const hashIndex = useHashIndex();
+  const index = clamp(hashIndex, total - 1);
+
+  const broadcast = useBroadcastListener({
+    channelName,
+    onReceive: (received) => {
+      writeHashIndex(clamp(received, total - 1));
+    },
+  });
+
+  const goTo = useCallback(
+    (target: number) => {
+      const clamped = clamp(target, total - 1);
+      writeHashIndex(clamped);
+      broadcast(clamped);
+    },
+    [total, broadcast],
+  );
+
+  const next = useCallback(() => {
+    goTo(index + 1);
+  }, [goTo, index]);
+
+  const prev = useCallback(() => {
+    goTo(index - 1);
+  }, [goTo, index]);
+
+  const first = useCallback(() => {
+    goTo(0);
+  }, [goTo]);
+
+  const last = useCallback(() => {
+    goTo(total - 1);
+  }, [goTo, total]);
+
+  useKeyboardNav({
+    onNext: next,
+    onPrev: prev,
+    onFirst: first,
+    onLast: last,
+    onToggleFullscreen: toggleFullscreen,
+  });
+
+  const isFullscreen = useIsFullscreen();
+  const isHydrated = useIsHydrated();
+
+  return { index, goTo, next, prev, isFullscreen, isHydrated };
+};

--- a/apps/main/src/app/slides/_components/slide-deck/hooks/use-hash-index.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/hooks/use-hash-index.ts
@@ -1,0 +1,42 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+const HASH_INDEX_RE = /^#(\d+)$/;
+
+const subscribe = (callback: () => void): (() => void) => {
+  window.addEventListener('hashchange', callback);
+  return () => {
+    window.removeEventListener('hashchange', callback);
+  };
+};
+
+const getSnapshot = (): number => {
+  const match = HASH_INDEX_RE.exec(window.location.hash);
+  if (match === null) return 0;
+  const value = Number.parseInt(match[1] ?? '', 10);
+  return Number.isInteger(value) ? Math.max(0, value - 1) : 0;
+};
+
+const getServerSnapshot = (): number => 0;
+
+/**
+ * URL ハッシュ (#3 等) を購読し、現在の index (0-origin) を返す。
+ * useSyncExternalStore を使うため、明示的な useEffect は不要。
+ * SSR では 0 を返す。
+ */
+export const useHashIndex = (): number =>
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+/**
+ * URL ハッシュを書き換える。
+ * `replaceState` は hashchange を発火しないので、useHashIndex の再評価を促すため
+ * 明示的に hashchange イベントを dispatch する。
+ */
+export const writeHashIndex = (index: number): void => {
+  if (typeof window === 'undefined') return;
+  const nextHash = `#${(index + 1).toString()}`;
+  if (window.location.hash === nextHash) return;
+  window.history.replaceState(null, '', nextHash);
+  window.dispatchEvent(new Event('hashchange'));
+};

--- a/apps/main/src/app/slides/_components/slide-deck/hooks/use-is-fullscreen.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/hooks/use-is-fullscreen.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+const subscribe = (callback: () => void): (() => void) => {
+  document.addEventListener('fullscreenchange', callback);
+  return () => {
+    document.removeEventListener('fullscreenchange', callback);
+  };
+};
+
+const getSnapshot = (): boolean => document.fullscreenElement !== null;
+const getServerSnapshot = (): boolean => false;
+
+/**
+ * Fullscreen API の状態を購読する。useSyncExternalStore のため useEffect 不要。
+ */
+export const useIsFullscreen = (): boolean =>
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+
+/**
+ * Fullscreen を toggle する (event handler から呼ぶ想定)。
+ */
+export const toggleFullscreen = (): void => {
+  if (typeof document === 'undefined') return;
+  if (document.fullscreenElement === null) {
+    void document.documentElement.requestFullscreen();
+  } else {
+    void document.exitFullscreen();
+  }
+};

--- a/apps/main/src/app/slides/_components/slide-deck/hooks/use-is-hydrated.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/hooks/use-is-hydrated.ts
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useLayoutEffect, useState } from 'react';
+
+const useBrowserLayoutEffect =
+  typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+/**
+ * クライアントでハイドレートが完了したかを示す。
+ *
+ * SSR で生成された HTML はブラウザが先に paint してしまうため、
+ * URL `#5` で来訪しても初回 paint には index=0 (スライド 1) が映る。
+ * その後 React がハイドレートして `useHashSync` が index を 4 に書き換えても、
+ * 一瞬スライド 1 が見えるフラッシュが残る。
+ *
+ * この hook は paint 前 (`useLayoutEffect`) で true になるので、
+ * 「ハイドレート前は空ステージ、ハイドレート後に正しいスライドを描画」
+ * という出し分けで SSR 由来のフラッシュを抑止できる。
+ */
+export const useIsHydrated = (): boolean => {
+  const [isHydrated, setIsHydrated] = useState(false);
+  useBrowserLayoutEffect(() => {
+    setIsHydrated(true);
+  }, []);
+  return isHydrated;
+};

--- a/apps/main/src/app/slides/_components/slide-deck/hooks/use-keyboard-nav.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/hooks/use-keyboard-nav.ts
@@ -1,0 +1,93 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+const NEXT_KEYS = new Set([
+  'ArrowRight',
+  'ArrowDown',
+  'PageDown',
+  ' ',
+  'Spacebar',
+]);
+const PREV_KEYS = new Set(['ArrowLeft', 'ArrowUp', 'PageUp']);
+const FULLSCREEN_KEYS = new Set(['f', 'F']);
+
+/**
+ * キーボード操作 (前後 / 先頭末尾 / フルスクリーン) を 1 つのリスナで捌く。
+ * - 矢印・PageUp/Down・Space で前後移動
+ * - Home/End で先頭/末尾
+ * - F/f で fullscreen toggle
+ * - 入力フィールドにフォーカスがある時は無効
+ *
+ * ハンドラ参照は ref で常に最新を見るので deps は空配列。
+ */
+export const useKeyboardNav = ({
+  onNext,
+  onPrev,
+  onFirst,
+  onLast,
+  onToggleFullscreen,
+}: {
+  onNext: () => void;
+  onPrev: () => void;
+  onFirst: () => void;
+  onLast: () => void;
+  onToggleFullscreen: () => void;
+}) => {
+  const handlersRef = useRef({
+    onNext,
+    onPrev,
+    onFirst,
+    onLast,
+    onToggleFullscreen,
+  });
+  handlersRef.current = {
+    onNext,
+    onPrev,
+    onFirst,
+    onLast,
+    onToggleFullscreen,
+  };
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) return;
+      const { target } = event;
+      if (target instanceof HTMLElement) {
+        const tag = target.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) {
+          return;
+        }
+      }
+      const h = handlersRef.current;
+      if (NEXT_KEYS.has(event.key)) {
+        event.preventDefault();
+        h.onNext();
+        return;
+      }
+      if (PREV_KEYS.has(event.key)) {
+        event.preventDefault();
+        h.onPrev();
+        return;
+      }
+      if (event.key === 'Home') {
+        event.preventDefault();
+        h.onFirst();
+        return;
+      }
+      if (event.key === 'End') {
+        event.preventDefault();
+        h.onLast();
+        return;
+      }
+      if (FULLSCREEN_KEYS.has(event.key)) {
+        event.preventDefault();
+        h.onToggleFullscreen();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => {
+      window.removeEventListener('keydown', handler);
+    };
+  }, []);
+};

--- a/apps/main/src/app/slides/_components/slide-deck/hooks/use-presenter-lifecycle.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/hooks/use-presenter-lifecycle.ts
@@ -1,0 +1,83 @@
+'use client';
+
+import { useEffect } from 'react';
+
+type HeartbeatMessage = { type: 'viewer-alive' };
+
+const HEARTBEAT_INTERVAL_MS = 1500;
+const HEARTBEAT_TIMEOUT_MS = 5000;
+
+const lifecycleChannelName = (slug: string, sessionId: string): string =>
+  `slides-lifecycle:${slug}:${sessionId}`;
+
+const isHeartbeatMessage = (data: unknown): data is HeartbeatMessage => {
+  if (typeof data !== 'object' || data === null) return false;
+  return (data as { type?: unknown }).type === 'viewer-alive';
+};
+
+/**
+ * Viewer から定期的に heartbeat を broadcast する。
+ * sessionId 単位でペアを分離し、複数 deck 同時起動でも干渉しない。
+ * reload 中は数百ミリ秒だけ heartbeat が止まるが、タイムアウト猶予内で復帰すれば presenter は閉じない。
+ */
+export const useBroadcastViewerHeartbeat = ({
+  slug,
+  sessionId,
+}: {
+  slug: string;
+  sessionId: string;
+}): void => {
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return undefined;
+    if (sessionId === '') return undefined;
+    const channel = new BroadcastChannel(lifecycleChannelName(slug, sessionId));
+    const send = (): void => {
+      // BroadcastChannel.postMessage は targetOrigin を取らない
+      // oxlint-disable-next-line unicorn/require-post-message-target-origin
+      channel.postMessage({ type: 'viewer-alive' } satisfies HeartbeatMessage);
+    };
+    send();
+    const intervalId = window.setInterval(send, HEARTBEAT_INTERVAL_MS);
+    return () => {
+      window.clearInterval(intervalId);
+      channel.close();
+    };
+  }, [slug, sessionId]);
+};
+
+/**
+ * Presenter で viewer の heartbeat 切断を検知して自身を閉じる。
+ * 直近 heartbeat から HEARTBEAT_TIMEOUT_MS 経過したら window.close()。
+ * window.open 起源の tab でのみ close が許可される。
+ */
+export const useClosePresenterOnViewerStop = ({
+  slug,
+  sessionId,
+}: {
+  slug: string;
+  sessionId: string;
+}): void => {
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return undefined;
+    if (sessionId === '') return undefined;
+    const channel = new BroadcastChannel(lifecycleChannelName(slug, sessionId));
+    let timeoutId: number | null = null;
+    const resetTimer = (): void => {
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+      timeoutId = window.setTimeout(() => {
+        window.close();
+      }, HEARTBEAT_TIMEOUT_MS);
+    };
+    const handler = (event: MessageEvent<unknown>): void => {
+      if (!isHeartbeatMessage(event.data)) return;
+      resetTimer();
+    };
+    channel.addEventListener('message', handler);
+    resetTimer();
+    return () => {
+      if (timeoutId !== null) window.clearTimeout(timeoutId);
+      channel.removeEventListener('message', handler);
+      channel.close();
+    };
+  }, [slug, sessionId]);
+};

--- a/apps/main/src/app/slides/_components/slide-deck/index.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/index.ts
@@ -1,0 +1,4 @@
+// slide-deck/ は内部実装。外部から触る公開面は SlideDeck (dispatcher) のみ。
+// hooks / stage / nav-button 等は内部利用なので barrel から出さない。
+// splitSlides / Slide 型は features/slides/application から直接 import する。
+export { SlideDeck } from './slide-deck';

--- a/apps/main/src/app/slides/_components/slide-deck/nav-button/index.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/nav-button/index.ts
@@ -1,0 +1,1 @@
+export * from './nav-button';

--- a/apps/main/src/app/slides/_components/slide-deck/nav-button/nav-button.stories.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/nav-button/nav-button.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { NavButton } from './nav-button';
+
+const meta: Meta<typeof NavButton> = {
+  title: 'app/slides/slide-deck/nav-button',
+  component: NavButton,
+  args: {
+    onAction: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof NavButton>;
+
+export const Prev: Story = {
+  args: {
+    direction: 'prev',
+    disabled: false,
+  },
+};
+
+export const Next: Story = {
+  args: {
+    direction: 'next',
+    disabled: false,
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    direction: 'next',
+    disabled: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: '次のスライド' });
+    await expect(button).toBeDisabled();
+  },
+};

--- a/apps/main/src/app/slides/_components/slide-deck/nav-button/nav-button.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/nav-button/nav-button.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { ChevronIcon, IconButton } from '@k8o/arte-odyssey';
+import type { FC } from 'react';
+
+type Props = {
+  direction: 'prev' | 'next';
+  disabled: boolean;
+  onAction: () => void;
+};
+
+export const NavButton: FC<Props> = ({ direction, disabled, onAction }) => (
+  <IconButton
+    bg="transparent"
+    label={direction === 'prev' ? '前のスライド' : '次のスライド'}
+    onAction={onAction}
+    renderItem={({
+      className,
+      children,
+      'aria-label': ariaLabel,
+      triggerProps,
+    }) => (
+      <button
+        aria-label={ariaLabel}
+        className={className}
+        disabled={disabled}
+        type="button"
+        {...triggerProps}
+      >
+        {children}
+      </button>
+    )}
+  >
+    <ChevronIcon direction={direction === 'prev' ? 'left' : 'right'} />
+  </IconButton>
+);

--- a/apps/main/src/app/slides/_components/slide-deck/progress-bar/index.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/progress-bar/index.ts
@@ -1,0 +1,1 @@
+export * from './progress-bar';

--- a/apps/main/src/app/slides/_components/slide-deck/progress-bar/progress-bar.module.css
+++ b/apps/main/src/app/slides/_components/slide-deck/progress-bar/progress-bar.module.css
@@ -1,0 +1,10 @@
+.track {
+  height: 2px;
+  width: 100%;
+  overflow: hidden;
+}
+
+.fill {
+  height: 100%;
+  transition: width 200ms ease;
+}

--- a/apps/main/src/app/slides/_components/slide-deck/progress-bar/progress-bar.stories.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/progress-bar/progress-bar.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { ProgressBar } from './progress-bar';
+
+const meta: Meta<typeof ProgressBar> = {
+  title: 'app/slides/slide-deck/progress-bar',
+  component: ProgressBar,
+};
+
+export default meta;
+type Story = StoryObj<typeof ProgressBar>;
+
+export const Start: Story = {
+  args: { current: 0, total: 5 },
+};
+
+export const Middle: Story = {
+  args: { current: 2, total: 5 },
+};
+
+export const End: Story = {
+  args: { current: 4, total: 5 },
+};

--- a/apps/main/src/app/slides/_components/slide-deck/progress-bar/progress-bar.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/progress-bar/progress-bar.tsx
@@ -1,0 +1,19 @@
+import { cn } from '@repo/helpers/cn';
+import type { FC } from 'react';
+
+import styles from './progress-bar.module.css';
+
+export const ProgressBar: FC<{ current: number; total: number }> = ({
+  current,
+  total,
+}) => {
+  const percent = total === 0 ? 0 : ((current + 1) / total) * 100;
+  return (
+    <div aria-hidden="true" className={cn(styles['track'], 'bg-bg-mute')}>
+      <div
+        className={cn(styles['fill'], 'bg-primary-border')}
+        style={{ width: `${percent.toString()}%` }}
+      />
+    </div>
+  );
+};

--- a/apps/main/src/app/slides/_components/slide-deck/slide-deck/index.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/slide-deck/index.ts
@@ -1,0 +1,1 @@
+export * from './slide-deck';

--- a/apps/main/src/app/slides/_components/slide-deck/slide-deck/slide-deck.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/slide-deck/slide-deck.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+import type { FC } from 'react';
+
+import type { Slide } from '@/features/slides/application/split-slides';
+
+import { DeckPresenter } from '../deck-presenter';
+import { DeckViewer } from '../deck-viewer';
+
+export const SlideDeck: FC<{
+  slug: string;
+  title: string;
+  slides: Slide[];
+  qrUrl: string;
+}> = ({ slug, title, slides, qrUrl }) => {
+  const searchParams = useSearchParams();
+  const isPresenter = searchParams.get('mode') === 'presenter';
+
+  if (isPresenter) {
+    return (
+      <DeckPresenter qrUrl={qrUrl} slides={slides} slug={slug} title={title} />
+    );
+  }
+
+  return <DeckViewer qrUrl={qrUrl} slides={slides} slug={slug} title={title} />;
+};

--- a/apps/main/src/app/slides/_components/slide-deck/slide-qr-code/index.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/slide-qr-code/index.ts
@@ -1,0 +1,1 @@
+export * from './slide-qr-code';

--- a/apps/main/src/app/slides/_components/slide-deck/slide-qr-code/slide-qr-code.stories.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/slide-qr-code/slide-qr-code.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { SlideQRCode } from './slide-qr-code';
+
+const meta: Meta<typeof SlideQRCode> = {
+  title: 'app/slides/slide-deck/slide-qr-code',
+  component: SlideQRCode,
+  decorators: [
+    (Story) => (
+      <div className="bg-bg-mute size-40 p-2">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof SlideQRCode>;
+
+export const Default: Story = {
+  args: {
+    url: 'https://k8o.me/slides/sample-deck',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const svg = canvas.getByRole('img', { name: /QRコード/ });
+    await expect(svg).toBeInTheDocument();
+  },
+};

--- a/apps/main/src/app/slides/_components/slide-deck/slide-qr-code/slide-qr-code.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/slide-qr-code/slide-qr-code.tsx
@@ -1,0 +1,49 @@
+import type { FC } from 'react';
+import { encode, type QrCodeGenerateResult } from 'uqr';
+
+// 同じ URL の QR は重複生成しない (key={index} で Stage が remount される時の再計算抑止)
+const qrCache = new Map<string, QrCodeGenerateResult>();
+
+const getQrMatrix = (url: string): QrCodeGenerateResult => {
+  let cached = qrCache.get(url);
+  if (cached === undefined) {
+    cached = encode(url, { border: 1, ecc: 'M' });
+    qrCache.set(url, cached);
+  }
+  return cached;
+};
+
+export const SlideQRCode: FC<{ url: string; className?: string }> = ({
+  url,
+  className,
+}) => {
+  const { size, data } = getQrMatrix(url);
+
+  return (
+    <svg
+      aria-label={`QRコード: ${url}`}
+      className={className}
+      role="img"
+      viewBox={`0 0 ${size.toString()} ${size.toString()}`}
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <rect fill="white" height={size} width={size} />
+      {data.flatMap((row, y) =>
+        row
+          .map((cell, x) =>
+            cell ? (
+              <rect
+                fill="black"
+                height={1}
+                key={`${y.toString()}-${x.toString()}`}
+                width={1}
+                x={x}
+                y={y}
+              />
+            ) : null,
+          )
+          .filter((node) => node !== null),
+      )}
+    </svg>
+  );
+};

--- a/apps/main/src/app/slides/_components/slide-deck/stage/index.ts
+++ b/apps/main/src/app/slides/_components/slide-deck/stage/index.ts
@@ -1,0 +1,1 @@
+export * from './stage';

--- a/apps/main/src/app/slides/_components/slide-deck/stage/stage.module.css
+++ b/apps/main/src/app/slides/_components/slide-deck/stage/stage.module.css
@@ -1,0 +1,36 @@
+.frame {
+  container-type: size;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.box {
+  width: min(100cqw, calc(100cqh * 16 / 9));
+  aspect-ratio: 16 / 9;
+  container-type: size;
+}
+
+.content {
+  padding: 5cqi 6cqi;
+  font-size: 2.5cqi;
+  line-height: 1.6;
+  gap: 2cqi;
+}
+
+.watermark {
+  inset: auto -10cqw -25cqh auto;
+  width: 70cqw;
+  opacity: 0.04;
+  transform: rotate(-12deg);
+}
+
+.qr {
+  bottom: 3cqh;
+  right: 2.5cqw;
+  width: 7cqw;
+  height: 7cqw;
+  border-radius: 0.5cqi;
+  background: white;
+  padding: 0.4cqi;
+}

--- a/apps/main/src/app/slides/_components/slide-deck/stage/stage.stories.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/stage/stage.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { Stage } from './stage';
+
+const meta: Meta<typeof Stage> = {
+  title: 'app/slides/slide-deck/stage',
+  component: Stage,
+  decorators: [
+    (Story) => (
+      <div className="h-svh w-full">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Stage>;
+
+export const Empty: Story = {
+  args: {
+    children: null,
+  },
+};
+
+export const WithContent: Story = {
+  args: {
+    children: (
+      <>
+        <h2>サンプル見出し</h2>
+        <p>ステージは 16:9 を維持しながら親要素にフィットします。</p>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('heading', { name: 'サンプル見出し' }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const WithQRCode: Story = {
+  args: {
+    qrUrl: 'https://k8o.me/slides/sample-deck',
+    children: <h2>QR 付き</h2>,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('img', { name: /QRコード/ }),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/main/src/app/slides/_components/slide-deck/stage/stage.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/stage/stage.tsx
@@ -1,0 +1,40 @@
+import { Logo } from '@k8o/arte-odyssey';
+import { cn } from '@repo/helpers/cn';
+import type { FC, ReactNode } from 'react';
+
+import { SlideQRCode } from '../slide-qr-code';
+
+import styles from './stage.module.css';
+
+/**
+ * `flush`: true の時は角丸 / 影 を外し、ステージが viewport edge に張り付いた時の
+ * 浮いて見える違和感を消す (フルスクリーン表示用)。
+ */
+export const Stage: FC<{
+  children: ReactNode;
+  qrUrl?: string;
+  flush?: boolean;
+}> = ({ children, qrUrl, flush = false }) => (
+  <div className={cn(styles['frame'], 'relative size-full')}>
+    <div
+      className={cn(
+        styles['box'],
+        'bg-bg-base text-fg-base relative overflow-hidden',
+        flush ? null : 'rounded-lg shadow-md',
+      )}
+    >
+      <Logo
+        aria-hidden="true"
+        className={cn(styles['watermark'], 'pointer-events-none absolute')}
+      />
+      <div
+        className={cn(styles['content'], 'relative flex size-full flex-col')}
+      >
+        {children}
+      </div>
+      {qrUrl !== undefined && (
+        <SlideQRCode className={cn(styles['qr'], 'absolute')} url={qrUrl} />
+      )}
+    </div>
+  </div>
+);

--- a/apps/main/src/app/slides/_components/slide-mdx/cover/cover.module.css
+++ b/apps/main/src/app/slides/_components/slide-mdx/cover/cover.module.css
@@ -1,0 +1,38 @@
+.cover {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  gap: 2cqi;
+  padding: 2cqi 0;
+}
+
+/* 表紙内では H1 を大見出し、H2 をサブタイトル、p を補足情報として再定義 */
+.cover :global(h1) {
+  font-size: 7cqi;
+  font-weight: 700;
+  line-height: 1.15;
+  margin: 0;
+  padding: 0;
+  border: none;
+  color: var(--color-fg-base);
+}
+
+.cover :global(h2) {
+  font-size: 3.2cqi;
+  font-weight: 500;
+  line-height: 1.3;
+  margin: 0;
+  padding: 0;
+  border: none;
+  color: var(--color-primary-fg);
+}
+
+.cover :global(p) {
+  font-size: 2cqi;
+  line-height: 1.5;
+  margin: 0;
+  color: var(--color-fg-mute);
+}

--- a/apps/main/src/app/slides/_components/slide-mdx/cover/cover.stories.tsx
+++ b/apps/main/src/app/slides/_components/slide-mdx/cover/cover.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { Cover } from './cover';
+
+const meta: Meta<typeof Cover> = {
+  title: 'app/slides/slide-mdx/cover',
+  component: Cover,
+  decorators: [
+    (Story) => (
+      <div
+        className="bg-bg-base flex h-svh w-full flex-col"
+        style={{ containerType: 'inline-size' }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Cover>;
+
+export const Primary: Story = {
+  args: {
+    children: (
+      <>
+        <h1>k8oのスライド機能</h1>
+        <h2>サンプルプレゼンテーション</h2>
+        <p>2026年5月 / k8o</p>
+      </>
+    ),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('heading', { level: 1, name: 'k8oのスライド機能' }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const TitleOnly: Story = {
+  args: {
+    children: <h1>シンプルな表紙</h1>,
+  },
+};

--- a/apps/main/src/app/slides/_components/slide-mdx/cover/cover.tsx
+++ b/apps/main/src/app/slides/_components/slide-mdx/cover/cover.tsx
@@ -1,0 +1,7 @@
+import type { FC, ReactNode } from 'react';
+
+import styles from './cover.module.css';
+
+export const Cover: FC<{ children?: ReactNode }> = ({ children }) => (
+  <div className={styles['cover']}>{children}</div>
+);

--- a/apps/main/src/app/slides/_components/slide-mdx/cover/index.ts
+++ b/apps/main/src/app/slides/_components/slide-mdx/cover/index.ts
@@ -1,0 +1,1 @@
+export * from './cover';

--- a/apps/main/src/app/slides/_components/slide-mdx/image/image.module.css
+++ b/apps/main/src/app/slides/_components/slide-mdx/image/image.module.css
@@ -1,0 +1,23 @@
+.figure {
+  margin: 0 0 1cqi;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5cqi;
+}
+
+.img {
+  display: block;
+  max-width: 50%;
+  max-height: 35cqh;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+}
+
+.caption {
+  font-size: 1.6cqi;
+  line-height: 1.4;
+  color: var(--color-fg-mute);
+  text-align: center;
+}

--- a/apps/main/src/app/slides/_components/slide-mdx/image/image.tsx
+++ b/apps/main/src/app/slides/_components/slide-mdx/image/image.tsx
@@ -1,0 +1,25 @@
+import NextImage, { type StaticImageData } from 'next/image';
+import type { FC } from 'react';
+
+import styles from './image.module.css';
+
+type Props = {
+  src: StaticImageData;
+  alt: string;
+  caption?: string;
+};
+
+export const Image: FC<Props> = ({ src, alt, caption }) => (
+  <figure className={styles['figure']}>
+    <NextImage
+      alt={alt}
+      className={styles['img']}
+      loading="eager"
+      priority
+      src={src}
+    />
+    {caption !== undefined && caption !== '' && (
+      <figcaption className={styles['caption']}>{caption}</figcaption>
+    )}
+  </figure>
+);

--- a/apps/main/src/app/slides/_components/slide-mdx/image/index.ts
+++ b/apps/main/src/app/slides/_components/slide-mdx/image/index.ts
@@ -1,0 +1,1 @@
+export * from './image';

--- a/apps/main/src/app/slides/_components/slide-mdx/index.ts
+++ b/apps/main/src/app/slides/_components/slide-mdx/index.ts
@@ -1,0 +1,5 @@
+// MDX writer が JSX で直接利用するコンポーネント群
+export { Cover } from './cover';
+export { Image } from './image';
+export { Notes } from './notes';
+export { SlideDeckShell } from './slide-deck-shell';

--- a/apps/main/src/app/slides/_components/slide-mdx/notes/index.ts
+++ b/apps/main/src/app/slides/_components/slide-mdx/notes/index.ts
@@ -1,0 +1,1 @@
+export * from './notes';

--- a/apps/main/src/app/slides/_components/slide-mdx/notes/notes.tsx
+++ b/apps/main/src/app/slides/_components/slide-mdx/notes/notes.tsx
@@ -1,6 +1,6 @@
 import type { FC, ReactNode } from 'react';
 
-export const NOTES_ROLE = 'slide-notes' as const;
+import { NOTES_ROLE } from '@/features/slides/application/notes-marker';
 
 /**
  * 発表者ノート用マーカー。常に null を返し、本編 DOM には出力されない。

--- a/apps/main/src/app/slides/_components/slide-mdx/notes/notes.tsx
+++ b/apps/main/src/app/slides/_components/slide-mdx/notes/notes.tsx
@@ -1,0 +1,17 @@
+import type { FC, ReactNode } from 'react';
+
+export const NOTES_ROLE = 'slide-notes' as const;
+
+/**
+ * 発表者ノート用マーカー。常に null を返し、本編 DOM には出力されない。
+ * split-slides 側は `$$slideRole === NOTES_ROLE` で識別するため、
+ * HMR や re-export で関数参照が変わっても判定が壊れない。
+ */
+type NotesComponent = FC<{ children: ReactNode }> & {
+  $$slideRole: typeof NOTES_ROLE;
+};
+
+const NotesImpl: FC<{ children: ReactNode }> = () => null;
+(NotesImpl as NotesComponent).$$slideRole = NOTES_ROLE;
+
+export const Notes: NotesComponent = NotesImpl as NotesComponent;

--- a/apps/main/src/app/slides/_components/slide-mdx/slide-deck-shell/index.ts
+++ b/apps/main/src/app/slides/_components/slide-mdx/slide-deck-shell/index.ts
@@ -1,0 +1,1 @@
+export * from './slide-deck-shell';

--- a/apps/main/src/app/slides/_components/slide-mdx/slide-deck-shell/slide-deck-shell.tsx
+++ b/apps/main/src/app/slides/_components/slide-mdx/slide-deck-shell/slide-deck-shell.tsx
@@ -1,0 +1,17 @@
+import type { FC, ReactNode } from 'react';
+
+import { splitSlides } from '@/features/slides/application/split-slides';
+
+import { SlideDeck } from '../../slide-deck/slide-deck';
+
+const SLIDES_BASE_URL = 'https://k8o.me/slides';
+
+export const SlideDeckShell: FC<{
+  slug: string;
+  title: string;
+  children: ReactNode;
+}> = ({ slug, title, children }) => {
+  const slides = splitSlides(children);
+  const qrUrl = `${SLIDES_BASE_URL}/${slug}`;
+  return <SlideDeck qrUrl={qrUrl} slides={slides} slug={slug} title={title} />;
+};

--- a/apps/main/src/app/slides/feed/route.ts
+++ b/apps/main/src/app/slides/feed/route.ts
@@ -1,0 +1,46 @@
+import { cacheLife } from 'next/cache';
+import { NextResponse } from 'next/server';
+import RSS from 'rss';
+
+import { getSlideContents } from '@/features/slides/interface/queries';
+
+import { metadata } from '../layout';
+
+const SLIDES_URL = 'https://k8o.me/slides';
+
+async function generateRssFeed() {
+  'use cache';
+  cacheLife('max');
+
+  const feed = new RSS({
+    title: metadata.title,
+    description: metadata.description,
+    feed_url: `${SLIDES_URL}/feed.xml`,
+    site_url: SLIDES_URL,
+    language: 'ja',
+  });
+
+  const slides = await getSlideContents();
+
+  for (const slide of slides) {
+    feed.item({
+      title: slide.title,
+      description: slide.description ?? '',
+      url: `${SLIDES_URL}/${slide.slug}`,
+      date: slide.updatedAt,
+      categories: slide.tags.map((tag) => tag),
+    });
+  }
+
+  return feed.xml();
+}
+
+export async function GET() {
+  const xml = await generateRssFeed();
+
+  return new NextResponse(xml, {
+    headers: {
+      'Content-Type': 'application/xml',
+    },
+  });
+}

--- a/apps/main/src/app/slides/feed/route.ts
+++ b/apps/main/src/app/slides/feed/route.ts
@@ -28,7 +28,7 @@ async function generateRssFeed() {
       description: slide.description ?? '',
       url: `${SLIDES_URL}/${slide.slug}`,
       date: slide.updatedAt,
-      categories: slide.tags.map((tag) => tag),
+      categories: slide.tags,
     });
   }
 

--- a/apps/main/src/app/slides/feed/route.ts
+++ b/apps/main/src/app/slides/feed/route.ts
@@ -15,7 +15,7 @@ async function generateRssFeed() {
   const feed = new RSS({
     title: metadata.title,
     description: metadata.description,
-    feed_url: `${SLIDES_URL}/feed.xml`,
+    feed_url: `${SLIDES_URL}/feed`,
     site_url: SLIDES_URL,
     language: 'ja',
   });

--- a/apps/main/src/app/slides/layout.tsx
+++ b/apps/main/src/app/slides/layout.tsx
@@ -1,0 +1,34 @@
+import { Heading } from '@k8o/arte-odyssey';
+import type { Metadata } from 'next';
+import Link from 'next/link';
+
+export const metadata = {
+  title: 'Slides',
+  description: '登壇や発表で使ったスライドをまとめています。',
+  openGraph: {
+    title: 'Slides',
+    description: '登壇や発表で使ったスライドをまとめています。',
+    url: 'https://k8o.me/slides',
+    siteName: 'k8o',
+    locale: 'ja',
+    type: 'website',
+  },
+  twitter: {
+    title: 'Slides',
+    card: 'summary',
+    description: '登壇や発表で使ったスライドをまとめています。',
+  },
+} satisfies Metadata;
+
+export default function Layout({ children }: LayoutProps<'/slides'>) {
+  return (
+    <div className="mx-auto w-full max-w-5xl">
+      <div className="flex flex-col gap-6">
+        <Link className="hover:underline" href="/slides">
+          <Heading type="h2">Slides</Heading>
+        </Link>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/app/slides/opengraph-image.tsx
+++ b/apps/main/src/app/slides/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { OgImage } from '@/app/_components/og-image';
+
+export const alt = 'slides';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default function OpenGraphImage() {
+  return OgImage({ title: 'k8oのSlides' });
+}

--- a/apps/main/src/app/slides/page.tsx
+++ b/apps/main/src/app/slides/page.tsx
@@ -1,0 +1,14 @@
+import { getSlideContents } from '@/features/slides/interface/queries';
+
+import { SlideCard } from './_components/slide-card';
+
+export default async function Page() {
+  const slides = await getSlideContents();
+  return (
+    <div className="flex flex-col gap-4">
+      {slides.map((slide) => (
+        <SlideCard key={slide.id} {...slide} />
+      ))}
+    </div>
+  );
+}

--- a/apps/main/src/features/slides/application/notes-marker.ts
+++ b/apps/main/src/features/slides/application/notes-marker.ts
@@ -1,0 +1,6 @@
+/**
+ * 発表者ノートコンポーネントを識別するための静的マーカー値。
+ * Notes コンポーネントの `$$slideRole` プロパティに設定され、
+ * splitSlides 側はこの文字列で判定する。
+ */
+export const NOTES_ROLE = 'slide-notes' as const;

--- a/apps/main/src/features/slides/application/path.test.ts
+++ b/apps/main/src/features/slides/application/path.test.ts
@@ -1,0 +1,35 @@
+import { join } from 'node:path';
+import { cwd } from 'node:process';
+
+import { slidePath } from './path';
+
+vi.mock('path');
+vi.mock('process');
+
+describe('slidePath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('スライドファイルのパスを生成する', () => {
+    const mockCwd = '/Users/test/project';
+    const mockJoin = vi
+      .fn()
+      .mockReturnValue(
+        '/Users/test/project/src/app/slides/(decks)/test-slug/content.mdx',
+      );
+
+    vi.mocked(cwd).mockReturnValue(mockCwd);
+    vi.mocked(join).mockImplementation(mockJoin);
+
+    const result = slidePath('test-slug');
+
+    expect(join).toHaveBeenCalledWith(
+      mockCwd,
+      'src/app/slides/(decks)/test-slug/content.mdx',
+    );
+    expect(result).toBe(
+      '/Users/test/project/src/app/slides/(decks)/test-slug/content.mdx',
+    );
+  });
+});

--- a/apps/main/src/features/slides/application/path.ts
+++ b/apps/main/src/features/slides/application/path.ts
@@ -1,0 +1,5 @@
+import { join } from 'node:path';
+import { cwd } from 'node:process';
+
+export const slidePath = (slug: string) =>
+  join(cwd(), `src/app/slides/(decks)/${slug}/content.mdx`);

--- a/apps/main/src/features/slides/application/slide.test.ts
+++ b/apps/main/src/features/slides/application/slide.test.ts
@@ -1,0 +1,83 @@
+import { db } from '@repo/database';
+import { getFrontmatter } from '@repo/helpers/mdx/frontmatter';
+
+import { slidePath } from './path';
+import { getSlide, getSlideMetadata } from './slide';
+
+vi.mock('@repo/database', () => ({
+  db: {
+    query: {
+      slides: {
+        findFirst: vi.fn(),
+      },
+    },
+  },
+}));
+vi.mock('@repo/helpers/mdx/frontmatter');
+vi.mock('./path');
+
+describe('slide service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getSlide', () => {
+    it('スライドの詳細情報を取得できる', async () => {
+      const mockSlide = {
+        id: 1,
+        slug: 'test-slug',
+        published: true,
+        createdAt: new Date().toISOString(),
+        slideTag: [
+          {
+            tag: { id: 1, name: 'TypeScript' },
+          },
+          {
+            tag: { id: 2, name: 'React' },
+          },
+        ],
+      };
+
+      vi.mocked(db.query.slides.findFirst).mockResolvedValue(mockSlide);
+
+      const result = await getSlide('test-slug');
+
+      expect(result).toEqual({
+        id: 1,
+        slug: 'test-slug',
+        tags: [
+          { id: 1, name: 'TypeScript' },
+          { id: 2, name: 'React' },
+        ],
+      });
+    });
+
+    it('存在しないスラッグの場合はエラーを投げる', async () => {
+      vi.mocked(db.query.slides.findFirst).mockResolvedValue(undefined);
+
+      await expect(getSlide('missing')).rejects.toThrow(
+        'Slide not found: missing',
+      );
+    });
+  });
+
+  describe('getSlideMetadata', () => {
+    it('frontmatterを返す', async () => {
+      const mockMetadata = {
+        title: 'Test Slide',
+        description: 'desc',
+        createdAt: '2026-05-15T00:00:00.000Z',
+        updatedAt: '2026-05-15T00:00:00.000Z',
+      };
+
+      vi.mocked(slidePath).mockReturnValue('/path/to/slide');
+      vi.mocked(getFrontmatter).mockResolvedValue(mockMetadata);
+
+      const result = await getSlideMetadata('test-slug');
+
+      expect(slidePath).toHaveBeenCalledWith('test-slug');
+      expect(getFrontmatter).toHaveBeenCalledWith('/path/to/slide');
+      expect(result).toBe(mockMetadata);
+    });
+  });
+});

--- a/apps/main/src/features/slides/application/slide.ts
+++ b/apps/main/src/features/slides/application/slide.ts
@@ -1,0 +1,33 @@
+import { db } from '@repo/database';
+import { getFrontmatter } from '@repo/helpers/mdx/frontmatter';
+
+import { slidePath } from './path';
+
+export const getSlide = async (slug: string) => {
+  const slide = await db.query.slides.findFirst({
+    where: (slideFields, { eq }) => eq(slideFields.slug, slug),
+    with: {
+      slideTag: {
+        with: {
+          tag: true,
+        },
+      },
+    },
+  });
+
+  if (!slide) {
+    throw new Error(`Slide not found: ${slug}`);
+  }
+
+  return {
+    id: slide.id,
+    slug: slide.slug,
+    tags: slide.slideTag.map((slideTag) => ({
+      id: slideTag.tag.id,
+      name: slideTag.tag.name,
+    })),
+  };
+};
+
+export const getSlideMetadata = (slug: string) =>
+  getFrontmatter(slidePath(slug));

--- a/apps/main/src/features/slides/application/slides.test.ts
+++ b/apps/main/src/features/slides/application/slides.test.ts
@@ -1,0 +1,57 @@
+import { db } from '@repo/database';
+
+import { getSlides } from './slides';
+
+vi.mock('@repo/database', () => ({
+  db: {
+    query: {
+      slides: {
+        findMany: vi.fn(),
+      },
+    },
+  },
+}));
+
+describe('slides service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('getSlides', () => {
+    it('公開スライドの一覧を取得する', async () => {
+      const mockSlides = [
+        {
+          id: 1,
+          slug: 'slide-1',
+          published: true,
+          createdAt: new Date().toISOString(),
+          slideTag: [{ tag: { name: 'TypeScript' } }, { tag: { name: 'CSS' } }],
+        },
+        {
+          id: 2,
+          slug: 'slide-2',
+          published: true,
+          createdAt: new Date().toISOString(),
+          slideTag: [],
+        },
+      ];
+
+      vi.mocked(db.query.slides.findMany).mockResolvedValue(mockSlides);
+
+      const result = await getSlides();
+
+      expect(result).toEqual([
+        { id: 1, slug: 'slide-1', tags: ['TypeScript', 'CSS'] },
+        { id: 2, slug: 'slide-2', tags: [] },
+      ]);
+    });
+
+    it('空配列の場合は空配列を返す', async () => {
+      vi.mocked(db.query.slides.findMany).mockResolvedValue([]);
+
+      const result = await getSlides();
+
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/apps/main/src/features/slides/application/slides.ts
+++ b/apps/main/src/features/slides/application/slides.ts
@@ -1,0 +1,24 @@
+import { db } from '@repo/database';
+
+export const getSlides = async () => {
+  const slideRows = await db.query.slides.findMany({
+    with: {
+      slideTag: {
+        with: {
+          tag: true,
+        },
+      },
+    },
+    where: (slideFields, { eq }) => eq(slideFields.published, true),
+    limit: 100,
+    orderBy(fields, operators) {
+      return [operators.desc(fields.createdAt), operators.desc(fields.id)];
+    },
+  });
+
+  return slideRows.map((slide) => ({
+    id: slide.id,
+    slug: slide.slug,
+    tags: slide.slideTag.map((slideTag) => slideTag.tag.name),
+  }));
+};

--- a/apps/main/src/features/slides/application/split-slides.test.tsx
+++ b/apps/main/src/features/slides/application/split-slides.test.tsx
@@ -1,0 +1,92 @@
+import React, { type FC, type ReactNode } from 'react';
+
+import { NOTES_ROLE } from './notes-marker';
+import { splitSlides } from './split-slides';
+
+// vitest の JSX classic transform 用に React を scope に置く
+void React;
+
+// テスト用 Notes: NOTES_ROLE マーカーを持つ関数コンポーネント
+type NotesComponent = FC<{ children: ReactNode }> & {
+  $$slideRole: typeof NOTES_ROLE;
+};
+const NotesImpl: FC<{ children: ReactNode }> = () => null;
+(NotesImpl as NotesComponent).$$slideRole = NOTES_ROLE;
+const TestNotes = NotesImpl as NotesComponent;
+
+const FakeNotes: FC = () => null;
+
+describe('splitSlides', () => {
+  describe('正常系', () => {
+    it('hr で区切らない場合は 1 枚のスライドになる', () => {
+      const children = [<h2 key="1">title</h2>, <p key="2">body</p>];
+      const slides = splitSlides(children);
+      expect(slides).toHaveLength(1);
+      expect(slides[0]?.content).toHaveLength(2);
+      expect(slides[0]?.notes).toHaveLength(0);
+    });
+
+    it('hr 要素ごとにスライドを分割する', () => {
+      const children = [
+        <h2 key="1">1</h2>,
+        <hr key="hr1" />,
+        <h2 key="2">2</h2>,
+        <hr key="hr2" />,
+        <h2 key="3">3</h2>,
+      ];
+      const slides = splitSlides(children);
+      expect(slides).toHaveLength(3);
+      expect(slides[0]?.content).toHaveLength(1);
+      expect(slides[1]?.content).toHaveLength(1);
+      expect(slides[2]?.content).toHaveLength(1);
+    });
+
+    it('Notes は content に含まれず notes に集められる', () => {
+      const children = [
+        <h2 key="1">title</h2>,
+        <TestNotes key="n1">メモ1</TestNotes>,
+        <p key="2">body</p>,
+        <TestNotes key="n2">メモ2</TestNotes>,
+      ];
+      const slides = splitSlides(children);
+      expect(slides).toHaveLength(1);
+      expect(slides[0]?.content).toHaveLength(2);
+      expect(slides[0]?.notes).toEqual(['メモ1', 'メモ2']);
+    });
+
+    it('Notes は所属するスライドにだけ振り分けられる', () => {
+      const children = [
+        <h2 key="1">1</h2>,
+        <TestNotes key="n1">1のメモ</TestNotes>,
+        <hr key="hr" />,
+        <h2 key="2">2</h2>,
+        <TestNotes key="n2">2のメモ</TestNotes>,
+      ];
+      const slides = splitSlides(children);
+      expect(slides[0]?.notes).toEqual(['1のメモ']);
+      expect(slides[1]?.notes).toEqual(['2のメモ']);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('children が空でも 1 枚の空スライドを返す', () => {
+      const slides = splitSlides(null);
+      expect(slides).toHaveLength(1);
+      expect(slides[0]?.content).toHaveLength(0);
+      expect(slides[0]?.notes).toHaveLength(0);
+    });
+
+    it('hr のみでも区切り通りに空スライドを生成', () => {
+      const children = [<hr key="1" />, <hr key="2" />];
+      const slides = splitSlides(children);
+      expect(slides).toHaveLength(3);
+    });
+
+    it('$$slideRole がない関数コンポーネントは content 扱い', () => {
+      const children = [<h2 key="1">title</h2>, <FakeNotes key="2" />];
+      const slides = splitSlides(children);
+      expect(slides[0]?.content).toHaveLength(2);
+      expect(slides[0]?.notes).toHaveLength(0);
+    });
+  });
+});

--- a/apps/main/src/features/slides/application/split-slides.ts
+++ b/apps/main/src/features/slides/application/split-slides.ts
@@ -1,0 +1,50 @@
+import {
+  Children,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+
+import { NOTES_ROLE } from './notes-marker';
+
+export type Slide = {
+  content: ReactNode[];
+  notes: ReactNode[];
+};
+
+const isHrElement = (node: ReactNode): boolean =>
+  isValidElement(node) && node.type === 'hr';
+
+const isNotesElement = (
+  node: ReactNode,
+): node is ReactElement<{ children: ReactNode }> => {
+  if (!isValidElement(node)) return false;
+  const { type } = node;
+  if (typeof type !== 'function') return false;
+  return (type as { $$slideRole?: string }).$$slideRole === NOTES_ROLE;
+};
+
+/**
+ * MDX が描画した children (h2, p, hr, Notes 等) を `---` (hr) で分割し、
+ * Notes は本編から外して各スライドの notes に集める。
+ */
+export const splitSlides = (children: ReactNode): Slide[] => {
+  const slides: Slide[] = [{ content: [], notes: [] }];
+  for (const child of Children.toArray(children)) {
+    const current = slides.at(-1);
+    if (current === undefined) continue;
+
+    if (isHrElement(child)) {
+      slides.push({ content: [], notes: [] });
+      continue;
+    }
+
+    if (isNotesElement(child)) {
+      current.notes.push(child.props.children);
+      continue;
+    }
+
+    current.content.push(child);
+  }
+  return slides;
+};

--- a/apps/main/src/features/slides/interface/queries.ts
+++ b/apps/main/src/features/slides/interface/queries.ts
@@ -1,0 +1,46 @@
+import { cacheLife } from 'next/cache';
+
+import {
+  getSlide,
+  getSlideMetadata,
+} from '@/features/slides/application/slide';
+import { getSlides } from '@/features/slides/application/slides';
+
+export async function getSlideContents() {
+  'use cache';
+  cacheLife('max');
+
+  const slides = await getSlides();
+  return Promise.all(
+    slides.map(async (slide) => {
+      const metadata = await getSlideMetadata(slide.slug);
+      return {
+        id: slide.id,
+        slug: slide.slug,
+        tags: slide.tags,
+        title: metadata.title,
+        description: metadata.description,
+        createdAt: metadata.createdAt,
+        updatedAt: metadata.updatedAt,
+      };
+    }),
+  );
+}
+
+export async function getSlideContent(slug: string) {
+  'use cache';
+  cacheLife('max');
+
+  const slide = await getSlide(slug);
+  const metadata = await getSlideMetadata(slug);
+
+  return {
+    id: slide.id,
+    slug: slide.slug,
+    tags: slide.tags,
+    title: metadata.title,
+    description: metadata.description,
+    createdAt: metadata.createdAt,
+    updatedAt: metadata.updatedAt,
+  };
+}

--- a/apps/main/src/mdx.d.ts
+++ b/apps/main/src/mdx.d.ts
@@ -1,0 +1,7 @@
+declare module '*.mdx' {
+  import type { MDXProps } from 'mdx/types';
+  import type { ComponentType } from 'react';
+
+  const Content: ComponentType<MDXProps>;
+  export default Content;
+}


### PR DESCRIPTION
## Summary

- `/slides` で MDX デッキを 16:9 ステージで表示。`---` で slide 分割
- `/slides/<slug>` (viewer) と `/slides/<slug>?mode=presenter` (発表者画面) を用意。発表者画面は Now / Next / Notes の 3 ペイン
- writer 向けの JSX (`<Cover>` / `<Image>` / `<Notes>`) を `slide-mdx/` に集約。MDX タグ override は `mdx-parts/` に分離
- viewer の「発表者モード」起動時は browser fullscreen API ではなく `isPresenting` state で chrome を畳んで Stage を viewport いっぱいに拡張 (ESC / × ボタンで終了)
- URL hash を index の単一情報源にし、`useSyncExternalStore` で hash / fullscreen を購読 (state→hash の同期 useEffect なし)
- `BroadcastChannel` で viewer ↔ presenter の index 同期 + sessionId 付き heartbeat (1.5s 間隔 / 5s タイムアウト) で viewer 終了時に presenter を自動 close。reload 時は猶予内で復帰して close されない
- RSS feed (`/slides/feed`) + sitemap / homepage への配線

## Test plan

- [x] `pnpm -F main type-check`
- [x] `pnpm -F main test -- --project=\"features test\"` (268 passed)
- [x] `pnpm exec vp check apps/main/src/app/slides` (0 errors / 1 pre-existing warning)
- [x] dev server で `/slides`, `/slides/sample-deck`, `/slides/sample-deck?mode=presenter` の 200 確認
- [ ] 手動: 発表者モード起動 → viewer は chrome 畳む / presenter 新タブで開く
- [ ] 手動: viewer タブ close → presenter 自動 close
- [ ] 手動: viewer reload → presenter は閉じない (heartbeat 復帰)
- [ ] 手動: 同 slug を 2 ペア起動 → ペア間で干渉しない (sessionId 分離)