### PR TITLE
refactor: clean up React patterns, drop redundant state and dead code

### DIFF
--- a/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
@@ -23,7 +23,6 @@ export const Presenter: FC<{
 }> = ({ days }) => {
   const totalContributions = days.reduce((total, day) => total + day.count, 0);
 
-  // 期間を計算（実際の日数に基づいて）
   const period =
     days.length >= 365
       ? '過去1年間'

--- a/apps/main/src/app/_components/playgrounds/async-clipboard/clipboard-text-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/async-clipboard/clipboard-text-demo.tsx
@@ -3,57 +3,57 @@
 import { Button, FormControl, TextField } from '@k8o/arte-odyssey';
 import { type FC, useEffect, useState } from 'react';
 
+type ClipboardPermissionName = 'clipboard-read' | 'clipboard-write';
+
+const subscribePermission = (
+  name: ClipboardPermissionName,
+  onChange: (state: PermissionState) => void,
+): (() => void) => {
+  let status: PermissionStatus | null = null;
+  let cancelled = false;
+  const handleChange = () => {
+    if (status) onChange(status.state);
+  };
+
+  navigator.permissions
+    .query({ name: name as PermissionName })
+    .then((permission) => {
+      if (cancelled) return undefined;
+      status = permission;
+      onChange(permission.state);
+      permission.addEventListener('change', handleChange);
+      return undefined;
+    })
+    .catch(() => {
+      console.warn(
+        'ClipboardについてのPermission APIをサポートしていないブラウザです。',
+      );
+    });
+
+  return () => {
+    cancelled = true;
+    status?.removeEventListener('change', handleChange);
+  };
+};
+
 export const ClipboardTextDemo: FC = () => {
-  const [text, setText] = useState<string>('');
+  const [text, setText] = useState('');
   const [readPermissions, setReadPermissions] = useState<PermissionState>();
   const [writePermissions, setWritePermissions] = useState<PermissionState>();
 
-  const copyText = async () => {
-    await navigator.clipboard.writeText(text);
-  };
-
-  const pasteText = async () => {
-    const pastedText = await navigator.clipboard.readText();
-    setText((prev) => prev + pastedText);
-  };
-
   useEffect(() => {
-    const readPermission = navigator.permissions.query({
-      // @ts-expect-error -- PermissionNameにclipboard-readがない
-      name: 'clipboard-read',
-    });
-    const writePermission = navigator.permissions.query({
-      // @ts-expect-error -- PermissionNameにclipboard-writeがない
-      name: 'clipboard-write',
-    });
-
-    void readPermission
-      .then((permission) => {
-        setReadPermissions(permission.state);
-        permission.addEventListener('change', () => {
-          setReadPermissions(permission.state);
-        });
-        return undefined;
-      })
-      .catch(() => {
-        console.warn(
-          'ClipboardについてのPermission APIをサポートしていないブラウザです。',
-        );
-      });
-
-    void writePermission
-      .then((permission) => {
-        setWritePermissions(permission.state);
-        permission.addEventListener('change', () => {
-          setWritePermissions(permission.state);
-        });
-        return undefined;
-      })
-      .catch(() => {
-        console.warn(
-          'ClipboardについてのPermission APIをサポートしていないブラウザです。',
-        );
-      });
+    const unsubscribeRead = subscribePermission(
+      'clipboard-read',
+      setReadPermissions,
+    );
+    const unsubscribeWrite = subscribePermission(
+      'clipboard-write',
+      setWritePermissions,
+    );
+    return () => {
+      unsubscribeRead();
+      unsubscribeWrite();
+    };
   }, []);
 
   return (
@@ -82,8 +82,21 @@ export const ClipboardTextDemo: FC = () => {
         )}
       />
       <div className="flex flex-wrap gap-4">
-        <Button onClick={() => void copyText()}>クリップボードにコピー</Button>
-        <Button onClick={() => void pasteText()}>
+        <Button
+          onClick={() => {
+            void navigator.clipboard.writeText(text);
+          }}
+        >
+          クリップボードにコピー
+        </Button>
+        <Button
+          onClick={() => {
+            void navigator.clipboard.readText().then((pasted) => {
+              setText((prev) => prev + pasted);
+              return undefined;
+            });
+          }}
+        >
           クリップボードからペースト
         </Button>
       </div>

--- a/apps/main/src/app/_components/playgrounds/async-clipboard/clipboard-text-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/async-clipboard/clipboard-text-demo.tsx
@@ -8,20 +8,14 @@ type ClipboardPermissionName = 'clipboard-read' | 'clipboard-write';
 const subscribePermission = (
   name: ClipboardPermissionName,
   onChange: (state: PermissionState) => void,
-): (() => void) => {
-  let status: PermissionStatus | null = null;
-  let cancelled = false;
-  const handleChange = () => {
-    if (status) onChange(status.state);
-  };
-
+): void => {
   navigator.permissions
     .query({ name: name as PermissionName })
     .then((permission) => {
-      if (cancelled) return undefined;
-      status = permission;
       onChange(permission.state);
-      permission.addEventListener('change', handleChange);
+      permission.addEventListener('change', () => {
+        onChange(permission.state);
+      });
       return undefined;
     })
     .catch(() => {
@@ -29,11 +23,6 @@ const subscribePermission = (
         'ClipboardについてのPermission APIをサポートしていないブラウザです。',
       );
     });
-
-  return () => {
-    cancelled = true;
-    status?.removeEventListener('change', handleChange);
-  };
 };
 
 export const ClipboardTextDemo: FC = () => {
@@ -42,18 +31,8 @@ export const ClipboardTextDemo: FC = () => {
   const [writePermissions, setWritePermissions] = useState<PermissionState>();
 
   useEffect(() => {
-    const unsubscribeRead = subscribePermission(
-      'clipboard-read',
-      setReadPermissions,
-    );
-    const unsubscribeWrite = subscribePermission(
-      'clipboard-write',
-      setWritePermissions,
-    );
-    return () => {
-      unsubscribeRead();
-      unsubscribeWrite();
-    };
+    subscribePermission('clipboard-read', setReadPermissions);
+    subscribePermission('clipboard-write', setWritePermissions);
   }, []);
 
   return (

--- a/apps/main/src/app/_components/playgrounds/composed-ranges/selection-properties.tsx
+++ b/apps/main/src/app/_components/playgrounds/composed-ranges/selection-properties.tsx
@@ -3,11 +3,13 @@
 import { Code, FormControl, TextField } from '@k8o/arte-odyssey';
 import { useEffect, useRef, useState } from 'react';
 
+// Selection はシングルトンで参照が変わらないため、配列で wrap して変更を検知する。
+type SelectionSnapshot = [Selection] | null;
+
 export function SelectionProperties() {
-  // Selectionオブジェクトはユニークなので、配列として保持して変更が起きた時に再レンダリングするようにする
-  const [selection, setSelection] = useState<[Selection] | null>(null);
   const ref = useRef<HTMLDivElement>(null);
   const [inView, setInView] = useState(false);
+  const [selection, setSelection] = useState<SelectionSnapshot>(null);
 
   useEffect(() => {
     const element = ref.current;
@@ -17,26 +19,24 @@ export function SelectionProperties() {
       setInView(entry?.isIntersecting ?? false);
     });
     observer.observe(element);
-
     return () => {
       observer.disconnect();
     };
   }, []);
 
   useEffect(() => {
-    const handleChange = () => {
-      if (!inView) {
-        return;
-      }
-      const currentSelection = window.getSelection();
-      setSelection(currentSelection ? [currentSelection] : null);
+    if (!inView) return undefined;
+    const handler = () => {
+      const current = window.getSelection();
+      setSelection(current ? [current] : null);
     };
-
-    document.addEventListener('selectionchange', handleChange);
+    document.addEventListener('selectionchange', handler);
     return () => {
-      document.removeEventListener('selectionchange', handleChange);
+      document.removeEventListener('selectionchange', handler);
     };
   }, [inView]);
+
+  const current = selection?.[0];
 
   return (
     <div className="flex flex-col gap-4" ref={ref}>
@@ -54,7 +54,7 @@ export function SelectionProperties() {
         <p className="font-bold">
           選択中のテキスト（<Code>selection.toString()</Code>）
         </p>
-        <p>{selection ? selection[0].toString() : ''}</p>
+        <p>{current ? current.toString() : ''}</p>
       </div>
       <div>
         <p className="font-bold">選択要素の開始位置の要素</p>
@@ -63,8 +63,8 @@ export function SelectionProperties() {
           <Code>selection.anchorOffset</Code>）
         </p>
         <p>
-          {selection
-            ? `${selection[0].anchorNode?.textContent}, ${selection[0].anchorOffset}`
+          {current
+            ? `${current.anchorNode?.textContent}, ${current.anchorOffset}`
             : ''}
         </p>
       </div>
@@ -75,8 +75,8 @@ export function SelectionProperties() {
           <Code>selection.focusOffset</Code>）
         </p>
         <p>
-          {selection
-            ? `${selection[0].focusNode?.textContent}, ${selection[0].focusOffset}`
+          {current
+            ? `${current.focusNode?.textContent}, ${current.focusOffset}`
             : ''}
         </p>
       </div>
@@ -84,7 +84,7 @@ export function SelectionProperties() {
         <p className="font-bold">
           選択の種類（<Code>selection.type</Code>）
         </p>
-        <p>{selection ? selection[0].type : ''}</p>
+        <p>{current ? current.type : ''}</p>
       </div>
     </div>
   );

--- a/apps/main/src/app/_components/playgrounds/event-timing/event-timing-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/event-timing/event-timing-demo.tsx
@@ -42,24 +42,18 @@ export function EventTimingDemo() {
       for (const entry of list.getEntries()) {
         if (!isPerformanceEventTiming(entry)) continue;
         const eventEntry = entry;
-
-        // interactionIdがないイベントはスキップ
         if (eventEntry.interactionId === 0) continue;
 
         const existing = interactionMap.get(eventEntry.interactionId);
-
-        // 同一インタラクションの中で最大のdurationを持つエントリを記録
         if (existing) {
           if (eventEntry.duration > existing.duration) {
             interactionMap.set(eventEntry.interactionId, eventEntry);
           }
           continue;
         }
-
-        // 新しいインタラクションを記録
         interactionMap.set(eventEntry.interactionId, eventEntry);
 
-        // 少し待ってから結果を追加（同一インタラクションの全イベントを待つ）
+        // 同一 interactionId のイベントが順次到着するので、少し待って最大 duration を確定させる
         const timeoutId = setTimeout(() => {
           timeoutIds.delete(timeoutId);
 

--- a/apps/main/src/app/_components/playgrounds/highlight/highlight-basic-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/highlight/highlight-basic-demo.tsx
@@ -3,28 +3,30 @@
 import { type FC, useEffect, useRef } from 'react';
 
 const text = '知らざるを知らずとなす、これ知るなり';
+const HIGHLIGHT_NAME = 'highlight-example1';
 
 export const HighlightBasicDemo: FC = () => {
   const ref = useRef<HTMLParagraphElement>(null);
 
   useEffect(() => {
-    if (!ref.current?.firstChild) return;
-    const textNode = ref.current.firstChild;
+    const textNode = ref.current?.firstChild;
+    if (!textNode) return undefined;
 
     const range = new Range();
     range.setStart(textNode, 12);
     range.setEnd(textNode, text.length);
 
-    const highlight = new Highlight(range);
-
-    CSS.highlights.set('highlight-example1', highlight);
+    CSS.highlights.set(HIGHLIGHT_NAME, new Highlight(range));
+    return () => {
+      CSS.highlights.delete(HIGHLIGHT_NAME);
+    };
   }, []);
 
   return (
     <>
       <p ref={ref}>{text}</p>
       <style>
-        {`::highlight(highlight-example1) {
+        {`::highlight(${HIGHLIGHT_NAME}) {
             background-color: var(--color-bg-warning);
             color: var(--color-fg-warning);
           }`}

--- a/apps/main/src/app/_components/playgrounds/highlight/highlight-priority-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/highlight/highlight-priority-demo.tsx
@@ -3,34 +3,36 @@
 import { type FC, useEffect, useRef } from 'react';
 
 const text = 'Imagination is more important than knowledge';
+const HIGHLIGHT_NAMES = [
+  'highlight-example2-1',
+  'highlight-example2-2',
+  'highlight-example2-3',
+] as const;
 
 export const HighlightPriorityDemo: FC = () => {
   const ref = useRef<HTMLParagraphElement>(null);
 
   useEffect(() => {
-    if (!ref.current?.firstChild) return;
-    const textNode = ref.current.firstChild;
+    const textNode = ref.current?.firstChild;
+    if (!textNode) return undefined;
 
-    const range1 = new Range();
-    range1.setStart(textNode, 0);
-    range1.setEnd(textNode, 11);
-    const highlight1 = new Highlight(range1);
-    highlight1.priority = 1;
+    const createHighlight = (priority?: number): Highlight => {
+      const range = new Range();
+      range.setStart(textNode, 0);
+      range.setEnd(textNode, 11);
+      const highlight = new Highlight(range);
+      if (priority !== undefined) highlight.priority = priority;
+      return highlight;
+    };
 
-    const range2 = new Range();
-    range2.setStart(textNode, 0);
-    range2.setEnd(textNode, 11);
-    const highlight2 = new Highlight(range2);
-    highlight2.priority = 1;
-
-    const range3 = new Range();
-    range3.setStart(textNode, 0);
-    range3.setEnd(textNode, 11);
-    const highlight3 = new Highlight(range3);
-
-    CSS.highlights.set('highlight-example2-1', highlight1);
-    CSS.highlights.set('highlight-example2-2', highlight2);
-    CSS.highlights.set('highlight-example2-3', highlight3);
+    CSS.highlights.set(HIGHLIGHT_NAMES[0], createHighlight(1));
+    CSS.highlights.set(HIGHLIGHT_NAMES[1], createHighlight(1));
+    CSS.highlights.set(HIGHLIGHT_NAMES[2], createHighlight());
+    return () => {
+      for (const name of HIGHLIGHT_NAMES) {
+        CSS.highlights.delete(name);
+      }
+    };
   }, []);
 
   return (
@@ -38,15 +40,15 @@ export const HighlightPriorityDemo: FC = () => {
       <p ref={ref}>{text}</p>
       <style>
         {`
-          ::highlight(highlight-example2-1) {
+          ::highlight(${HIGHLIGHT_NAMES[0]}) {
             background-color: var(--color-bg-info);
             color: var(--color-fg-info);
           }
-          ::highlight(highlight-example2-2) {
+          ::highlight(${HIGHLIGHT_NAMES[1]}) {
             background-color: var(--color-bg-warning);
             color: var(--color-fg-warning);
           }
-          ::highlight(highlight-example2-3) {
+          ::highlight(${HIGHLIGHT_NAMES[2]}) {
             background-color: var(--color-bg-error);
             color: var(--color-fg-error);
           }

--- a/apps/main/src/app/_components/playgrounds/highlight/highlight-spelling-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/highlight/highlight-spelling-demo.tsx
@@ -3,13 +3,14 @@
 import { type FC, useEffect, useRef } from 'react';
 
 const text = '食べれる';
+const HIGHLIGHT_NAME = 'highlight-example3';
 
 export const HighlightSpellingDemo: FC = () => {
   const ref = useRef<HTMLParagraphElement>(null);
 
   useEffect(() => {
-    if (!ref.current?.firstChild) return;
-    const textNode = ref.current.firstChild;
+    const textNode = ref.current?.firstChild;
+    if (!textNode) return undefined;
 
     const range = new Range();
     range.setStart(textNode, 2);
@@ -17,15 +18,17 @@ export const HighlightSpellingDemo: FC = () => {
 
     const highlight = new Highlight(range);
     highlight.type = 'spelling-error';
-
-    CSS.highlights.set('highlight-example3', highlight);
+    CSS.highlights.set(HIGHLIGHT_NAME, highlight);
+    return () => {
+      CSS.highlights.delete(HIGHLIGHT_NAME);
+    };
   }, []);
 
   return (
     <>
       <p ref={ref}>{text}</p>
       <style>
-        {`::highlight(highlight-example3) {
+        {`::highlight(${HIGHLIGHT_NAME}) {
             background-color: var(--color-bg-error);
             color: var(--color-fg-error);
           }`}

--- a/apps/main/src/app/_components/playgrounds/print-color-adjust/print-color-adjust-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/print-color-adjust/print-color-adjust-demo.tsx
@@ -6,9 +6,12 @@ import { type FC, useEffect, useState } from 'react';
 export const PrintColorAdjustDemo: FC = () => {
   const [isExact, setIsExact] = useState(false);
 
-  const handleClick = () => {
-    setIsExact(!isExact);
-    document.body.style.printColorAdjust = isExact ? 'economy' : 'exact';
+  const toggle = () => {
+    setIsExact((prev) => {
+      const next = !prev;
+      document.body.style.printColorAdjust = next ? 'exact' : 'economy';
+      return next;
+    });
   };
 
   useEffect(
@@ -29,7 +32,7 @@ export const PrintColorAdjustDemo: FC = () => {
       <p className="text-fg-mute self-center text-xs md:text-sm">
         現在の設定: {isExact ? '正確（exact）' : 'ブラウザにお任せ（economy）'}
       </p>
-      <Button onClick={handleClick}>
+      <Button onClick={toggle}>
         {isExact ? 'ブラウザにお任せする' : '正確にする'}
       </Button>
     </div>

--- a/apps/main/src/app/_components/playgrounds/requestclose/dialog-requestclose-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/requestclose/dialog-requestclose-demo.tsx
@@ -8,39 +8,41 @@ export const DialogRequestCloseDemo: FC = () => {
   const [state, setState] = useState('');
   const [logs, setLogs] = useState<string[]>([]);
 
+  const stateRef = useRef(state);
+  stateRef.current = state;
+
   useEffect(() => {
     const dialog = ref.current;
     if (!dialog) return undefined;
 
     const handleClose = () => {
-      setLogs((previousLogs) => [
-        'ダイアログが閉じられました',
-        ...previousLogs,
-      ]);
+      setLogs((prev) => ['ダイアログが閉じられました', ...prev]);
       setState('');
     };
     const handleCancel = (e: Event) => {
-      setLogs((previousLogs) => [
-        'ダイアログがキャンセルされました',
-        ...previousLogs,
-      ]);
-      if (state !== '') {
+      setLogs((prev) => ['ダイアログがキャンセルされました', ...prev]);
+      if (stateRef.current !== '') {
         e.preventDefault();
       }
     };
 
     dialog.addEventListener('close', handleClose);
     dialog.addEventListener('cancel', handleCancel);
-
     return () => {
       dialog.removeEventListener('close', handleClose);
       dialog.removeEventListener('cancel', handleCancel);
     };
-  }, [state]);
+  }, []);
 
   return (
     <div className="flex flex-col gap-4 p-4">
-      <Button onClick={() => ref.current?.showModal()}>ダイアログを開く</Button>
+      <Button
+        onClick={() => {
+          ref.current?.showModal();
+        }}
+      >
+        ダイアログを開く
+      </Button>
       {logs.length > 0 && (
         <div className="border-border-base max-h-40 overflow-y-scroll border">
           <ul className="list-disc p-2 pl-6">

--- a/apps/main/src/app/_components/playgrounds/scrollbar-color/scrollbar-color-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/scrollbar-color/scrollbar-color-demo.tsx
@@ -3,10 +3,6 @@
 import { range } from '@repo/helpers/array/range';
 import { useEffect, useRef, useState } from 'react';
 
-/**
- * scrollbar-colorプロパティのデモ
- * スクロールバーの色をカスタマイズできることを確認できる
- */
 export function ScrollbarColorDemo() {
   const [thumbColor, setThumbColor] = useState('#6366f1');
   const [trackColor, setTrackColor] = useState('#e2e8f0');
@@ -14,9 +10,7 @@ export function ScrollbarColorDemo() {
 
   useEffect(() => {
     const element = scrollRef.current;
-    if (!element) return;
-
-    element.tabIndex = 0;
+    if (element) element.tabIndex = 0;
   }, []);
 
   return (

--- a/apps/main/src/app/_components/playgrounds/scrollbar-color/scrollbar-color-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/scrollbar-color/scrollbar-color-demo.tsx
@@ -1,17 +1,11 @@
 'use client';
 
 import { range } from '@repo/helpers/array/range';
-import { useEffect, useRef, useState } from 'react';
+import { useState } from 'react';
 
 export function ScrollbarColorDemo() {
   const [thumbColor, setThumbColor] = useState('#6366f1');
   const [trackColor, setTrackColor] = useState('#e2e8f0');
-  const scrollRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    const element = scrollRef.current;
-    if (element) element.tabIndex = 0;
-  }, []);
 
   return (
     <div className="space-y-4">
@@ -50,10 +44,10 @@ export function ScrollbarColorDemo() {
 
       <div
         className="border-border-base bg-bg-mute h-48 overflow-y-scroll rounded-lg border p-4"
-        ref={scrollRef}
         style={{
           scrollbarColor: `${thumbColor} ${trackColor}`,
         }}
+        tabIndex={0}
       >
         <div className="space-y-4">
           {range(0, 20).map((n) => (

--- a/apps/main/src/app/_components/playgrounds/scrollend/scrollend-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/scrollend/scrollend-demo.tsx
@@ -1,12 +1,8 @@
 'use client';
 
 import { range } from '@repo/helpers/array/range';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-/**
- * scrollendイベントのデモ
- * スクロール可能なコンテナでscrollendイベントの発火を確認できる
- */
 export function ScrollendDemo() {
   const [scrollCount, setScrollCount] = useState(0);
   const [scrollendCount, setScrollendCount] = useState(0);
@@ -15,34 +11,20 @@ export function ScrollendDemo() {
   );
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  const handleScroll = useCallback(() => {
-    setScrollCount((prev) => prev + 1);
-  }, []);
-
-  const handleScrollend = useCallback(() => {
-    setScrollendCount((prev) => prev + 1);
-    setLastScrollendTime(new Date().toLocaleTimeString('ja-JP'));
-  }, []);
-
-  const resetCounts = useCallback(() => {
-    setScrollCount(0);
-    setScrollendCount(0);
-    setLastScrollendTime(null);
-  }, []);
-
   useEffect(() => {
     const element = scrollRef.current;
     if (!element) return undefined;
 
     element.tabIndex = 0;
-    element.addEventListener('scroll', handleScroll, { passive: true });
+    const handleScrollend = () => {
+      setScrollendCount((prev) => prev + 1);
+      setLastScrollendTime(new Date().toLocaleTimeString('ja-JP'));
+    };
     element.addEventListener('scrollend', handleScrollend);
-
     return () => {
-      element.removeEventListener('scroll', handleScroll);
       element.removeEventListener('scrollend', handleScrollend);
     };
-  }, [handleScroll, handleScrollend]);
+  }, []);
 
   return (
     <div className="space-y-4">
@@ -63,7 +45,11 @@ export function ScrollendDemo() {
         )}
         <button
           className="bg-bg-mute hover:bg-bg-subtle ml-auto rounded-md px-3 py-1 text-sm"
-          onClick={resetCounts}
+          onClick={() => {
+            setScrollCount(0);
+            setScrollendCount(0);
+            setLastScrollendTime(null);
+          }}
           type="button"
         >
           リセット
@@ -72,6 +58,9 @@ export function ScrollendDemo() {
 
       <div
         className="bg-bg-mute h-48 overflow-y-scroll rounded-xl p-4"
+        onScroll={() => {
+          setScrollCount((prev) => prev + 1);
+        }}
         ref={scrollRef}
       >
         <div className="space-y-4">

--- a/apps/main/src/app/_components/playgrounds/scrollend/scrollend-trigger-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/scrollend/scrollend-trigger-demo.tsx
@@ -2,95 +2,81 @@
 
 import { Button } from '@k8o/arte-odyssey';
 import { range } from '@repo/helpers/array/range';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-export function ScrollendTriggerDemo() {
-  const [scrollendCount, setScrollendCount] = useState(0);
+const FLASH_DURATION_MS = 300;
+
+const useScrollendCounter = () => {
+  const [count, setCount] = useState(0);
   const [lastTrigger, setLastTrigger] = useState<string | null>(null);
   const [showFlash, setShowFlash] = useState(false);
-  const scrollToRef = useRef<HTMLDivElement>(null);
-  const snapRef = useRef<HTMLDivElement>(null);
   const flashTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleScrollendScrollTo = useCallback(() => {
-    setScrollendCount((prev) => prev + 1);
-    setLastTrigger('scrollTo()');
-    setShowFlash(true);
-    if (flashTimeoutRef.current) {
-      clearTimeout(flashTimeoutRef.current);
-    }
-    flashTimeoutRef.current = setTimeout(() => {
-      setShowFlash(false);
-    }, 300);
-  }, []);
-
-  const handleScrollendSnap = useCallback(() => {
-    setScrollendCount((prev) => prev + 1);
-    setLastTrigger('scroll-snap');
-    setShowFlash(true);
-    if (flashTimeoutRef.current) {
-      clearTimeout(flashTimeoutRef.current);
-    }
-    flashTimeoutRef.current = setTimeout(() => {
-      setShowFlash(false);
-    }, 300);
-  }, []);
 
   useEffect(
     () => () => {
-      if (flashTimeoutRef.current) {
-        clearTimeout(flashTimeoutRef.current);
-      }
+      if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
     },
     [],
   );
 
-  useEffect(() => {
-    const element = scrollToRef.current;
-    if (!element) return undefined;
+  const trigger = (label: string) => {
+    setCount((prev) => prev + 1);
+    setLastTrigger(label);
+    setShowFlash(true);
+    if (flashTimeoutRef.current) clearTimeout(flashTimeoutRef.current);
+    flashTimeoutRef.current = setTimeout(() => {
+      setShowFlash(false);
+    }, FLASH_DURATION_MS);
+  };
 
-    element.tabIndex = 0;
-    element.addEventListener('scrollend', handleScrollendScrollTo);
-
-    return () => {
-      element.removeEventListener('scrollend', handleScrollendScrollTo);
-    };
-  }, [handleScrollendScrollTo]);
-
-  useEffect(() => {
-    const element = snapRef.current;
-    if (!element) return undefined;
-
-    element.tabIndex = 0;
-    element.addEventListener('scrollend', handleScrollendSnap);
-
-    return () => {
-      element.removeEventListener('scrollend', handleScrollendSnap);
-    };
-  }, [handleScrollendSnap]);
-
-  const scrollToTop = useCallback(() => {
-    scrollToRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
-  }, []);
-
-  const scrollToBottom = useCallback(() => {
-    scrollToRef.current?.scrollTo({
-      top: scrollToRef.current.scrollHeight,
-      behavior: 'smooth',
-    });
-  }, []);
-
-  const resetCounts = useCallback(() => {
-    setScrollendCount(0);
+  const reset = () => {
+    setCount(0);
     setLastTrigger(null);
-  }, []);
+  };
+
+  return { count, lastTrigger, showFlash, trigger, reset };
+};
+
+const useScrollendListener = (
+  ref: React.RefObject<HTMLElement | null>,
+  onScrollend: () => void,
+) => {
+  const handlerRef = useRef(onScrollend);
+  handlerRef.current = onScrollend;
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return undefined;
+    element.tabIndex = 0;
+    const handler = () => {
+      handlerRef.current();
+    };
+    element.addEventListener('scrollend', handler);
+    return () => {
+      element.removeEventListener('scrollend', handler);
+    };
+  }, [ref]);
+};
+
+export function ScrollendTriggerDemo() {
+  const { count, lastTrigger, showFlash, trigger, reset } =
+    useScrollendCounter();
+  const scrollToRef = useRef<HTMLDivElement>(null);
+  const snapRef = useRef<HTMLDivElement>(null);
+
+  useScrollendListener(scrollToRef, () => {
+    trigger('scrollTo()');
+  });
+  useScrollendListener(snapRef, () => {
+    trigger('scroll-snap');
+  });
 
   return (
     <div className="space-y-4 overflow-hidden">
       <div className="flex flex-wrap items-center gap-3">
         <div className="bg-bg-mute relative flex items-center gap-2 rounded-md px-3 py-1.5">
           <span className="text-fg-mute text-sm">scrollend:</span>
-          <span className="text-primary-fg font-bold">{scrollendCount}</span>
+          <span className="text-primary-fg font-bold">{count}</span>
           <span className="text-fg-mute text-sm">回</span>
           {showFlash ? (
             <div className="bg-primary-bg absolute inset-0 rounded-md opacity-30" />
@@ -101,7 +87,7 @@ export function ScrollendTriggerDemo() {
             {lastTrigger}
           </div>
         )}
-        <Button color="gray" onClick={resetCounts} size="sm" variant="outlined">
+        <Button color="gray" onClick={reset} size="sm" variant="outlined">
           リセット
         </Button>
       </div>
@@ -111,10 +97,25 @@ export function ScrollendTriggerDemo() {
           <div className="flex items-center justify-between">
             <h4 className="text-sm font-bold">scrollTo() API</h4>
             <div className="flex gap-1">
-              <Button color="primary" onClick={scrollToTop} size="sm">
+              <Button
+                color="primary"
+                onClick={() => {
+                  scrollToRef.current?.scrollTo({ top: 0, behavior: 'smooth' });
+                }}
+                size="sm"
+              >
                 先頭へ
               </Button>
-              <Button color="primary" onClick={scrollToBottom} size="sm">
+              <Button
+                color="primary"
+                onClick={() => {
+                  scrollToRef.current?.scrollTo({
+                    top: scrollToRef.current.scrollHeight,
+                    behavior: 'smooth',
+                  });
+                }}
+                size="sm"
+              >
                 末尾へ
               </Button>
             </div>

--- a/apps/main/src/app/_components/playgrounds/view-transitions/view-transition-basic-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/view-transitions/view-transition-basic-demo.tsx
@@ -46,41 +46,31 @@ export function ViewTransitionBasicDemo() {
     }
   };
 
-  // アイテムをシャッフル
   const shuffleItems = () => {
-    const updateDOM = () => {
+    withViewTransition(() => {
       setItems((prev) => [...prev].toSorted(() => Math.random() - 0.5));
-    };
-
-    withViewTransition(updateDOM);
+    });
   };
 
-  // アイテムを追加
   const addItem = () => {
-    const updateDOM = () => {
+    withViewTransition(() => {
       const newId = count + 1;
-      const randomColor = getRandomColor();
       setItems((prev) => [
         ...prev,
         {
           id: newId,
           text: `アイテム ${newId}`,
-          color: randomColor,
+          color: getRandomColor(),
         },
       ]);
       setCount(newId);
-    };
-
-    withViewTransition(updateDOM);
+    });
   };
 
-  // アイテムを削除
   const removeItem = (id: number) => {
-    const updateDOM = () => {
+    withViewTransition(() => {
       setItems((prev) => prev.filter((item) => item.id !== id));
-    };
-
-    withViewTransition(updateDOM);
+    });
   };
 
   return (

--- a/apps/main/src/app/base-converter/_components/base-converter/base-converter.tsx
+++ b/apps/main/src/app/base-converter/_components/base-converter/base-converter.tsx
@@ -9,115 +9,63 @@ import {
   useClipboard,
   useToast,
 } from '@k8o/arte-odyssey';
-import { useCallback, useState } from 'react';
+import { useState } from 'react';
 
 type Base = 2 | 8 | 10 | 16;
 
-const convertNumber = (
-  number: string,
-  baseFrom: Base,
-  baseTo: Base,
-): string => {
-  if (baseFrom === baseTo) return number;
+const BASES = [
+  { base: 2, label: '2進数' },
+  { base: 8, label: '8進数' },
+  { base: 10, label: '10進数' },
+  { base: 16, label: '16進数' },
+] as const satisfies Array<{ base: Base; label: string }>;
 
-  return Number.parseInt(number, baseFrom).toString(baseTo);
+const VALIDATORS: Record<Base, RegExp> = {
+  2: /^[01]+$/,
+  8: /^[0-7]+$/,
+  10: /^\d+$/,
+  16: /^[0-9a-fA-F]+$/,
 };
 
-const BASES = [
-  {
-    base: 2 as const,
-    label: '2進数',
-  },
-  {
-    base: 8 as const,
-    label: '8進数',
-  },
-  {
-    base: 10 as const,
-    label: '10進数',
-  },
-  {
-    base: 16 as const,
-    label: '16進数',
-  },
-] as const;
+const ERROR_MESSAGES: Record<Base, string> = {
+  2: '2進数は0または1で入力してください',
+  8: '8進数は0から7で入力してください',
+  10: '10進数は0から9で入力してください',
+  16: '16進数は0から9またはaからfで入力してください',
+};
+
+const EMPTY_VALUES: Record<Base, string> = { 2: '', 8: '', 10: '', 16: '' };
+
+const convertFrom = (value: string, base: Base): Record<Base, string> => ({
+  2: base === 2 ? value : Number.parseInt(value, base).toString(2),
+  8: base === 8 ? value : Number.parseInt(value, base).toString(8),
+  10: base === 10 ? value : Number.parseInt(value, base).toString(10),
+  16: base === 16 ? value : Number.parseInt(value, base).toString(16),
+});
 
 export const BaseConverter = () => {
+  const [values, setValues] = useState<Record<Base, string>>(EMPTY_VALUES);
   const [invalid, setInvalid] = useState<{
     target: Base;
     message: string;
   } | null>(null);
-  const [binary, setBinary] = useState('');
-  const [octal, setOctal] = useState('');
-  const [decimal, setDecimal] = useState('');
-  const [hexadecimal, setHexadecimal] = useState('');
   const { writeClipboard } = useClipboard();
   const { onOpen } = useToast();
 
-  const handleChange = useCallback((value: string, base: Base) => {
-    setInvalid(null);
+  const handleChange = (value: string, base: Base) => {
     if (value === '') {
-      setBinary('');
-      setOctal('');
-      setDecimal('');
-      setHexadecimal('');
+      setValues(EMPTY_VALUES);
+      setInvalid(null);
       return;
     }
-    switch (base) {
-      case 2:
-        setBinary(value);
-        if (!/^[01]+$/.test(value)) {
-          setInvalid({
-            target: 2,
-            message: '2進数は0または1で入力してください',
-          });
-          break;
-        }
-        setOctal(convertNumber(value, 2, 8));
-        setDecimal(convertNumber(value, 2, 10));
-        setHexadecimal(convertNumber(value, 2, 16));
-        break;
-      case 8:
-        setOctal(value);
-        if (!/^[0-7]+$/.test(value)) {
-          setInvalid({
-            target: 8,
-            message: '8進数は0から7で入力してください',
-          });
-          break;
-        }
-        setBinary(convertNumber(value, 8, 2));
-        setDecimal(convertNumber(value, 8, 10));
-        setHexadecimal(convertNumber(value, 8, 16));
-        break;
-      case 10:
-        setDecimal(value);
-        if (!/^\d+$/.test(value)) {
-          setInvalid({
-            target: 10,
-            message: '10進数は0から9で入力してください',
-          });
-          break;
-        }
-        setBinary(convertNumber(value, 10, 2));
-        setOctal(convertNumber(value, 10, 8));
-        setHexadecimal(convertNumber(value, 10, 16));
-        break;
-      case 16:
-        setHexadecimal(value);
-        if (!/^[0-9a-fA-F]+$/.test(value)) {
-          setInvalid({
-            target: 16,
-            message: '16進数は0から9またはaからfで入力してください',
-          });
-          break;
-        }
-        setBinary(convertNumber(value, 16, 2));
-        setOctal(convertNumber(value, 16, 8));
-        setDecimal(convertNumber(value, 16, 10));
-        break;
+    if (!VALIDATORS[base].test(value)) {
+      setValues((prev) => ({ ...prev, [base]: value }));
+      setInvalid({ target: base, message: ERROR_MESSAGES[base] });
+      return;
     }
-  }, []);
+    setValues(convertFrom(value, base));
+    setInvalid(null);
+  };
 
   const handleCopy = (value: string, label: string) => {
     if (!value) return;
@@ -125,13 +73,6 @@ export const BaseConverter = () => {
       onOpen('success', `${label}をコピーしました`);
       return undefined;
     });
-  };
-
-  const values: Record<Base, string> = {
-    2: binary,
-    8: octal,
-    10: decimal,
-    16: hexadecimal,
   };
 
   return (

--- a/apps/main/src/app/blog/_components/blog-layout/table-of-contents/table-of-contents.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/table-of-contents/table-of-contents.tsx
@@ -3,7 +3,7 @@
 import { useClickAway } from '@k8o/arte-odyssey';
 import { cn } from '@repo/helpers/cn';
 import Link from 'next/link';
-import { type FC, useCallback, useEffect, useRef, useState } from 'react';
+import { type FC, useEffect, useRef, useState } from 'react';
 
 import type { HeadingTree } from '@/shared/mdx/types';
 
@@ -32,10 +32,44 @@ const LinkButton: FC<{
   </Link>
 );
 
+type TocNode = {
+  text: string;
+  children?: readonly TocNode[];
+};
+
+const TocItem: FC<{
+  node: TocNode;
+  depth: number;
+  activeId: string;
+  onNavigate: (id: string) => void;
+}> = ({ node, depth, activeId, onNavigate }) => (
+  <li>
+    <LinkButton
+      depth={depth}
+      isActive={activeId === node.text}
+      onNavigate={onNavigate}
+      text={node.text}
+    />
+    {node.children && node.children.length > 0 && (
+      <ul>
+        {node.children.map((child) => (
+          <TocItem
+            activeId={activeId}
+            depth={depth + 1}
+            key={child.text}
+            node={child}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </ul>
+    )}
+  </li>
+);
+
 export const TableOfContents: FC<{
   headingTree: HeadingTree;
 }> = ({ headingTree }) => {
-  const [activeId, setActiveId] = useState<string>('');
+  const [activeId, setActiveId] = useState('');
 
   const ref = useRef<HTMLDetailsElement>(null);
   useClickAway(ref, () => {
@@ -44,53 +78,39 @@ export const TableOfContents: FC<{
     }
   });
 
-  // リンククリック時のナビゲーション処理
-  const handleNavigate = useCallback((id: string) => {
-    setActiveId(id);
-  }, []);
-
-  // IntersectionObserverで見出しを監視
   useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
-        // 交差している要素のうち、最も上にあるものを選択
-        const intersectingEntries = entries.filter(
-          (entry) => entry.isIntersecting,
+        const intersecting = entries.filter((entry) => entry.isIntersecting);
+        if (intersecting.length === 0) return;
+        const topEntry = intersecting.reduce((prev, current) =>
+          prev.boundingClientRect.top < current.boundingClientRect.top
+            ? prev
+            : current,
         );
-
-        if (intersectingEntries.length > 0) {
-          // boundingClientRectのtopが最も小さい（画面上部に近い）要素を選択
-          const topEntry = intersectingEntries.reduce((prev, current) =>
-            prev.boundingClientRect.top < current.boundingClientRect.top
-              ? prev
-              : current,
-          );
-          setActiveId(topEntry.target.id);
-        }
+        setActiveId(topEntry.target.id);
       },
-      {
-        rootMargin: '-80px 0px -80% 0px',
-      },
+      { rootMargin: '-80px 0px -80% 0px' },
     );
 
-    // すべての見出し要素を監視
     const headings = document.querySelectorAll('h2[id], h3[id], h4[id]');
-    for (const heading of headings) {
-      observer.observe(heading);
-    }
+    for (const heading of headings) observer.observe(heading);
     const eocElement = document.querySelector(`#${END_OF_CONTENT_ID}`);
-    if (eocElement) {
-      observer.observe(eocElement);
-    }
+    if (eocElement) observer.observe(eocElement);
 
     return () => {
       observer.disconnect();
     };
   }, []);
 
-  if (headingTree.children.length === 0) {
-    return null;
-  }
+  if (headingTree.children.length === 0) return null;
+
+  const summaryText =
+    activeId === ''
+      ? 'もくじ'
+      : activeId === END_OF_CONTENT_ID
+        ? 'さいごまで よみました'
+        : activeId;
 
   return (
     <details
@@ -103,77 +123,18 @@ export const TableOfContents: FC<{
     >
       <summary className="text-md text-primary-fg flex items-center gap-2 p-4 font-bold sm:text-lg">
         <ProgressBar activeId={activeId} headingTree={headingTree} />
-        <span className="truncate">
-          {activeId === ''
-            ? 'もくじ'
-            : activeId === END_OF_CONTENT_ID
-              ? 'さいごまで よみました'
-              : activeId}
-        </span>
+        <span className="truncate">{summaryText}</span>
       </summary>
       <ul className="text-fg-base flex max-h-[75vh] flex-col overflow-y-scroll p-2">
-        {headingTree.children.map((depth1) => {
-          if (depth1.children.length === 0) {
-            return (
-              <li key={depth1.text}>
-                <LinkButton
-                  depth={1}
-                  isActive={activeId === depth1.text}
-                  onNavigate={handleNavigate}
-                  text={depth1.text}
-                />
-              </li>
-            );
-          }
-          return (
-            <li key={depth1.text}>
-              <LinkButton
-                depth={1}
-                isActive={activeId === depth1.text}
-                onNavigate={handleNavigate}
-                text={depth1.text}
-              />
-              <ul>
-                {depth1.children.map((depth2) => {
-                  if (depth2.children.length === 0) {
-                    return (
-                      <li key={depth2.text}>
-                        <LinkButton
-                          depth={2}
-                          isActive={activeId === depth2.text}
-                          onNavigate={handleNavigate}
-                          text={depth2.text}
-                        />
-                      </li>
-                    );
-                  }
-                  return (
-                    <li key={depth2.text}>
-                      <LinkButton
-                        depth={2}
-                        isActive={activeId === depth2.text}
-                        onNavigate={handleNavigate}
-                        text={depth2.text}
-                      />
-                      <ul>
-                        {depth2.children.map((depth3) => (
-                          <li key={depth3.text}>
-                            <LinkButton
-                              depth={3}
-                              isActive={activeId === depth3.text}
-                              onNavigate={handleNavigate}
-                              text={depth3.text}
-                            />
-                          </li>
-                        ))}
-                      </ul>
-                    </li>
-                  );
-                })}
-              </ul>
-            </li>
-          );
-        })}
+        {headingTree.children.map((node) => (
+          <TocItem
+            activeId={activeId}
+            depth={1}
+            key={node.text}
+            node={node}
+            onNavigate={setActiveId}
+          />
+        ))}
       </ul>
     </details>
   );

--- a/apps/main/src/app/blog/_components/scroll-to-top-on-path-change/scroll-to-top-on-path-change.tsx
+++ b/apps/main/src/app/blog/_components/scroll-to-top-on-path-change/scroll-to-top-on-path-change.tsx
@@ -19,18 +19,14 @@ export const ScrollToTopOnPathChange = () => {
   }, []);
 
   useEffect(() => {
-    if (prevPathname.current === null) {
-      prevPathname.current = pathname;
-      return;
-    }
-    if (prevPathname.current === pathname) return;
+    const prev = prevPathname.current;
     prevPathname.current = pathname;
 
-    if (isPopState.current) {
-      isPopState.current = false;
-      return;
-    }
+    if (prev === null || prev === pathname) return;
 
+    const popState = isPopState.current;
+    isPopState.current = false;
+    if (popState) return;
     if (window.location.hash) return;
 
     window.scrollTo(0, 0);

--- a/apps/main/src/app/radius-maker/_components/control-panel/control-panel.tsx
+++ b/apps/main/src/app/radius-maker/_components/control-panel/control-panel.tsx
@@ -9,30 +9,91 @@ import {
   useToast,
 } from '@k8o/arte-odyssey';
 import { cn } from '@repo/helpers/cn';
-import type { FC, KeyboardEvent, MouseEvent, TouchEvent } from 'react';
+import type {
+  CSSProperties,
+  FC,
+  KeyboardEvent,
+  MouseEvent,
+  TouchEvent,
+} from 'react';
 import { useMemo } from 'react';
 
+import type { RadiusPosition } from '../../_types/radius-position';
 import { TemplateSelector } from '../template-selector';
 import { useControlPanel } from './use-control-panel';
 
-// ベースサイズ（px）
 const BASE_SIZE = 192;
 
-// ビューポート幅640px〜1280pxでモバイル値→2倍に連続スケーリング
 const fluidPx = (mobile: number): string => {
   const desktop = mobile * 2;
   return `clamp(${mobile}px, ${((mobile * 100) / 640).toFixed(2)}vw, ${desktop}px)`;
 };
 
+type ControlKey = keyof RadiusPosition;
+type ColorVariable = 'primary' | 'secondary' | 'quaternary' | 'tertiary';
+
+type ControlConfig = {
+  key: ControlKey;
+  label: string;
+  variable: ColorVariable;
+  toStyle: (value: number) => CSSProperties;
+};
+
+const CONTROLS: ControlConfig[] = [
+  {
+    key: 'topLeftX',
+    label: '左上の上側の丸みを調整する(左右キーで操作します)',
+    variable: 'primary',
+    toStyle: (v) => ({ top: '-12px', left: `calc(${v}% - 12px)` }),
+  },
+  {
+    key: 'topRightX',
+    label: '右上の上側の丸みを調整する(左右キーで操作します)',
+    variable: 'secondary',
+    toStyle: (v) => ({ top: '-12px', right: `calc(${v}% - 12px)` }),
+  },
+  {
+    key: 'topLeftY',
+    label: '左上の左側の丸みを調整する(上下キーで操作します)',
+    variable: 'primary',
+    toStyle: (v) => ({ top: `calc(${v}% - 12px)`, left: '-12px' }),
+  },
+  {
+    key: 'topRightY',
+    label: '右上の右側の丸みを調整する(上下キーで操作します)',
+    variable: 'secondary',
+    toStyle: (v) => ({ top: `calc(${v}% - 12px)`, right: '-12px' }),
+  },
+  {
+    key: 'bottomLeftY',
+    label: '左下の左側の丸みを調整する(上下キーで操作します)',
+    variable: 'quaternary',
+    toStyle: (v) => ({ bottom: `calc(${v}% - 12px)`, left: '-12px' }),
+  },
+  {
+    key: 'bottomRightY',
+    label: '右下の右側の丸みを調整する(上下キーで操作します)',
+    variable: 'tertiary',
+    toStyle: (v) => ({ bottom: `calc(${v}% - 12px)`, right: '-12px' }),
+  },
+  {
+    key: 'bottomLeftX',
+    label: '左下の下側の丸みを調整する(左右キーで操作します)',
+    variable: 'quaternary',
+    toStyle: (v) => ({ bottom: '-12px', left: `calc(${v}% - 12px)` }),
+  },
+  {
+    key: 'bottomRightX',
+    label: '右下の下側の丸みを調整する(左右キーで操作します)',
+    variable: 'tertiary',
+    toStyle: (v) => ({ bottom: '-12px', right: `calc(${v}% - 12px)` }),
+  },
+];
+
 const OperateButton: FC<{
   label: string;
-  position: {
-    top?: string;
-    right?: string;
-    bottom?: string;
-    left?: string;
-  };
-  variable: 'primary' | 'secondary' | 'quaternary' | 'tertiary';
+  position: CSSProperties;
+  variable: ColorVariable;
   onMouseDown: (e: MouseEvent) => void;
   onTouchStart: (e: TouchEvent) => void;
   onKeyDown: (e: KeyboardEvent) => void;
@@ -83,7 +144,6 @@ export const ControlPanel: FC = () => {
   const { writeClipboard } = useClipboard();
   const { onOpen } = useToast();
 
-  // アスペクト比に応じたサイズを計算
   const containerSize = useMemo(() => {
     if (aspectRatio >= 1) {
       return { width: BASE_SIZE, height: BASE_SIZE / aspectRatio };
@@ -102,9 +162,7 @@ export const ControlPanel: FC = () => {
 
   return (
     <div className="flex flex-col gap-8">
-      {/* メインエリア: デスクトップ2カラム */}
       <div className="flex flex-col gap-8 sm:grid sm:grid-cols-[1fr_16rem] sm:items-start sm:gap-6">
-        {/* テンプレート（モバイルでは先に表示） */}
         <div className="order-1 sm:order-2">
           <TemplateSelector currentPosition={position} onSelect={setPosition} />
           <div className="mt-6">
@@ -124,7 +182,6 @@ export const ControlPanel: FC = () => {
           </div>
         </div>
 
-        {/* シェイプエディタ */}
         <div className="order-2 flex items-center justify-center sm:sticky sm:top-6 sm:order-1">
           <div
             className="flex items-center justify-center"
@@ -143,160 +200,31 @@ export const ControlPanel: FC = () => {
             >
               <div
                 className="bg-primary-fg absolute size-full"
-                style={{
-                  borderRadius,
-                }}
+                style={{ borderRadius }}
               />
-              <OperateButton
-                isActive={activePosition === 'topLeftX'}
-                label="左上の上側の丸みを調整する(左右キーで操作します)"
-                onKeyDown={(e) => {
-                  keyDownHandler(e, 'topLeftX');
-                }}
-                onMouseDown={(e) => {
-                  mouseDownHandler(e, 'topLeftX');
-                }}
-                onTouchStart={(e) => {
-                  touchStartHandler(e, 'topLeftX');
-                }}
-                position={{
-                  top: '-12px',
-                  left: `calc(${position.topLeftX.toString()}% - 12px)`,
-                }}
-                variable="primary"
-              />
-              <OperateButton
-                isActive={activePosition === 'topRightX'}
-                label="右上の上側の丸みを調整する(左右キーで操作します)"
-                onKeyDown={(e) => {
-                  keyDownHandler(e, 'topRightX');
-                }}
-                onMouseDown={(e) => {
-                  mouseDownHandler(e, 'topRightX');
-                }}
-                onTouchStart={(e) => {
-                  touchStartHandler(e, 'topRightX');
-                }}
-                position={{
-                  top: '-12px',
-                  right: `calc(${position.topRightX.toString()}% - 12px)`,
-                }}
-                variable="secondary"
-              />
-              <OperateButton
-                isActive={activePosition === 'topLeftY'}
-                label="左上の左側の丸みを調整する(上下キーで操作します)"
-                onKeyDown={(e) => {
-                  keyDownHandler(e, 'topLeftY');
-                }}
-                onMouseDown={(e) => {
-                  mouseDownHandler(e, 'topLeftY');
-                }}
-                onTouchStart={(e) => {
-                  touchStartHandler(e, 'topLeftY');
-                }}
-                position={{
-                  top: `calc(${position.topLeftY.toString()}% - 12px)`,
-                  left: '-12px',
-                }}
-                variable="primary"
-              />
-              <OperateButton
-                isActive={activePosition === 'topRightY'}
-                label="右上の右側の丸みを調整する(上下キーで操作します)"
-                onKeyDown={(e) => {
-                  keyDownHandler(e, 'topRightY');
-                }}
-                onMouseDown={(e) => {
-                  mouseDownHandler(e, 'topRightY');
-                }}
-                onTouchStart={(e) => {
-                  touchStartHandler(e, 'topRightY');
-                }}
-                position={{
-                  top: `calc(${position.topRightY.toString()}% - 12px)`,
-                  right: '-12px',
-                }}
-                variable="secondary"
-              />
-              <OperateButton
-                isActive={activePosition === 'bottomLeftY'}
-                label="左下の左側の丸みを調整する(上下キーで操作します)"
-                onKeyDown={(e) => {
-                  keyDownHandler(e, 'bottomLeftY');
-                }}
-                onMouseDown={(e) => {
-                  mouseDownHandler(e, 'bottomLeftY');
-                }}
-                onTouchStart={(e) => {
-                  touchStartHandler(e, 'bottomLeftY');
-                }}
-                position={{
-                  bottom: `calc(${position.bottomLeftY.toString()}% - 12px)`,
-                  left: '-12px',
-                }}
-                variable="quaternary"
-              />
-              <OperateButton
-                isActive={activePosition === 'bottomRightY'}
-                label="右下の右側の丸みを調整する(上下キーで操作します)"
-                onKeyDown={(e) => {
-                  keyDownHandler(e, 'bottomRightY');
-                }}
-                onMouseDown={(e) => {
-                  mouseDownHandler(e, 'bottomRightY');
-                }}
-                onTouchStart={(e) => {
-                  touchStartHandler(e, 'bottomRightY');
-                }}
-                position={{
-                  bottom: `calc(${position.bottomRightY.toString()}% - 12px)`,
-                  right: '-12px',
-                }}
-                variable="tertiary"
-              />
-              <OperateButton
-                isActive={activePosition === 'bottomLeftX'}
-                label="左下の下側の丸みを調整する(左右キーで操作します)"
-                onKeyDown={(e) => {
-                  keyDownHandler(e, 'bottomLeftX');
-                }}
-                onMouseDown={(e) => {
-                  mouseDownHandler(e, 'bottomLeftX');
-                }}
-                onTouchStart={(e) => {
-                  touchStartHandler(e, 'bottomLeftX');
-                }}
-                position={{
-                  bottom: '-12px',
-                  left: `calc(${position.bottomLeftX.toString()}% - 12px)`,
-                }}
-                variable="quaternary"
-              />
-              <OperateButton
-                isActive={activePosition === 'bottomRightX'}
-                label="右下の下側の丸みを調整する(左右キーで操作します)"
-                onKeyDown={(e) => {
-                  keyDownHandler(e, 'bottomRightX');
-                }}
-                onMouseDown={(e) => {
-                  mouseDownHandler(e, 'bottomRightX');
-                }}
-                onTouchStart={(e) => {
-                  touchStartHandler(e, 'bottomRightX');
-                }}
-                position={{
-                  bottom: '-12px',
-                  right: `calc(${position.bottomRightX.toString()}% - 12px)`,
-                }}
-                variable="tertiary"
-              />
+              {CONTROLS.map(({ key, label, variable, toStyle }) => (
+                <OperateButton
+                  isActive={activePosition === key}
+                  key={key}
+                  label={label}
+                  onKeyDown={(e) => {
+                    keyDownHandler(e, key);
+                  }}
+                  onMouseDown={(e) => {
+                    mouseDownHandler(e, key);
+                  }}
+                  onTouchStart={(e) => {
+                    touchStartHandler(e, key);
+                  }}
+                  position={toStyle(position[key])}
+                  variable={variable}
+                />
+              ))}
             </div>
           </div>
         </div>
       </div>
 
-      {/* CSS出力（全幅） */}
       <div className="border-border-base bg-bg-base relative rounded-xl border p-4">
         <div className="absolute top-3 right-3">
           <Button

--- a/apps/main/src/app/radius-maker/_components/control-panel/use-control-panel.ts
+++ b/apps/main/src/app/radius-maker/_components/control-panel/use-control-panel.ts
@@ -14,6 +14,36 @@ import { positionToBorderRadius } from '../../_utils/position-to-border-radius';
 
 type Position = keyof RadiusPosition;
 
+// その軸での「正方向」（数値が大きいほど右下に動くか）が反転している頂点を判定する。
+// top-Y と (Left & X) は素直に正方向、それ以外は 100 - value で反転する。
+const isPositiveAxis = (target: Position): boolean =>
+  (target.startsWith('top') && target.endsWith('Y')) ||
+  (target.includes('Left') && target.endsWith('X'));
+
+const computeValueFromPoint = (
+  rect: DOMRect,
+  target: Position,
+  clientX: number,
+  clientY: number,
+): number => {
+  const ratio = target.endsWith('X')
+    ? (clientX - rect.left) / rect.width
+    : (clientY - rect.top) / rect.height;
+  const raw = Math.floor(between(ratio * 100, 0, 100));
+  return isPositiveAxis(target) ? raw : 100 - raw;
+};
+
+const computeArrowDelta = (target: Position, key: string): number | null => {
+  if (target.endsWith('X')) {
+    if (key !== 'ArrowRight' && key !== 'ArrowLeft') return null;
+    const direction = key === 'ArrowRight' ? 1 : -1;
+    return target.endsWith('LeftX') ? direction : -direction;
+  }
+  if (key !== 'ArrowUp' && key !== 'ArrowDown') return null;
+  const direction = key === 'ArrowDown' ? 1 : -1;
+  return target.startsWith('top') ? direction : -direction;
+};
+
 export const useControlPanel = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [position, setPosition] = useState<RadiusPosition>({
@@ -27,7 +57,6 @@ export const useControlPanel = () => {
     bottomRightY: 36,
   });
   const [activePosition, setActivePosition] = useState<Position | null>(null);
-  // 0.5〜2.0（横幅/縦幅）
   const [aspectRatio, setAspectRatio] = useState(1);
 
   const borderRadius = useMemo(
@@ -36,171 +65,68 @@ export const useControlPanel = () => {
   );
 
   const mouseDownHandler = useCallback(
-    (
-      e: ReactMouseEvent,
-      targetPosition:
-        | 'topLeftX'
-        | 'topLeftY'
-        | 'topRightX'
-        | 'topRightY'
-        | 'bottomRightX'
-        | 'bottomRightY'
-        | 'bottomLeftX'
-        | 'bottomLeftY',
-    ) => {
+    (e: ReactMouseEvent, target: Position) => {
       e.preventDefault();
-      setActivePosition(targetPosition);
-      const mouseUpHandler = (event: MouseEvent) => {
-        setPosition((prev) => {
-          if (!containerRef.current) {
-            return prev;
-          }
-          const rect = containerRef.current.getBoundingClientRect();
-          const newValue = Math.floor(
-            between(
-              targetPosition.endsWith('X')
-                ? ((event.clientX - rect.left) / rect.width) * 100
-                : ((event.clientY - rect.top) / rect.height) * 100,
-              0,
-              100,
-            ),
-          );
-          return {
-            ...prev,
-            [targetPosition]:
-              (targetPosition.startsWith('top') &&
-                targetPosition.endsWith('Y')) ||
-              (targetPosition.includes('Left') && targetPosition.endsWith('X'))
-                ? newValue
-                : 100 - newValue,
-          };
-        });
+      setActivePosition(target);
+      const handleMove = (event: MouseEvent) => {
+        const rect = containerRef.current?.getBoundingClientRect();
+        if (!rect) return;
+        const nextValue = computeValueFromPoint(
+          rect,
+          target,
+          event.clientX,
+          event.clientY,
+        );
+        setPosition((prev) => ({ ...prev, [target]: nextValue }));
       };
-      window.addEventListener('mouseup', () => {
+      const handleUp = () => {
         setActivePosition(null);
-        window.removeEventListener('mousemove', mouseUpHandler);
-      });
-      window.addEventListener('mousemove', mouseUpHandler);
+        window.removeEventListener('mousemove', handleMove);
+        window.removeEventListener('mouseup', handleUp);
+      };
+      window.addEventListener('mousemove', handleMove);
+      window.addEventListener('mouseup', handleUp);
     },
     [],
   );
 
   const touchStartHandler = useCallback(
-    (
-      e: ReactTouchEvent,
-      targetPosition:
-        | 'topLeftX'
-        | 'topLeftY'
-        | 'topRightX'
-        | 'topRightY'
-        | 'bottomRightX'
-        | 'bottomRightY'
-        | 'bottomLeftX'
-        | 'bottomLeftY',
-    ) => {
+    (e: ReactTouchEvent, target: Position) => {
       e.preventDefault();
-      setActivePosition(targetPosition);
-      const touchMoveHandler = (event: TouchEvent) => {
+      setActivePosition(target);
+      const handleMove = (event: TouchEvent) => {
         event.preventDefault();
-        setPosition((prev) => {
-          const changedTouches = event.changedTouches[0];
-          if (!(containerRef.current && changedTouches)) {
-            return prev;
-          }
-          const rect = containerRef.current.getBoundingClientRect();
-          const newValue = Math.floor(
-            between(
-              targetPosition.endsWith('X')
-                ? ((changedTouches.clientX - rect.left) / rect.width) * 100
-                : ((changedTouches.clientY - rect.top) / rect.height) * 100,
-              0,
-              100,
-            ),
-          );
-          return {
-            ...prev,
-            [targetPosition]:
-              (targetPosition.startsWith('top') &&
-                targetPosition.endsWith('Y')) ||
-              (targetPosition.includes('Left') && targetPosition.endsWith('X'))
-                ? newValue
-                : 100 - newValue,
-          };
-        });
+        const touch = event.changedTouches[0];
+        const rect = containerRef.current?.getBoundingClientRect();
+        if (!rect || !touch) return;
+        const nextValue = computeValueFromPoint(
+          rect,
+          target,
+          touch.clientX,
+          touch.clientY,
+        );
+        setPosition((prev) => ({ ...prev, [target]: nextValue }));
       };
-      window.addEventListener('touchend', () => {
+      const handleEnd = () => {
         setActivePosition(null);
-        window.removeEventListener('touchmove', touchMoveHandler);
-      });
-      window.addEventListener('touchmove', touchMoveHandler, {
-        passive: false,
-      });
+        window.removeEventListener('touchmove', handleMove);
+        window.removeEventListener('touchend', handleEnd);
+      };
+      window.addEventListener('touchmove', handleMove, { passive: false });
+      window.addEventListener('touchend', handleEnd);
     },
     [],
   );
 
   const keyDownHandler = useCallback(
-    (
-      e: ReactKeyboardEvent,
-      targetPosition:
-        | 'topLeftX'
-        | 'topLeftY'
-        | 'topRightX'
-        | 'topRightY'
-        | 'bottomRightX'
-        | 'bottomRightY'
-        | 'bottomLeftX'
-        | 'bottomLeftY',
-    ) => {
-      if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
-        e.preventDefault();
-        if (targetPosition.endsWith('LeftX')) {
-          setPosition((prev) => ({
-            ...prev,
-            [targetPosition]: between(
-              prev[targetPosition] + (e.key === 'ArrowRight' ? 1 : -1),
-              0,
-              100,
-            ),
-          }));
-        }
-        if (targetPosition.endsWith('RightX')) {
-          setPosition((prev) => ({
-            ...prev,
-            [targetPosition]: between(
-              prev[targetPosition] + (e.key === 'ArrowLeft' ? 1 : -1),
-              0,
-              100,
-            ),
-          }));
-        }
-      }
-      if (e.key === 'ArrowUp' || e.key === 'ArrowDown') {
-        e.preventDefault();
-        if (targetPosition.startsWith('top') && targetPosition.endsWith('Y')) {
-          setPosition((prev) => ({
-            ...prev,
-            [targetPosition]: between(
-              prev[targetPosition] + (e.key === 'ArrowDown' ? 1 : -1),
-              0,
-              100,
-            ),
-          }));
-        }
-        if (
-          targetPosition.startsWith('bottom') &&
-          targetPosition.endsWith('Y')
-        ) {
-          setPosition((prev) => ({
-            ...prev,
-            [targetPosition]: between(
-              prev[targetPosition] + (e.key === 'ArrowUp' ? 1 : -1),
-              0,
-              100,
-            ),
-          }));
-        }
-      }
+    (e: ReactKeyboardEvent, target: Position) => {
+      const delta = computeArrowDelta(target, e.key);
+      if (delta === null) return;
+      e.preventDefault();
+      setPosition((prev) => ({
+        ...prev,
+        [target]: between(prev[target] + delta, 0, 100),
+      }));
     },
     [],
   );

--- a/apps/main/src/app/sql-table-builder/_components/create-restrictions/create-restrictions.tsx
+++ b/apps/main/src/app/sql-table-builder/_components/create-restrictions/create-restrictions.tsx
@@ -43,14 +43,12 @@ const RESTRICTION_CONFIG: Record<
 };
 
 const RestrictionItem: FC<{
-  id: string;
   restriction: Restriction;
   index: number;
   restrictionError: InvalidRestrictions['errors'][string] | undefined;
   columns: Record<string, Column>;
   setRestriction: (restriction: Restriction) => void;
   onDelete: () => void;
-  canDelete: boolean;
 }> = ({
   restriction,
   index,
@@ -58,14 +56,12 @@ const RestrictionItem: FC<{
   columns,
   setRestriction,
   onDelete,
-  canDelete,
 }) => {
   const [isOpen, setIsOpen] = useState(true);
   const config = RESTRICTION_CONFIG[restriction.type];
 
   return (
     <div className="border-border-base bg-bg-base overflow-hidden rounded-xl border">
-      {/* ヘッダー */}
       <div className="flex w-full items-center justify-between gap-3 px-4 py-3">
         <button
           aria-expanded={isOpen}
@@ -88,30 +84,19 @@ const RestrictionItem: FC<{
             <ChevronIcon direction="down" />
           </div>
         </button>
-        {canDelete && (
-          <IconButton
-            label="削除"
-            onClick={() => {
-              onDelete();
-            }}
-            size="sm"
-          >
-            <CloseIcon />
-          </IconButton>
-        )}
+        <IconButton label="削除" onClick={onDelete} size="sm">
+          <CloseIcon />
+        </IconButton>
       </div>
 
-      {/* コンテンツ */}
       {isOpen && (
-        <div>
-          <div className="border-border-base overflow-hidden border-t px-4 py-4">
-            <CreateRestriction
-              columns={columns}
-              restriction={restriction}
-              restrictionError={restrictionError}
-              setRestriction={setRestriction}
-            />
-          </div>
+        <div className="border-border-base overflow-hidden border-t px-4 py-4">
+          <CreateRestriction
+            columns={columns}
+            restriction={restriction}
+            restrictionError={restrictionError}
+            setRestriction={setRestriction}
+          />
         </div>
       )}
     </div>
@@ -129,10 +114,7 @@ export const CreateRestrictions: FC<Props> = ({
   const handleAddRestriction = () => {
     setRestrictions({
       ...restrictions,
-      [uuidV4()]: {
-        type: 'primary',
-        columns: [],
-      },
+      [uuidV4()]: { type: 'primary', columns: [] },
     });
   };
 
@@ -147,19 +129,16 @@ export const CreateRestrictions: FC<Props> = ({
   const handleSetRestriction = (idToUpdate: string) => (value: Restriction) => {
     setRestrictions(
       Object.fromEntries(
-        restrictionsEntries.map(([id, restriction]) => {
-          if (id === idToUpdate) {
-            return [id, value];
-          }
-          return [id, restriction];
-        }),
+        restrictionsEntries.map(([id, restriction]) => [
+          id,
+          id === idToUpdate ? value : restriction,
+        ]),
       ),
     );
   };
 
   return (
     <div className="flex flex-col gap-4">
-      {/* ツールバー */}
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
           <Button
@@ -176,29 +155,22 @@ export const CreateRestrictions: FC<Props> = ({
         </div>
       </div>
 
-      {/* 制約リスト */}
       <div className="flex flex-col gap-3">
-        {restrictionsEntries.map(([id, restriction], idx) => {
-          const restrictionError = restrictionsError?.[id];
-          return (
-            <RestrictionItem
-              canDelete
-              columns={columns}
-              id={id}
-              index={idx}
-              key={id}
-              onDelete={() => {
-                handleDeleteRestriction(id);
-              }}
-              restriction={restriction}
-              restrictionError={restrictionError}
-              setRestriction={handleSetRestriction(id)}
-            />
-          );
-        })}
+        {restrictionsEntries.map(([id, restriction], idx) => (
+          <RestrictionItem
+            columns={columns}
+            index={idx}
+            key={id}
+            onDelete={() => {
+              handleDeleteRestriction(id);
+            }}
+            restriction={restriction}
+            restrictionError={restrictionsError?.[id]}
+            setRestriction={handleSetRestriction(id)}
+          />
+        ))}
       </div>
 
-      {/* 制約がない場合のプレースホルダー */}
       {restrictionsEntries.length === 0 && (
         <div className="bg-bg-mute flex flex-col items-center justify-center gap-2 rounded-xl py-8">
           <p className="text-fg-mute text-sm">制約がありません</p>

--- a/apps/main/src/features/baseline/interface/queries.ts
+++ b/apps/main/src/features/baseline/interface/queries.ts
@@ -7,7 +7,7 @@ export async function getBaselineFeatures() {
   'use cache';
   cacheLife('minutes');
 
-  const features = await Promise.resolve(_getBaselineFeatures());
+  const features = await _getBaselineFeatures();
   return features;
 }
 
@@ -15,7 +15,7 @@ export async function getFeatureBlogMap() {
   'use cache';
   cacheLife('max');
 
-  const featureBlogMap = await Promise.resolve(_getFeatureBlogMap());
+  const featureBlogMap = await _getFeatureBlogMap();
   return featureBlogMap;
 }
 

--- a/apps/main/src/features/blog/interface/queries.ts
+++ b/apps/main/src/features/blog/interface/queries.ts
@@ -55,7 +55,7 @@ export async function getBlogToc(slug: string) {
   'use cache';
   cacheLife('max');
 
-  const toc = await Promise.resolve(_getBlogToc(slug));
+  const toc = await _getBlogToc(slug);
   return toc;
 }
 
@@ -74,6 +74,6 @@ export async function getBlogView(id: number) {
   'use cache';
   cacheLife('minutes');
 
-  const view = await Promise.resolve(_getBlogView(id));
+  const view = await _getBlogView(id);
   return view;
 }

--- a/apps/main/src/features/reading-list/interface/queries.ts
+++ b/apps/main/src/features/reading-list/interface/queries.ts
@@ -9,7 +9,7 @@ export async function getArticles() {
   'use cache';
   cacheLife('hours');
 
-  const articles = await Promise.resolve(_getArticles());
+  const articles = await _getArticles();
   return articles;
 }
 
@@ -17,6 +17,6 @@ export async function getArticleSources() {
   'use cache';
   cacheLife('hours');
 
-  const articleSources = await Promise.resolve(_getArticleSources());
+  const articleSources = await _getArticleSources();
   return articleSources;
 }

--- a/apps/main/src/features/tags/interface/queries.ts
+++ b/apps/main/src/features/tags/interface/queries.ts
@@ -7,7 +7,7 @@ export async function getTags(page = 1) {
   'use cache';
   cacheLife('max');
 
-  const tags = await Promise.resolve(_getTags(page));
+  const tags = await _getTags(page);
   return tags;
 }
 
@@ -15,6 +15,6 @@ export async function getTag(id: number) {
   'use cache';
   cacheLife('max');
 
-  const tag = await Promise.resolve(_getTag(id));
+  const tag = await _getTag(id);
   return tag;
 }

--- a/apps/main/src/features/talks/interface/queries.ts
+++ b/apps/main/src/features/talks/interface/queries.ts
@@ -6,6 +6,6 @@ export async function getTalks() {
   'use cache';
   cacheLife('max');
 
-  const talks = await Promise.resolve(_getTalks());
+  const talks = await _getTalks();
   return talks;
 }


### PR DESCRIPTION
## Summary

最近の機能開発で溜まった「useEffect の過剰使用 / 同じ JSX の繰り返し / 不要な Promise.resolve / 説明だけのコメント」を一通り整理しました。24 ファイル変更で **-284 行**（825 削除 / 541 追加）。

### React の使い方

- **`scrollend-trigger-demo`**: `useState + useCallback x2 + useEffect x3 + ref タイマー` を `useScrollendCounter` / `useScrollendListener` の 2 つの hook に切り出し、フラッシュロジックの重複を解消
- **`scrollend-demo`** / **`scrollbar-color-demo`**: tabIndex 設定を既存の useEffect に同居させ、`onScroll` は React のイベントプロップに戻す
- **`dialog-requestclose-demo`**: state を ref で参照することで、キー入力ごとに listener を貼り直していたのをやめる（依存 `[state]` を `[]` に）
- **`clipboard-text-demo`**: 2 つの permission 購読を共通ヘルパに、`@ts-expect-error x2` を境界でのキャストに置き換え
- **`print-color-adjust-demo`**: stale state を見ていた toggle を functional updater に修正
- **`scroll-to-top-on-path-change`**: 2 つの ref と分岐をフラットに
- **`composed-ranges/selection-properties`**: 不要な分岐を削除し variable 名を整理
- **`highlight-{basic,spelling,priority}-demo`**: `CSS.highlights` のクリーンアップを追加（グローバルレジストリにリークしていた）

### バグ修正

- **`use-control-panel.ts`**: `mouseup` / `touchend` のリスナーが毎ドラッグごとに増え続けていたメモリリークを修正。`'topLeftX' | 'topLeftY' | ...` の 8 通り union 重複を `keyof RadiusPosition` で集約、軸正負と矢印キー差分を純粋関数に切り出して keyDownHandler の重複ブランチを削減

### データ駆動化 / 凝集の解消

- **`control-panel.tsx`** (329 → 206 行): 8 個のほぼ同じ `<OperateButton>` を `CONTROLS` 配列ベースに
- **`base-converter.tsx`** (172 → 107 行): 4 つの state と巨大 switch を `Record<Base, string>` + `VALIDATORS` / `ERROR_MESSAGES` / `convertFrom` に
- **`table-of-contents.tsx`**: 3 階層ベタ書きの JSX を `<TocItem>` の再帰コンポーネントに
- **`create-restrictions.tsx`**: 常に true な `canDelete` prop、ダミーラッパー div、`{/* ヘッダー */}` などのコメントを削除

### サーバ層

- `features/*/interface/queries.ts`: `await Promise.resolve(_getXxx())` の wrap を、下位がもともと `Promise` を返している箇所では `await _getXxx()` に整理（`require-await` と `return-await` が両立するよう temp variable は維持）

### コメント / oxlint-disable

- 「次の行が何をするか」だけを述べていた narrative コメント（`// アイテムを追加` 等）を削除
- 新しい `oxlint-disable` は追加していない。既存の disable は意味があるもの（`BroadcastChannel/MessagePort の targetOrigin 非対応` 等）のみ残置

## Test plan

- [x] `pnpm run check`: 0 errors / 77 warnings（ベースラインと同じ）
- [x] `pnpm run type-check`: 全 5 タスク成功
- [x] `apps/main` features+unit テスト: 51/51 passed
- [x] `apps/admin` features テスト: 10/10 passed
- [x] `@repo/helpers` / `@repo/code-highlight` テスト: 全 pass
- [ ] storybook play tests（playwright 必要なため CI 側で確認）

https://claude.ai/code/session_01DCZ3RmDXGHwWTnkKxJ4TgD

---
_Generated by [Claude Code](https://claude.ai/code/session_01DCZ3RmDXGHwWTnkKxJ4TgD)_