### PR TITLE
feat(blog): add 4 Baseline 2026 articles

### DIFF
--- a/apps/main/src/app/_components/playgrounds/baseline-shift/baseline-shift-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/baseline-shift/baseline-shift-demo.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Playground } from '../playground';
+import { BaselineShiftDemo } from './baseline-shift-demo';
+
+const playgroundTitle = BaselineShiftDemo.name;
+
+const meta: Meta<typeof BaselineShiftDemo> = {
+  title: 'playgrounds/baseline-shift/BaselineShiftDemo',
+  component: BaselineShiftDemo,
+  decorators: [
+    (Story) => (
+      <Playground title={playgroundTitle}>
+        <Story />
+      </Playground>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof BaselineShiftDemo>;
+
+export const Default: Story = {};

--- a/apps/main/src/app/_components/playgrounds/baseline-shift/baseline-shift-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/baseline-shift/baseline-shift-demo.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { FormControl, Select } from '@k8o/arte-odyssey';
+import { useState } from 'react';
+
+type BaselineShiftValue = '0' | 'sub' | 'super' | '0.3em' | '-0.3em';
+
+const FONT_SIZE = 28;
+const BASELINE_Y = 40;
+const SVG_WIDTH = 360;
+
+type Example = {
+  prefix: string;
+  shifted: string;
+  suffix: string;
+};
+
+const EXAMPLES: readonly Example[] = [
+  { prefix: '水の化学式は H', shifted: '2', suffix: 'O です。' },
+  { prefix: '面積は 10 m', shifted: '2', suffix: ' です。' },
+  { prefix: '注釈付きの語', shifted: '※1', suffix: 'を本文に。' },
+];
+
+export function BaselineShiftDemo() {
+  const [value, setValue] = useState<BaselineShiftValue>('super');
+
+  return (
+    <div className="flex flex-col gap-6">
+      <FormControl
+        label="baseline-shift"
+        renderInput={({ 'aria-labelledby': _, ...props }) => (
+          <Select
+            {...props}
+            onChange={(e) => {
+              setValue(e.target.value as BaselineShiftValue);
+            }}
+            options={[
+              { value: '0', label: '0 (既定)' },
+              { value: 'sub', label: 'sub' },
+              { value: 'super', label: 'super' },
+              { value: '0.3em', label: '0.3em' },
+              { value: '-0.3em', label: '-0.3em' },
+            ]}
+            value={value}
+          />
+        )}
+      />
+
+      <p className="text-fg-mute text-sm">
+        SVGの <code>tspan</code> に <code>baseline-shift: {value}</code>{' '}
+        を当てています。赤い文字がずらしの対象、グレーの破線が親{' '}
+        <code>text</code> のベースラインです。
+      </p>
+
+      <div className="bg-bg-base flex flex-col gap-2 rounded-xl p-6 shadow-sm">
+        {EXAMPLES.map((example, idx) => (
+          <svg
+            aria-label={`baseline-shift: ${value} の例 ${(idx + 1).toString()}`}
+            height="56"
+            key={example.prefix}
+            viewBox={`0 0 ${SVG_WIDTH.toString()} 56`}
+            width="100%"
+          >
+            <line
+              className="stroke-border-base"
+              strokeDasharray="3 3"
+              strokeWidth="1"
+              x1="0"
+              x2={SVG_WIDTH}
+              y1={BASELINE_Y}
+              y2={BASELINE_Y}
+            />
+            <text
+              className="fill-fg-base"
+              fontSize={FONT_SIZE}
+              x="0"
+              y={BASELINE_Y}
+            >
+              {example.prefix}
+              <tspan
+                className="fill-fg-error"
+                fontSize="0.8em"
+                fontWeight="bold"
+                style={{ baselineShift: value }}
+              >
+                {example.shifted}
+              </tspan>
+              {example.suffix}
+            </text>
+          </svg>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/app/_components/playgrounds/baseline-shift/index.ts
+++ b/apps/main/src/app/_components/playgrounds/baseline-shift/index.ts
@@ -1,0 +1,19 @@
+import type { PlaygroundSection } from '../types';
+import { BaselineShiftDemo } from './baseline-shift-demo';
+
+export { BaselineShiftDemo } from './baseline-shift-demo';
+
+export const baselineShiftSection: PlaygroundSection = {
+  id: 'baseline-shift',
+  title: 'baseline-shift',
+  description:
+    'インラインレベル要素のベースラインを親要素から相対的にずらすCSSプロパティです。SVGとHTMLをまたいで同じプロパティで扱えます。',
+  type: 'blog',
+  slug: 'baseline-shift',
+  demos: [
+    {
+      component: BaselineShiftDemo,
+      title: 'baseline-shift値の比較',
+    },
+  ],
+};

--- a/apps/main/src/app/_components/playgrounds/index.ts
+++ b/apps/main/src/app/_components/playgrounds/index.ts
@@ -25,6 +25,7 @@ export * from './scope';
 export * from './screen-wake-lock';
 export * from './scrollbar-color';
 export * from './scrollend';
+export * from './open-pseudo';
 export * from './shape-function';
 export * from './shared-worker';
 export * from './spelling-grammar-error';
@@ -50,6 +51,7 @@ import { highlightSection } from './highlight';
 import { inputFileWebkitdirectorySection } from './input-file-webkitdirectory';
 import { invokerCommandsSection } from './invoker-commands';
 import { lcpSection } from './largest-contentful-paint';
+import { openPseudoSection } from './open-pseudo';
 import { popoverSection } from './popover';
 import { printColorAdjustSection } from './print-color-adjust';
 import { requestCloseSection } from './requestclose';
@@ -83,6 +85,7 @@ export const playgroundSections: PlaygroundSection[] = [
   inputFileWebkitdirectorySection,
   invokerCommandsSection,
   lcpSection,
+  openPseudoSection,
   popoverSection,
   requestCloseSection,
   printColorAdjustSection,

--- a/apps/main/src/app/_components/playgrounds/index.ts
+++ b/apps/main/src/app/_components/playgrounds/index.ts
@@ -31,6 +31,7 @@ export * from './spelling-grammar-error';
 export * from './suspense-list';
 export * from './text-decoration-skip-ink-all';
 export * from './text-indent-keywords';
+export * from './toggleevent-source';
 export * from './view-transitions';
 
 import { absSignSection } from './abs-sign';
@@ -63,6 +64,7 @@ import { spellingGrammarErrorSection } from './spelling-grammar-error';
 import { suspenseListSection } from './suspense-list';
 import { textDecorationSkipInkAllSection } from './text-decoration-skip-ink-all';
 import { textIndentKeywordsSection } from './text-indent-keywords';
+import { toggleEventSourceSection } from './toggleevent-source';
 import type { PlaygroundSection } from './types';
 import { viewTransitionsSection } from './view-transitions';
 
@@ -97,5 +99,6 @@ export const playgroundSections: PlaygroundSection[] = [
   spellingGrammarErrorSection,
   textDecorationSkipInkAllSection,
   textIndentKeywordsSection,
+  toggleEventSourceSection,
   viewTransitionsSection,
 ];

--- a/apps/main/src/app/_components/playgrounds/index.ts
+++ b/apps/main/src/app/_components/playgrounds/index.ts
@@ -3,6 +3,7 @@
 export * from './abs-sign';
 export * from './active-view-transition';
 export * from './async-clipboard';
+export * from './baseline-shift';
 export * from './caret-position-from-point';
 export * from './composed-ranges';
 export * from './content-visibility';
@@ -35,6 +36,7 @@ export * from './view-transitions';
 import { absSignSection } from './abs-sign';
 import { activeViewTransitionSection } from './active-view-transition';
 import { asyncClipboardSection } from './async-clipboard';
+import { baselineShiftSection } from './baseline-shift';
 import { caretPositionFromPointSection } from './caret-position-from-point';
 import { composedRangesSection } from './composed-ranges';
 import { contentVisibilitySection } from './content-visibility';
@@ -67,6 +69,7 @@ import { viewTransitionsSection } from './view-transitions';
 export const playgroundSections: PlaygroundSection[] = [
   activeViewTransitionSection,
   asyncClipboardSection,
+  baselineShiftSection,
   caretPositionFromPointSection,
   composedRangesSection,
   contentVisibilitySection,

--- a/apps/main/src/app/_components/playgrounds/open-pseudo/index.ts
+++ b/apps/main/src/app/_components/playgrounds/open-pseudo/index.ts
@@ -1,0 +1,19 @@
+import type { PlaygroundSection } from '../types';
+import { OpenPseudoDemo } from './open-pseudo-demo';
+
+export { OpenPseudoDemo } from './open-pseudo-demo';
+
+export const openPseudoSection: PlaygroundSection = {
+  id: 'open-pseudo',
+  title: ':open',
+  description:
+    'dialog、details、select、ピッカー付きのinputが開いている間にマッチするCSS疑似クラスです。要素別の属性セレクタを横断して一本化できます。',
+  type: 'blog',
+  slug: 'open-pseudo',
+  demos: [
+    {
+      component: OpenPseudoDemo,
+      title: ':openで開いている要素を一括スタイリング',
+    },
+  ],
+};

--- a/apps/main/src/app/_components/playgrounds/open-pseudo/open-pseudo-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/open-pseudo/open-pseudo-demo.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Playground } from '../playground';
+import { OpenPseudoDemo } from './open-pseudo-demo';
+
+const playgroundTitle = OpenPseudoDemo.name;
+
+const meta: Meta<typeof OpenPseudoDemo> = {
+  title: 'playgrounds/open-pseudo/OpenPseudoDemo',
+  component: OpenPseudoDemo,
+  decorators: [
+    (Story) => (
+      <Playground title={playgroundTitle}>
+        <Story />
+      </Playground>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OpenPseudoDemo>;
+
+export const Default: Story = {};

--- a/apps/main/src/app/_components/playgrounds/open-pseudo/open-pseudo-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/open-pseudo/open-pseudo-demo.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { Button, Code } from '@k8o/arte-odyssey';
+import { useRef } from 'react';
+
+export function OpenPseudoDemo() {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <style>{`
+        .open-demo-target {
+          outline: 3px solid transparent;
+          outline-offset: 6px;
+          transition: outline-color 150ms, background-color 150ms;
+        }
+        .open-demo-target:open {
+          outline-color: var(--color-primary-border);
+        }
+        /* select / input のピッカーは対象要素の上にUIが被るので、
+           親に :has() で背景色を付けて開いていることを別途見せる */
+        .open-demo-section:has(:open) {
+          background-color: var(--color-primary-bg-subtle);
+        }
+      `}</style>
+
+      <p className="text-fg-mute text-sm">
+        対象要素には共通のスタイルだけ当てています。開いている要素にだけ
+        <Code>:open</Code>が当たって枠線が出ます。<Code>select</Code>や
+        <Code>input</Code>はピッカーが要素を覆ってしまうので、親セクションに
+        <Code>:has(:open)</Code>
+        で背景色も付けて開いている状態が見えるようにしています。
+      </p>
+
+      <section className="open-demo-section flex flex-col gap-2 rounded-lg p-3 transition-colors">
+        <h4 className="text-fg-base font-bold">details</h4>
+        <details className="open-demo-target bg-bg-base rounded-md p-3">
+          <summary className="cursor-pointer">クリックして開く</summary>
+          <p className="mt-2">
+            開いている間、<Code>details:open</Code>が当たります。
+          </p>
+        </details>
+      </section>
+
+      <section className="open-demo-section flex flex-col gap-2 rounded-lg p-3 transition-colors">
+        <h4 className="text-fg-base font-bold">dialog</h4>
+        <div className="flex items-center gap-3">
+          <Button
+            onClick={() => {
+              dialogRef.current?.showModal();
+            }}
+          >
+            dialog を開く
+          </Button>
+          <span className="text-fg-mute text-sm">
+            開いている間、<Code>dialog:open</Code>が当たります
+          </span>
+        </div>
+        {/* dialog 自身へのクリック = backdrop クリック扱いで閉じる。ESC キーは dialog 標準で閉じるのでキーボード代替は不要。 */}
+        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
+        <dialog
+          className="open-demo-target bg-bg-base inset-0 m-auto size-fit rounded-md p-4"
+          onClick={(e) => {
+            if (e.target === e.currentTarget) {
+              dialogRef.current?.close();
+            }
+          }}
+          ref={dialogRef}
+        >
+          <p className="mb-3">
+            この dialog にも <Code>:open</Code> が当たっています。
+          </p>
+          <Button
+            onClick={() => {
+              dialogRef.current?.close();
+            }}
+          >
+            閉じる
+          </Button>
+        </dialog>
+      </section>
+
+      <section className="open-demo-section flex flex-col gap-2 rounded-lg p-3 transition-colors">
+        <h4 className="text-fg-base font-bold">select</h4>
+        <select
+          className="open-demo-target bg-bg-base rounded-md p-2"
+          defaultValue="1"
+        >
+          <option value="1">選択肢 1</option>
+          <option value="2">選択肢 2</option>
+          <option value="3">選択肢 3</option>
+        </select>
+        <span className="text-fg-mute text-sm">
+          ピッカーを開いている間だけ<Code>select:open</Code>が当たります。
+        </span>
+      </section>
+
+      <section className="open-demo-section flex flex-col gap-2 rounded-lg p-3 transition-colors">
+        <h4 className="text-fg-base font-bold">input (color)</h4>
+        <input
+          className="open-demo-target bg-bg-base h-12 w-24 rounded-md p-1"
+          defaultValue="#3b82f6"
+          type="color"
+        />
+        <span className="text-fg-mute text-sm">
+          カラーピッカーを開いている間だけ
+          <Code>input[type=&quot;color&quot;]:open</Code>が当たります。
+        </span>
+      </section>
+    </div>
+  );
+}

--- a/apps/main/src/app/_components/playgrounds/open-pseudo/open-pseudo-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/open-pseudo/open-pseudo-demo.tsx
@@ -57,8 +57,9 @@ export function OpenPseudoDemo() {
           </span>
         </div>
         {/* dialog 自身へのクリック = backdrop クリック扱いで閉じる。ESC キーは dialog 標準で閉じるのでキーボード代替は不要。 */}
-        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events */}
+        {/* oxlint-disable-next-line jsx-a11y/click-events-have-key-events */}
         <dialog
+          aria-label=":open デモ用ダイアログ"
           className="open-demo-target bg-bg-base inset-0 m-auto size-fit rounded-md p-4"
           onClick={(e) => {
             if (e.target === e.currentTarget) {

--- a/apps/main/src/app/_components/playgrounds/open-pseudo/open-pseudo-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/open-pseudo/open-pseudo-demo.tsx
@@ -83,6 +83,7 @@ export function OpenPseudoDemo() {
       <section className="open-demo-section flex flex-col gap-2 rounded-lg p-3 transition-colors">
         <h4 className="text-fg-base font-bold">select</h4>
         <select
+          aria-label="select :open デモ用の選択肢"
           className="open-demo-target bg-bg-base rounded-md p-2"
           defaultValue="1"
         >
@@ -98,6 +99,7 @@ export function OpenPseudoDemo() {
       <section className="open-demo-section flex flex-col gap-2 rounded-lg p-3 transition-colors">
         <h4 className="text-fg-base font-bold">input (color)</h4>
         <input
+          aria-label="input :open デモ用のカラーピッカー"
           className="open-demo-target bg-bg-base h-12 w-24 rounded-md p-1"
           defaultValue="#3b82f6"
           type="color"

--- a/apps/main/src/app/_components/playgrounds/toggleevent-source/index.ts
+++ b/apps/main/src/app/_components/playgrounds/toggleevent-source/index.ts
@@ -1,0 +1,19 @@
+import type { PlaygroundSection } from '../types';
+import { ToggleEventSourceDemo } from './toggleevent-source-demo';
+
+export { ToggleEventSourceDemo } from './toggleevent-source-demo';
+
+export const toggleEventSourceSection: PlaygroundSection = {
+  id: 'toggleevent-source',
+  title: 'ToggleEvent.source',
+  description:
+    'toggle / beforetoggleイベントに発火元の要素を載せて渡すプロパティです。複数トリガーから共有のポップオーバーを開くケースで、どのボタンから開かれたかを判定できます。',
+  type: 'blog',
+  slug: 'toggleevent-source',
+  demos: [
+    {
+      component: ToggleEventSourceDemo,
+      title: 'event.sourceで発火元のボタンを取得',
+    },
+  ],
+};

--- a/apps/main/src/app/_components/playgrounds/toggleevent-source/toggleevent-source-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/toggleevent-source/toggleevent-source-demo.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Playground } from '../playground';
+import { ToggleEventSourceDemo } from './toggleevent-source-demo';
+
+const playgroundTitle = ToggleEventSourceDemo.name;
+
+const meta: Meta<typeof ToggleEventSourceDemo> = {
+  title: 'playgrounds/toggleevent-source/ToggleEventSourceDemo',
+  component: ToggleEventSourceDemo,
+  decorators: [
+    (Story) => (
+      <Playground title={playgroundTitle}>
+        <Story />
+      </Playground>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ToggleEventSourceDemo>;
+
+export const Default: Story = {};

--- a/apps/main/src/app/_components/playgrounds/toggleevent-source/toggleevent-source-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/toggleevent-source/toggleevent-source-demo.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { Button, Code } from '@k8o/arte-odyssey';
+import { useEffect, useRef, useState } from 'react';
+
+// Baseline 2026で追加された source プロパティをTypeScriptの型に拡張
+type ToggleEventWithSource = ToggleEvent & { source?: Element | null };
+
+// showPopover が source オプションを受けるシグネチャの型補完
+type ShowPopoverOptions = { source?: Element };
+
+type Member = {
+  id: string;
+  name: string;
+  role: string;
+  bio: string;
+};
+
+const MEMBERS: readonly Member[] = [
+  {
+    id: 'alice',
+    name: 'Alice',
+    role: 'Frontend Engineer',
+    bio: 'TypeScript と Web Standards をひたすら追いかける人',
+  },
+  {
+    id: 'bob',
+    name: 'Bob',
+    role: 'Designer',
+    bio: 'デザインシステムとアクセシビリティに強い',
+  },
+  {
+    id: 'carol',
+    name: 'Carol',
+    role: 'Product Manager',
+    bio: 'ロードマップ整理とユーザーリサーチが本職',
+  },
+];
+
+const FALLBACK: Member = {
+  id: '',
+  name: '—',
+  role: '—',
+  bio: 'ボタンから開いてください',
+};
+
+const POPOVER_ID = 'toggleevent-source-member-card';
+
+type ToggleLog = {
+  oldState: string;
+  newState: string;
+  memberId: string | null;
+  buttonText: string | null;
+};
+
+const INITIAL_LOG: ToggleLog = {
+  oldState: '—',
+  newState: '—',
+  memberId: null,
+  buttonText: null,
+};
+
+export function ToggleEventSourceDemo() {
+  const popoverRef = useRef<HTMLDivElement>(null);
+  const [active, setActive] = useState<Member>(FALLBACK);
+  const [toggleLog, setToggleLog] = useState<ToggleLog>(INITIAL_LOG);
+
+  useEffect(() => {
+    const popover = popoverRef.current;
+    if (!popover) return undefined;
+
+    const onToggle = (event: Event) => {
+      const toggleEvent = event as ToggleEventWithSource;
+      const { source } = toggleEvent;
+      const sourceEl = source instanceof HTMLElement ? source : null;
+      const memberId = sourceEl?.dataset['memberId'] ?? null;
+
+      setToggleLog({
+        oldState: toggleEvent.oldState,
+        newState: toggleEvent.newState,
+        memberId,
+        buttonText: sourceEl ? sourceEl.textContent.trim() : null,
+      });
+
+      if (toggleEvent.newState !== 'open') return;
+      const member = MEMBERS.find((m) => m.id === memberId);
+      if (member) setActive(member);
+    };
+
+    popover.addEventListener('toggle', onToggle);
+    return () => {
+      popover.removeEventListener('toggle', onToggle);
+    };
+  }, []);
+
+  // popover が開いている状態で別のボタンを押されても再ショーされるよう、
+  // 明示的に hide → show でやり直して source を毎回更新する。
+  const openWithSource = (button: HTMLElement) => {
+    const popover = popoverRef.current;
+    if (!popover) return;
+    if (popover.matches(':popover-open')) {
+      popover.hidePopover();
+    }
+    (popover.showPopover as (options?: ShowPopoverOptions) => void)({
+      source: button,
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <p className="text-fg-mute text-sm">
+        どのメンバーの「詳細」を押しても同じポップオーバーが開きます。
+        <Code>toggle</Code>イベントの<Code>event.source</Code>
+        から発火元のボタンを取って、その<Code>data-member-id</Code>
+        で表示内容を切り替えます。
+      </p>
+
+      <ul className="flex flex-col gap-2">
+        {MEMBERS.map((member) => (
+          <li
+            className="bg-bg-base flex items-center justify-between rounded-md p-3"
+            key={member.id}
+          >
+            <div>
+              <p className="text-fg-base font-bold">{member.name}</p>
+              <p className="text-fg-mute text-xs">{member.role}</p>
+            </div>
+            <Button
+              data-member-id={member.id}
+              onClick={(e) => {
+                openWithSource(e.currentTarget);
+              }}
+              size="sm"
+            >
+              詳細
+            </Button>
+          </li>
+        ))}
+      </ul>
+
+      <div className="bg-bg-subtle text-fg-mute rounded-md p-3 font-mono text-xs">
+        <p>最新の toggle イベントから取った情報（open / close 両方）</p>
+        <p>event.oldState: {JSON.stringify(toggleLog.oldState)}</p>
+        <p>event.newState: {JSON.stringify(toggleLog.newState)}</p>
+        <p>event.source.textContent: {JSON.stringify(toggleLog.buttonText)}</p>
+        <p>
+          event.source.dataset.memberId: {JSON.stringify(toggleLog.memberId)}
+        </p>
+      </div>
+
+      <div
+        className="bg-bg-base m-auto w-72 rounded-md p-4 shadow-md"
+        id={POPOVER_ID}
+        popover="auto"
+        ref={popoverRef}
+      >
+        <p className="text-fg-base font-bold">{active.name}</p>
+        <p className="text-fg-mute mt-1 text-xs">{active.role}</p>
+        <p className="text-fg-base mt-2 text-sm">{active.bio}</p>
+        <div className="mt-3 flex justify-end">
+          {/* popovertarget の hide ボタンで閉じると、閉じる方向のtoggleでこのボタンが source になる */}
+          <Button
+            data-member-id="close"
+            popoverTarget={POPOVER_ID}
+            popoverTargetAction="hide"
+            size="sm"
+            variant="outlined"
+          >
+            閉じる
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/app/_components/playgrounds/toggleevent-source/toggleevent-source-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/toggleevent-source/toggleevent-source-demo.tsx
@@ -126,6 +126,7 @@ export function ToggleEventSourceDemo() {
               <p className="text-fg-mute text-xs">{member.role}</p>
             </div>
             <Button
+              aria-label={`${member.name}の詳細`}
               data-member-id={member.id}
               onClick={(e) => {
                 openWithSource(e.currentTarget);

--- a/apps/main/src/app/blog/(articles)/baseline-shift/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/baseline-shift/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+const slug = 'baseline-shift';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt,
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/baseline-shift'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/baseline-shift/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/baseline-shift/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+export const alt = 'baseline-shiftでテキストのベースラインをずらす';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const blog = await getBlogContent('baseline-shift');
+
+  return OgImage({
+    category: 'Blog',
+    title: blog.title,
+  });
+}

--- a/apps/main/src/app/blog/(articles)/baseline-shift/page.mdx
+++ b/apps/main/src/app/blog/(articles)/baseline-shift/page.mdx
@@ -1,0 +1,105 @@
+---
+title: baseline-shiftでSVGテキストのベースラインをずらす
+description: baseline-shiftはCSS Inline 3で定義されたCSSプロパティで、SVGテキスト要素のベースラインを親要素から相対的にずらすために使います。SVGの同名属性の後継として位置付けられ、Baseline 2026で主要ブラウザに揃いました。
+createdAt: 2026-05-23
+updatedAt: 2026-05-23
+featureIds:
+  - baseline-shift
+---
+
+import { BaselineStatus } from '@k8o/arte-odyssey';
+import { LinkCard } from '@/app/_components/link-card';
+import { BaselineShiftDemo, Playground } from '@/app/_components/playgrounds';
+
+# baseline-shiftでSVGテキストのベースラインをずらす
+
+<BaselineStatus featureId="baseline-shift" />
+
+## はじめに
+
+SVGの`<text>`の中で化学式や数式、図中のラベルを書くとき、特定の文字だけ上付き・下付きにしたい場面があります。SVGには古くから`baseline-shift`という同名の属性があり、`<text>`や`<tspan>`の属性として書けばずらせました。ただこの属性は非推奨化が進んでおり、CSSプロパティへの移行が推奨されています。
+
+CSS Inline 3で再定義された`baseline-shift`プロパティはこの後継で、SVGの`<text>`内のテキスト要素のベースラインをCSSから制御できます。Baseline 2026で主要ブラウザに揃い、SVG中のテキストの上付き・下付き調整をCSSで素直に書けるようになりました。
+
+## プロパティの値
+
+`baseline-shift`はインラインレベルボックスとSVGテキスト要素（`<tspan>`や`<textPath>`）に適用されるプロパティで、対象要素のドミナントベースラインを親のベースラインから相対的に動かします。ただし現状ChromeやEdgeはHTMLのインラインへの視覚適用が未対応で、実用上はSVGテキストでの利用が中心になります。CSS Inline Layout Module Level 3で定義されている値は次の通りです。初期値は`0`（ずらさない）です。
+
+<LinkCard href="https://drafts.csswg.org/css-inline-3/#baseline-shift-property" />
+
+- `<length-percentage>` - 任意の長さや割合でずらす。`em` / `px` / `%`などが使える。正の値で上、負の値で下に動く
+- `sub` - 親フォントに定義されている下付き位置までずらす
+- `super` - 親フォントに定義されている上付き位置までずらす
+- `top` - 行ボックスの上端にベースラインを揃える
+- `center` - 行ボックスの上下中央にベースラインを揃える
+- `bottom` - 行ボックスの下端にベースラインを揃える
+
+`sub`と`super`はフォントごとに埋め込まれた下付き・上付きの標準位置を使うので、ブラウザが`<sub>` / `<sup>`を表示するときの位置に近い結果になります。`top` / `center` / `bottom`は行ボックス（その1行ぶんのテキストを上下方向に収める箱）の端や中央に揃えるための値です。なお`top` / `center` / `bottom`は現状Firefoxのみの対応で、Chrome / Edge / Safariは未対応のため、跨いで使えるのは`<length-percentage>` / `sub` / `super`までです。
+
+## 基本の使い方
+
+SVGの`<text>`の中で`<tspan>`に`baseline-shift`を当てると、その部分だけベースラインが動きます。化学式や単位の上付き・下付きをCSSで揃えて書きたい場面で使えます。
+
+```html
+<svg viewBox="0 0 360 60" width="360" height="60">
+  <text x="0" y="40" font-size="28">
+    水の化学式は H<tspan class="sub">2</tspan>O です。
+  </text>
+  <text x="0" y="40" font-size="28">
+    面積は 10 m<tspan class="sup">2</tspan> です。
+  </text>
+</svg>
+```
+
+```css
+.sub {
+  /* [!hl] */
+  baseline-shift: sub;
+  font-size: 0.8em;
+}
+
+.sup {
+  /* [!hl] */
+  baseline-shift: super;
+  font-size: 0.8em;
+}
+```
+
+長さで微調整したいときは`em`が使いやすいです。
+
+```css
+.note {
+  baseline-shift: 0.3em;
+  font-size: 0.75em;
+}
+```
+
+CSSプロパティとして書くことで、SVGの`baseline-shift`属性を直接書くより一貫した記述ができます。属性とCSSの両方が効く場合、CSSの方が優先されます。
+
+<Playground title="baseline-shift値の比較">
+  <BaselineShiftDemo />
+</Playground>
+
+## vertical-alignとの関係
+
+CSS Inline Layout 3では、`vertical-align`は`baseline-source`、`alignment-baseline`、`baseline-shift`の3つを束ねるショートハンドとして定義されています。SVGテキストでも`vertical-align`が同じ意味で使えますが、`baseline-shift`はずらしの量だけを単独で扱えるロングハンドとして、デザインシステムやレイヤーで合成したいときに役立ちます。
+
+```css
+/* shorthand: 他のサブプロパティも同時にリセットされる */
+text .note {
+  vertical-align: 0.3em;
+}
+
+/* longhand: 他のベースライン関連を触らずにずれだけを管理したいとき */
+text .note {
+  baseline-shift: 0.3em;
+}
+```
+
+なお3つのロングハンドのうち、`baseline-shift`がBaseline 2026で揃った一方で、残りの2つはまだ温度差があります。`alignment-baseline`はFirefox 149で実装が入り、Chrome / Edge / Safari / Firefoxすべてで動くようになったので、近いうちにBaselineに正式に組み込まれるのを待っている状態です。`baseline-source`はSafariの対応待ちで、現状はChrome / Edge / Firefoxのみです。3つすべてが揃って初めて、`vertical-align`をショートハンドとしてフルに使える状態になります。
+
+## おわりに
+
+`baseline-shift`はSVGテキストのベースラインをずらすCSSプロパティとして、SVGの古い同名属性に代わる位置付けでBaseline 2026に揃いました。化学式・数式・図中ラベルなど、SVGの`<text>`に細かい上付き・下付きを入れたい場面で素直に書ける選択肢です。
+
+ただ、HTMLインラインへの視覚適用や`top` / `center` / `bottom`、`baseline-source`など、CSS Inline 3の周辺プロパティはFirefoxだけが先行している部分が多く、ChromeやSafariで安心して使えるようになるまではまだ距離があるように感じました。Baselineに揃ったとはいえ、実用面でフルに活かせるのはもう少し先になりそうです。

--- a/apps/main/src/app/blog/(articles)/open-pseudo/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/open-pseudo/layout.tsx
@@ -1,0 +1,35 @@
+import type { Metadata } from 'next';
+
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+const slug = 'open-pseudo';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt,
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({ children }: LayoutProps<'/blog/open-pseudo'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/open-pseudo/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/open-pseudo/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+export const alt = ':open疑似クラスで開いている要素をまとめてスタイリングする';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const blog = await getBlogContent('open-pseudo');
+
+  return OgImage({
+    category: 'Blog',
+    title: blog.title,
+  });
+}

--- a/apps/main/src/app/blog/(articles)/open-pseudo/page.mdx
+++ b/apps/main/src/app/blog/(articles)/open-pseudo/page.mdx
@@ -1,0 +1,72 @@
+---
+title: ':open疑似クラスで開いている要素をまとめてスタイリングする'
+description: ':openはdialog、details、select、ピッカー付きのinputといった開閉できる要素が開いている間にマッチするCSS疑似クラスです。Baseline 2026で揃ったので、dialog[open]やdetails[open]といった要素別の属性セレクタを横断して一本化できます。'
+createdAt: 2026-05-23
+updatedAt: 2026-05-23
+featureIds:
+  - open-pseudo
+---
+
+import { BaselineStatus } from '@k8o/arte-odyssey';
+import { OpenPseudoDemo, Playground } from '@/app/_components/playgrounds';
+
+# :open疑似クラスで開いている要素をまとめてスタイリングする
+
+<BaselineStatus featureId="open-pseudo" />
+
+## はじめに
+
+HTMLには開閉できる要素が複数あります。`<dialog>`、`<details>`、`<select>`、ピッカーUIを持つ`<input>`などです。これまでは開いているときに当てるCSSはそれぞれ別のセレクタが必要でした。
+
+- `<dialog>` → `dialog[open]`
+- `<details>` → `details[open]`
+- `<select>` → 専用セレクタなし
+- `<input type="color">`などのピッカー → 専用セレクタなし
+
+Baseline 2026で揃った`:open`疑似クラスは、これらをまとめて表せるセレクタです。なお、`popover`属性を持つ要素は別系統で`:popover-open`が用意されており、`:open`の対象には含まれません。
+
+## マッチする要素
+
+`:open`は現在開いている状態の要素にマッチします。仕様上、対象になるのは以下です。
+
+- `<dialog>` - `open`属性が付いているとき
+- `<details>` - `open`属性が付いているとき
+- `<select>` - ピッカー（ドロップダウン）が開いているとき
+- `<input>`のうちピッカーUIを持つ型（`color`、`date`、`file`など） - ピッカーが開いているとき
+
+`popover`属性を持つ要素は`:open`ではなく`:popover-open`で扱います。
+
+## 使い方
+
+開いた瞬間だけ枠線を強調したい、開いているトリガーボタンとそろえて色を変えたい、といったケースで一本のセレクタで書けます。
+
+```css
+:open {
+  /* [!hl] */
+  outline: 2px solid var(--color-accent);
+  outline-offset: 4px;
+}
+```
+
+要素を絞りたいときは普通のセレクタと組み合わせます。
+
+```css
+/* dialogとdetailsが開いているとき */
+dialog:open,
+details:open {
+  border-color: var(--color-accent);
+}
+
+/* selectのピッカーが開いているとき */
+select:open {
+  box-shadow: 0 10px 30px rgb(0 0 0 / 0.2);
+}
+```
+
+<Playground title=":openで開いている要素を一括スタイリング">
+  <OpenPseudoDemo />
+</Playground>
+
+## おわりに
+
+`:open`の本当の価値は`<select>`やピッカー付き`<input>`（`color`、`date`、`file`など）にスタイリングできることにあります。`<dialog>`や`<details>`は元から属性セレクタで取れていたので`:open`はそれを横断的にまとめる書き方でしかないですが、これらネイティブピッカーの開閉に追従するCSSはこれまで書きようがなく、`:open`が唯一無二の手段として加わった形です。Baseline 2026で主要ブラウザに揃ったことで、ネイティブUIに踏み込んだスタイリングが現実的に書けるようになりました。

--- a/apps/main/src/app/blog/(articles)/toggleevent-source/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/toggleevent-source/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+const slug = 'toggleevent-source';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt,
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/toggleevent-source'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/toggleevent-source/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/toggleevent-source/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+export const alt = 'ToggleEvent.sourceでポップオーバーを開いた要素を特定する';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const blog = await getBlogContent('toggleevent-source');
+
+  return OgImage({
+    category: 'Blog',
+    title: blog.title,
+  });
+}

--- a/apps/main/src/app/blog/(articles)/toggleevent-source/page.mdx
+++ b/apps/main/src/app/blog/(articles)/toggleevent-source/page.mdx
@@ -1,0 +1,89 @@
+---
+title: ToggleEvent.sourceでポップオーバーを開いた要素を特定する
+description: ToggleEvent.sourceはBaseline 2026で追加された、toggle / beforetoggleイベントに発火元の要素を載せて渡すプロパティです。同じポップオーバーを複数のボタンから開くケースで、どのボタンから開かれたかをリスナー側で素直に判定できます。
+createdAt: 2026-05-23
+updatedAt: 2026-05-23
+featureIds:
+  - toggleevent-source
+---
+
+import { BaselineStatus } from '@k8o/arte-odyssey';
+import {
+  Playground,
+  ToggleEventSourceDemo,
+} from '@/app/_components/playgrounds';
+
+# ToggleEvent.sourceでポップオーバーを開いた要素を特定する
+
+<BaselineStatus featureId="toggleevent-source" />
+
+## はじめに
+
+Popover APIや`<details>`、`<dialog>`では、開閉のたびに`beforetoggle` / `toggle`イベントが発火します。複数のトリガーから1つのポップオーバーを開くようなUIでは、リスナーの中で今回はどのボタンから開かれたのかを知りたい場面が出てきます。
+
+これまでは、各ボタンに別々のイベントを張って状態を別管理する、データ属性を見て分岐する、といった工夫が必要でした。Baseline 2026で追加された`ToggleEvent.source`は、その発火元を`ToggleEvent`自体に載せて渡してくれるプロパティです。
+
+## どんなプロパティか
+
+`toggle` / `beforetoggle`イベントは`ToggleEvent`インターフェースを持ちます。これまでは`newState` / `oldState`で閉→開・開→閉の遷移だけが分かりましたが、`source`が追加されたことで遷移を引き起こした要素も同じイベントから取れるようになりました。
+
+### `source`に何が入るか
+
+`source`にはイベントを引き起こした呼び出し元が入ります。呼び出し元として拾われるのは次の3パターンで、開く方向でも閉じる方向でも同じです。
+
+- `popovertarget`属性を持つボタン
+- `commandfor` + `command="show-popover"` / `"hide-popover"` / `"toggle-popover"`が指定されたボタン
+- スクリプトから`showPopover({ source })` / `togglePopover({ source })`の`source`オプションで渡した要素
+
+### `source`が`null`になるケース
+
+呼び出し元を介さない経路で開閉した場合は`null`になります。
+
+- `hidePopover()`をスクリプトから呼ぶ（`hidePopover`は`source`オプションを取らない）
+- `showPopover()` / `togglePopover()`を`source`オプションを取らずに呼ぶ
+- ESCキーや外側クリックによるlight-dismissで閉じる
+
+ユーザー操作起点の発火と区別できるので、リスナー側で分岐させる材料にも使えます。
+
+## 使い方
+
+メンバー一覧の「詳細」ボタンを押すと、共通のポップオーバーが押されたメンバーの情報に切り替わって表示されます。
+
+<Playground title="event.sourceで発火元のボタンを取得">
+  <ToggleEventSourceDemo />
+</Playground>
+
+このUIは、ボタン側に`popovertarget`属性で共通ポップオーバーを指定し、`data-member-id`でどのメンバーかを持たせる構成です。開く操作はブラウザに任せられるので、HTMLは次のように書けます。
+
+```html
+<button popovertarget="member-card" data-member-id="alice">詳細</button>
+<button popovertarget="member-card" data-member-id="bob">詳細</button>
+<button popovertarget="member-card" data-member-id="carol">詳細</button>
+
+<div id="member-card" popover></div>
+```
+
+JS側はポップオーバーに`toggle`リスナーを1つ張るだけです。`event.source`が押されたボタンを返してくれるので、その`data-member-id`から表示すべき中身を組み立てます。
+
+```js
+const popover = document.getElementById('member-card');
+
+popover.addEventListener('toggle', (event) => {
+  // 閉じる方向(light-dismissやhidePopover)はsourceがnullのことが多いので、
+  // 開く方向だけを処理する
+  if (event.newState !== 'open') return;
+
+  // [!hl]
+  // [!callout: 発火元のボタン要素が取れる]
+  const trigger = event.source;
+  if (!(trigger instanceof HTMLElement)) return;
+
+  popover.replaceChildren(renderMember(trigger.dataset.memberId));
+});
+```
+
+ボタンごとに個別のリスナーを張ったり、最後に押されたボタンを別途状態として持ち回したりする必要がなくなり、ポップオーバー側の1か所で発火元を判定できるのが`event.source`の効きどころです。
+
+## おわりに
+
+`ToggleEvent.source`はやっていることは小さいですが、複数トリガーが1つのポップオーバーを共有するUIでは効きの大きい機能です。Baseline 2026で揃ったことで、ボタンごとにリスナーを分けたり、開いたボタンをグローバルに記録したりといった回避策が一段整理できます。Popover APIや`commandfor`を組み合わせた宣言的なUIと相性がよく、合わせて使うときに覚えておきたい一手です。

--- a/apps/main/src/app/blog/(articles)/wasm-branch-hinting/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/wasm-branch-hinting/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+const slug = 'wasm-branch-hinting';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt,
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/wasm-branch-hinting'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/wasm-branch-hinting/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/wasm-branch-hinting/opengraph-image.tsx
@@ -1,0 +1,19 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+export const alt = 'WebAssemblyのBranch Hintingで分岐予測を助ける';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const blog = await getBlogContent('wasm-branch-hinting');
+
+  return OgImage({
+    category: 'Blog',
+    title: blog.title,
+  });
+}

--- a/apps/main/src/app/blog/(articles)/wasm-branch-hinting/page.mdx
+++ b/apps/main/src/app/blog/(articles)/wasm-branch-hinting/page.mdx
@@ -1,0 +1,116 @@
+---
+title: WebAssemblyのBranch Hintingで分岐予測を助ける
+description: Branch HintingはWebAssemblyのbr_ifやifの分岐に対してどちらに進みやすいかをメタデータとしてカスタムセクションに埋め込み、エンジンの最適化を助ける仕組みです。Baseline 2026で揃ったので、ホットパスのチューニングに使える選択肢になりました。
+createdAt: 2026-05-23
+updatedAt: 2026-05-23
+featureIds:
+  - wasm-branch-hinting
+---
+
+import { BaselineStatus } from '@k8o/arte-odyssey';
+
+# WebAssemblyのBranch Hintingで分岐予測を助ける
+
+<BaselineStatus featureId="wasm-branch-hinting" />
+
+## はじめに
+
+CPUは分岐命令に出会うと、次にどちらの命令を実行するかを予測しながらパイプラインを先に進めます。予測が外れるとパイプラインを捨ててやり直すのでコストが大きく、ホットパスでは分岐の偏りに合わせて生成コードを並べておくと体感に効きます。「ほとんど通らないエラーパス」と「ほぼ毎回通る正常パス」が分かっているなら、コンパイラやJITに伝えることでホットパスを直線的に配置したり、低頻度側を別領域へ追い出したりといった最適化に繋げられます。
+
+C++などでは`[[likely]]` / `[[unlikely]]`属性のように、分岐先のステートメントに直接ヒントを付ける構文が用意されています。
+
+```cpp
+if (cache.contains(key)) [[likely]] {
+  return cache.get(key);
+} else [[unlikely]] {
+  return load_from_disk(key);
+}
+```
+
+ネイティブのコンパイラはこのヒントを使って条件ジャンプの並べ替えやホット・コールドのコード配置を決めますが、WebAssemblyにはそのヒントを運ぶ手段が長くありませんでした。Baseline 2026で揃ったBranch Hintingは、分岐命令にメタデータとしてlikely / unlikelyを載せる仕組みです。
+
+## どんな仕組みか
+
+WebAssemblyで条件分岐を担う代表的な命令は`br_if`と`if`です。
+
+- `br_if $label` - スタックの先頭の値が0以外なら`$label`へジャンプし、0ならそのまま次の命令へ進む。ジャンプ先はラベルがどの構造に付いているかで変わり、`block ... end`のラベルは末尾にバインドされるのでブロックの外へ抜け、`loop ... end`のラベルは先頭にバインドされるのでループの頭へ戻る（次のイテレーションに入る）
+- `if ... else ... end` - スタックの先頭の値で`then`側か`else`側のブロックを実行する。普通の`if文`に近い
+
+Branch Hintingは新しい命令ではなく、この`br_if`と`if`にカスタムセクションのメタデータを紐付けて、条件が真になりやすいかどうかをエンジンに伝える仕組みです。バイナリには`metadata.code.branch_hint`という名前のカスタムセクションが追加され、`0x00`は条件が真になりにくい（unlikely）、`0x01`は条件が真になりやすい（likely）という意味のバイト値で表します。実際には1分岐あたり、対象命令のバイトオフセット・ヒントの長さ・ヒント値の3つをまとめた1レコードとして記録されます。
+
+エンジン側はこれを最適化のヒントとして使えます。具体的にはJITが生成するコードで条件ジャンプの並び順を変えたり、likely側を直前に置いてキャッシュヒットを狙ったりといった調整が期待できます。あくまでヒントなので、これによって動作は変わりません。
+
+## テキスト形式での書き方
+
+WebAssemblyのバイナリはそのままだと読み書きしにくいので、デバッグや学習用にはWAT（WebAssembly Text Format、`.wat`）というテキスト表記が用意されています。`(func ...)`や`(loop ...)`のように括弧で命令や構造を入れ子にして書き、`wat2wasm`などで`.wasm`バイナリに変換します。以下のコード例もWATです。
+
+### スタックマシンの基本
+
+WebAssemblyはスタックマシン形式の言語で、命令は引数を式の中に書くのではなく、暗黙のスタックに値を積み下ろしして渡します。たとえば`1 + 2`は次のように書きます。
+
+```wasm
+i32.const 1   ;; スタックに 1 を積む
+i32.const 2   ;; スタックに 2 を積む（[1, 2]）
+i32.add       ;; 2つpopして合計をpush（[3]）
+```
+
+`i32.const`が値をpushし、`i32.add`がそれを消費して結果をpushする、というリズムです。このあと出てくる他の命令も同じ仕組みで動くので、新しく出てくる命令はコード中の`;;`コメントで補足していきます。
+
+### Branch Hintingのアノテーション
+
+WATでは`(@metadata.code.branch_hint ...)`というカスタムアノテーションでヒントを書きます。アノテーションは直後の命令に対するヒントとして解釈されるので、対象の`br_if`や`if`の直前に置きます。値は`"\01"`がlikely、`"\00"`がunlikelyです。
+
+次の例はカウンタをインクリメントしながらループを回す関数です。説明用の断片で、`(module ...)`では包んでいません。
+
+```wasm
+(func $hot_loop (param $n i32)
+  (local $i i32)
+  loop $cont
+    ;; ローカル変数 $i の値を積む
+    local.get $i
+    i32.const 1
+    i32.add
+    ;; スタックトップを $i に代入してそのまま残す
+    local.tee $i
+    local.get $n
+    ;; 2つpopして $i < $n の結果を積む
+    i32.lt_s
+    // [!hl]
+    // [!callout: ほとんどの回で br_if は取られる。落ちるのは $i が $n に追いついた最後の1回だけなので likely]
+    (@metadata.code.branch_hint "\01")
+    ;; スタックトップが非0なら $cont へジャンプ
+    br_if $cont
+  end
+)
+```
+
+`if`にも同様にアノテーションを置けます。次の例はnullチェックです。こちらも断片で、`$throw_null_pointer_error`の宣言は省略しています。
+
+```wasm
+(func $maybe_throw (param $ptr i32)
+  local.get $ptr
+  ;; 0なら1、非0なら0を積む（ここまでで実質 $ptr == 0 が乗る）
+  i32.eqz
+  // [!hl]
+  // [!callout: $ptr は普段ほぼ null ではないので、if の then 側に入るのはまれ → unlikely]
+  (@metadata.code.branch_hint "\00")
+  ;; スタックトップが非0なら then 側を実行
+  if
+    call $throw_null_pointer_error
+  end
+)
+```
+
+## ツール側の対応
+
+WAT手書きで使うことはそう多くないので、実用上はツールチェイン側の対応が前提になります。
+
+- wabt - `wat2wasm`に`--enable-annotations`を付けると、アノテーション付きWATをバイナリに変換できます
+- Binaryen - `wasm-opt`はフラグなしでbranch hintingを読み書きします。フィーチャーフラグでのガードはなく、各種最適化パスも一緒にヒントを保持・伝搬します。`--instrument-branch-hints`でヒントの的中率を測るための計装パスも用意されています
+- LLVM/Emscripten - C++の`[[likely]]` / `[[unlikely]]`などのヒント表現がwasm出力時にBranch Hintingに変換される流れが整いつつあります
+
+JavaScriptから直接特定の分岐をlikelyに指定するような注入の用途は少なく、コンパイラやランタイムが自動で埋め込んだヒントを実行エンジンが拾ってくれる、という使い方が中心になります。
+
+## おわりに
+
+Branch HintingはWebAssemblyのバイナリにそっと添えるメタデータで、この分岐はほぼこちらに進むとエンジンに伝えるだけのシンプルな仕組みです。Baseline 2026で主要ブラウザが揃ったことで、コンパイラがwasmを出すときに当たり前のヒントとして埋め込める段階になりました。アプリ側で明示的に意識する場面は少ないですが、PGOやプロファイリングと組み合わせると体感に効く一手として覚えておくと役立ちます。

--- a/packages/database/migrations/0046_giant_mephisto.sql
+++ b/packages/database/migrations/0046_giant_mephisto.sql
@@ -1,0 +1,12 @@
+-- 新しいタグの追加
+INSERT INTO tags (id, name) VALUES (133, 'WebAssembly');--> statement-breakpoint
+INSERT INTO tags (id, name) VALUES (134, 'wasm-branch-hinting');--> statement-breakpoint
+-- ブログレコードの追加
+INSERT INTO blogs (id, slug, published, created_at)
+VALUES (70, 'wasm-branch-hinting', 1, '2026-05-23T00:00:00.000Z');--> statement-breakpoint
+-- ビューカウント初期化
+INSERT INTO blog_views (blog_id, views) VALUES (70, 0);--> statement-breakpoint
+-- タグ紐付け (Baseline 2026: 99, WebAssembly: 133, wasm-branch-hinting: 134)
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (70, 99);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (70, 133);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (70, 134);

--- a/packages/database/migrations/0047_uneven_zzzax.sql
+++ b/packages/database/migrations/0047_uneven_zzzax.sql
@@ -1,0 +1,11 @@
+-- 新しいタグの追加
+INSERT INTO tags (id, name) VALUES (135, 'baseline-shift');--> statement-breakpoint
+-- ブログレコードの追加
+INSERT INTO blogs (id, slug, published, created_at)
+VALUES (71, 'baseline-shift', 1, '2026-05-23T00:00:00.000Z');--> statement-breakpoint
+-- ビューカウント初期化
+INSERT INTO blog_views (blog_id, views) VALUES (71, 0);--> statement-breakpoint
+-- タグ紐付け (CSS: 30, Baseline 2026: 99, baseline-shift: 135)
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (71, 30);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (71, 99);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (71, 135);

--- a/packages/database/migrations/0048_wooden_starbolt.sql
+++ b/packages/database/migrations/0048_wooden_starbolt.sql
@@ -1,0 +1,12 @@
+-- 新しいタグの追加
+INSERT INTO tags (id, name) VALUES (136, 'toggleevent-source');--> statement-breakpoint
+-- ブログレコードの追加
+INSERT INTO blogs (id, slug, published, created_at)
+VALUES (72, 'toggleevent-source', 1, '2026-05-23T00:00:00.000Z');--> statement-breakpoint
+-- ビューカウント初期化
+INSERT INTO blog_views (blog_id, views) VALUES (72, 0);--> statement-breakpoint
+-- タグ紐付け (HTML: 15, Popover API: 19, Baseline 2026: 99, toggleevent-source: 136)
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (72, 15);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (72, 19);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (72, 99);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (72, 136);

--- a/packages/database/migrations/0049_sparkling_randall_flagg.sql
+++ b/packages/database/migrations/0049_sparkling_randall_flagg.sql
@@ -1,0 +1,11 @@
+-- 新しいタグの追加
+INSERT INTO tags (id, name) VALUES (137, ':open');--> statement-breakpoint
+-- ブログレコードの追加
+INSERT INTO blogs (id, slug, published, created_at)
+VALUES (73, 'open-pseudo', 1, '2026-05-23T00:00:00.000Z');--> statement-breakpoint
+-- ビューカウント初期化
+INSERT INTO blog_views (blog_id, views) VALUES (73, 0);--> statement-breakpoint
+-- タグ紐付け (CSS: 30, Baseline 2026: 99, :open: 137)
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (73, 30);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (73, 99);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (73, 137);

--- a/packages/database/migrations/meta/0046_snapshot.json
+++ b/packages/database/migrations/meta/0046_snapshot.json
@@ -1,0 +1,1315 @@
+{
+  "id": "9dbfc511-e835-4fa5-8586-208a27051645",
+  "prevId": "d168beea-1bd1-4707-9c3b-4a2e5383a3dd",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "tableTo": "article_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_id_idx": {
+          "name": "comments_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_tag": {
+      "name": "slide_tag",
+      "columns": {
+        "slide_id": {
+          "name": "slide_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slide_tag_slide_id_idx": {
+          "name": "slide_tag_slide_id_idx",
+          "columns": [
+            "slide_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_tag_id_idx": {
+          "name": "slide_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_unique_idx": {
+          "name": "slide_tag_unique_idx",
+          "columns": [
+            "slide_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "slide_tag_slide_id_slides_id_fk": {
+          "name": "slide_tag_slide_id_slides_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "tableTo": "slides",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "slide_tag_tag_id_tags_id_fk": {
+          "name": "slide_tag_tag_id_tags_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slides": {
+      "name": "slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slides_slug_idx": {
+          "name": "slides_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_id_idx": {
+          "name": "talks_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/0047_snapshot.json
+++ b/packages/database/migrations/meta/0047_snapshot.json
@@ -1,0 +1,1315 @@
+{
+  "id": "527a91e9-a774-4151-9fc0-2bd716925c97",
+  "prevId": "9dbfc511-e835-4fa5-8586-208a27051645",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "tableTo": "article_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_id_idx": {
+          "name": "comments_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_tag": {
+      "name": "slide_tag",
+      "columns": {
+        "slide_id": {
+          "name": "slide_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slide_tag_slide_id_idx": {
+          "name": "slide_tag_slide_id_idx",
+          "columns": [
+            "slide_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_tag_id_idx": {
+          "name": "slide_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_unique_idx": {
+          "name": "slide_tag_unique_idx",
+          "columns": [
+            "slide_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "slide_tag_slide_id_slides_id_fk": {
+          "name": "slide_tag_slide_id_slides_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "tableTo": "slides",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "slide_tag_tag_id_tags_id_fk": {
+          "name": "slide_tag_tag_id_tags_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slides": {
+      "name": "slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slides_slug_idx": {
+          "name": "slides_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_id_idx": {
+          "name": "talks_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/0048_snapshot.json
+++ b/packages/database/migrations/meta/0048_snapshot.json
@@ -1,0 +1,1315 @@
+{
+  "id": "4288b0b5-8de0-4a85-b122-62720b63ca6c",
+  "prevId": "527a91e9-a774-4151-9fc0-2bd716925c97",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "tableTo": "article_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_id_idx": {
+          "name": "comments_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_tag": {
+      "name": "slide_tag",
+      "columns": {
+        "slide_id": {
+          "name": "slide_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slide_tag_slide_id_idx": {
+          "name": "slide_tag_slide_id_idx",
+          "columns": [
+            "slide_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_tag_id_idx": {
+          "name": "slide_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_unique_idx": {
+          "name": "slide_tag_unique_idx",
+          "columns": [
+            "slide_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "slide_tag_slide_id_slides_id_fk": {
+          "name": "slide_tag_slide_id_slides_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "tableTo": "slides",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "slide_tag_tag_id_tags_id_fk": {
+          "name": "slide_tag_tag_id_tags_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slides": {
+      "name": "slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slides_slug_idx": {
+          "name": "slides_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_id_idx": {
+          "name": "talks_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/0049_snapshot.json
+++ b/packages/database/migrations/meta/0049_snapshot.json
@@ -1,0 +1,1315 @@
+{
+  "id": "4eca708c-13fe-47f0-a606-1ca0d3db0358",
+  "prevId": "4288b0b5-8de0-4a85-b122-62720b63ca6c",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "tableTo": "article_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_id_idx": {
+          "name": "comments_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_tag": {
+      "name": "slide_tag",
+      "columns": {
+        "slide_id": {
+          "name": "slide_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slide_tag_slide_id_idx": {
+          "name": "slide_tag_slide_id_idx",
+          "columns": [
+            "slide_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_tag_id_idx": {
+          "name": "slide_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_unique_idx": {
+          "name": "slide_tag_unique_idx",
+          "columns": [
+            "slide_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "slide_tag_slide_id_slides_id_fk": {
+          "name": "slide_tag_slide_id_slides_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "tableTo": "slides",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "slide_tag_tag_id_tags_id_fk": {
+          "name": "slide_tag_tag_id_tags_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slides": {
+      "name": "slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slides_slug_idx": {
+          "name": "slides_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_id_idx": {
+          "name": "talks_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1778908531903,
       "tag": "0045_wild_supernaut",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "6",
+      "when": 1779173540389,
+      "tag": "0046_giant_mephisto",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1779174329657,
       "tag": "0048_wooden_starbolt",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "6",
+      "when": 1779174330690,
+      "tag": "0049_sparkling_randall_flagg",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -330,6 +330,13 @@
       "when": 1779173540389,
       "tag": "0046_giant_mephisto",
       "breakpoints": true
+    },
+    {
+      "idx": 47,
+      "version": "6",
+      "when": 1779174317722,
+      "tag": "0047_uneven_zzzax",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1779174317722,
       "tag": "0047_uneven_zzzax",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "6",
+      "when": 1779174329657,
+      "tag": "0048_wooden_starbolt",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Baseline 2026 で追加された4機能の解説記事を追加します。各記事 1 コミットに分けています。

- `feat(blog): add wasm-branch-hinting article` — WebAssembly Branch Hinting (Playground なし)
- `feat(blog): add baseline-shift article with SVG Playground` — SVG `<tspan>` 主軸 + SVG ベースの Playground
- `feat(blog): add toggleevent-source article with Playground` — `ToggleEvent.source` + メンバーカード切替の Playground
- `feat(blog): add open-pseudo article with Playground` — `:open` 疑似クラス + 4要素 + `:has(:open)` セクション点灯の Playground

各記事に対応する DB migration（0046〜0049）と Playground レジストリ更新も含みます。

Closes #1768
Closes #1769
Closes #1770
Closes #1771

## Test plan

- [ ] 各記事ページが表示される（/blog/wasm-branch-hinting, /blog/baseline-shift, /blog/toggleevent-source, /blog/open-pseudo）
- [ ] OG 画像が生成される
- [ ] BaselineStatus の featureId（wasm-branch-hinting / baseline-shift / toggleevent-source / open-pseudo）が解決される
- [ ] baseline-shift Playground: SVG tspan が選択値に応じてずれる
- [ ] toggleevent-source Playground: メンバーボタンで内容が切り替わり、debug panel に oldState/newState/source.* が出る。閉じるボタンで close 方向にも source が入る
- [ ] open-pseudo Playground: details/dialog/select/input(color) で `:open` の枠線 + `:has(:open)` のセクション背景が出る。dialog は backdrop クリックで閉じる