### PR TITLE
feat(blog): add Container Style Queries article

### DIFF
--- a/apps/main/src/app/_components/playgrounds/container-style-queries/container-style-queries-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/container-style-queries/container-style-queries-demo.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Playground } from '../playground';
+import { ContainerStyleQueriesDemo } from './container-style-queries-demo';
+
+const playgroundTitle = ContainerStyleQueriesDemo.name;
+
+const meta: Meta<typeof ContainerStyleQueriesDemo> = {
+  title: 'playgrounds/container-style-queries/ContainerStyleQueriesDemo',
+  component: ContainerStyleQueriesDemo,
+  decorators: [
+    (Story) => (
+      <Playground title={playgroundTitle}>
+        <Story />
+      </Playground>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ContainerStyleQueriesDemo>;
+
+export const Default: Story = {};

--- a/apps/main/src/app/_components/playgrounds/container-style-queries/container-style-queries-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/container-style-queries/container-style-queries-demo.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { Code, Radio } from '@k8o/arte-odyssey';
+import { useId, useState } from 'react';
+
+type Theme = 'light' | 'dark' | 'sepia';
+
+const themeOptions = [
+  { value: 'light', label: 'light' },
+  { value: 'dark', label: 'dark' },
+  { value: 'sepia', label: 'sepia' },
+] as const;
+
+const isTheme = (value: string): value is Theme =>
+  themeOptions.some((option) => option.value === value);
+
+export function ContainerStyleQueriesDemo() {
+  const [theme, setTheme] = useState<Theme>('light');
+  const labelId = useId();
+
+  return (
+    <div className="flex flex-col gap-6">
+      <style>{`
+        .csq-theme-root {
+          container-name: csq-theme;
+        }
+
+        .csq-card {
+          padding: 1rem;
+          border-radius: 0.5rem;
+          border: 1px solid currentColor;
+          transition: background-color 200ms, color 200ms, border-color 200ms;
+        }
+
+        @container csq-theme style(--csq-theme: light) {
+          .csq-card {
+            background-color: #ffffff;
+            color: #1f2937;
+            border-color: #d1d5db;
+          }
+        }
+
+        @container csq-theme style(--csq-theme: dark) {
+          .csq-card {
+            background-color: #0f172a;
+            color: #f1f5f9;
+            border-color: #334155;
+          }
+        }
+
+        @container csq-theme style(--csq-theme: sepia) {
+          .csq-card {
+            background-color: #f4ecd8;
+            color: #5b4636;
+            border-color: #c9b48f;
+          }
+        }
+      `}</style>
+
+      <div className="flex flex-col gap-2">
+        <p className="text-fg-mute text-sm">
+          親の<Code>--csq-theme</Code>を切り替えると、子の
+          <Code>.csq-card</Code>のスタイルが<Code>@container style()</Code>
+          で追従します。途中のラッパーは<Code>--csq-theme: light</Code>
+          に固定していますが、<Code>container-name</Code>
+          で対象を親に固定しているので、深い子孫のカードも親の値で判定されます。
+        </p>
+        <p className="text-fg-base text-sm font-bold" id={labelId}>
+          親の<Code>--csq-theme</Code>の値
+        </p>
+        <Radio
+          aria-labelledby={labelId}
+          name={`csq-theme-${labelId}`}
+          onChange={(event) => {
+            const next = event.target.value;
+            if (isTheme(next)) {
+              setTheme(next);
+            }
+          }}
+          options={themeOptions}
+          value={theme}
+        />
+      </div>
+
+      <div
+        className="csq-theme-root flex flex-col gap-3 rounded-lg p-4"
+        style={{ '--csq-theme': theme }}
+      >
+        <p className="text-fg-mute text-sm">
+          親 (<Code>{`--csq-theme: ${theme}`}</Code>)
+        </p>
+        <div className="csq-card">
+          <p className="font-bold">直近の子のカード</p>
+          <p className="text-sm">親の値に応じて色が変わります。</p>
+        </div>
+        <div
+          className="bg-bg-subtle rounded-md p-3"
+          style={{ '--csq-theme': 'light' }}
+        >
+          <p className="text-fg-mute mb-2 text-sm">
+            途中のラッパーは<Code>--csq-theme: light</Code>に固定
+          </p>
+          <div className="csq-card">
+            <p className="font-bold">深い子孫のカード</p>
+            <p className="text-sm">
+              途中で上書きされていても、
+              <code className="font-mono">container-name</code>
+              で親に固定しているので親の値で判定されます。
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/app/_components/playgrounds/container-style-queries/index.ts
+++ b/apps/main/src/app/_components/playgrounds/container-style-queries/index.ts
@@ -1,0 +1,19 @@
+import type { PlaygroundSection } from '../types';
+import { ContainerStyleQueriesDemo } from './container-style-queries-demo';
+
+export { ContainerStyleQueriesDemo } from './container-style-queries-demo';
+
+export const containerStyleQueriesSection: PlaygroundSection = {
+  id: 'container-style-queries',
+  title: 'Container style queries',
+  description:
+    '@container style()で祖先要素のカスタムプロパティの値を条件にスタイルを切り替えるCSSの仕組みです。テーマやコンテキストごとのスタイル分岐を子要素側で完結できます。',
+  type: 'blog',
+  slug: 'container-style-queries',
+  demos: [
+    {
+      component: ContainerStyleQueriesDemo,
+      title: 'Container style queriesで親のテーマに追従するカード',
+    },
+  ],
+};

--- a/apps/main/src/app/_components/playgrounds/index.ts
+++ b/apps/main/src/app/_components/playgrounds/index.ts
@@ -6,6 +6,7 @@ export * from './async-clipboard';
 export * from './baseline-shift';
 export * from './caret-position-from-point';
 export * from './composed-ranges';
+export * from './container-style-queries';
 export * from './content-visibility';
 export * from './contrast-color';
 export * from './crisp-edges';
@@ -41,6 +42,7 @@ import { asyncClipboardSection } from './async-clipboard';
 import { baselineShiftSection } from './baseline-shift';
 import { caretPositionFromPointSection } from './caret-position-from-point';
 import { composedRangesSection } from './composed-ranges';
+import { containerStyleQueriesSection } from './container-style-queries';
 import { contentVisibilitySection } from './content-visibility';
 import { contrastColorSection } from './contrast-color';
 import { crispEdgesSection } from './crisp-edges';
@@ -76,6 +78,7 @@ export const playgroundSections: PlaygroundSection[] = [
   baselineShiftSection,
   caretPositionFromPointSection,
   composedRangesSection,
+  containerStyleQueriesSection,
   contentVisibilitySection,
   contrastColorSection,
   crispEdgesSection,

--- a/apps/main/src/app/blog/(articles)/container-style-queries/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/container-style-queries/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+const slug = 'container-style-queries';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt,
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/container-style-queries'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/container-style-queries/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/container-style-queries/opengraph-image.tsx
@@ -1,0 +1,20 @@
+import { OgImage } from '@/app/_components/og-image';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+export const alt =
+  'Container style queriesでカスタムプロパティの値からスタイルを切り替える';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const blog = await getBlogContent('container-style-queries');
+
+  return OgImage({
+    category: 'Blog',
+    title: blog.title,
+  });
+}

--- a/apps/main/src/app/blog/(articles)/container-style-queries/page.mdx
+++ b/apps/main/src/app/blog/(articles)/container-style-queries/page.mdx
@@ -1,0 +1,118 @@
+---
+title: 'Container style queriesでカスタムプロパティの値からスタイルを切り替える'
+description: 'Container style queriesは@container style()で祖先要素のカスタムプロパティの値を条件にスタイルを切り替えるCSSの仕組みです。Baseline 2026で揃ったので、テーマやコンテキストごとのスタイル分岐を子要素側で完結できるようになりました。'
+createdAt: 2026-05-26
+updatedAt: 2026-05-26
+featureIds:
+  - container-style-queries
+---
+
+import { BaselineStatus } from '@k8o/arte-odyssey';
+import {
+  ContainerStyleQueriesDemo,
+  Playground,
+} from '@/app/_components/playgrounds';
+
+# Container style queriesでカスタムプロパティの値からスタイルを切り替える
+
+<BaselineStatus featureId="container-style-queries" />
+
+## はじめに
+
+Container queriesといえばサイズベースの`@container (width > 600px)`が定着していますが、もう一つの軸が`@container style()`関数を使ったスタイルクエリです。祖先要素のカスタムプロパティの値を条件にして、子要素のスタイルを切り替えられます。
+
+Baseline 2026で揃ったContainer style queriesを使うと、親はカスタムプロパティを立てるだけで、子のCSSがそれを読んでスタイルを決める形に書けます。
+
+## 基本構文
+
+スタイルクエリは、まず`container-name`で祖先にスタイルクエリの対象として名前を付け、その親の上で評価したいカスタムプロパティを`@container style(...)`の中に書きます。
+
+```css
+.theme {
+  /* [!hl] */
+  /* [!callout: スタイルクエリの対象にする親に名前を付ける] */
+  container-name: theme;
+  --theme: dark;
+}
+
+/* [!hl] */
+/* [!callout: theme と名前を付けた祖先の --theme が dark のときだけ当たる] */
+@container theme style(--theme: dark) {
+  .card {
+    background: black;
+    color: white;
+  }
+}
+```
+
+`container-type`を指定する必要はありません。`container-type: size`や`inline-size`はサイズクエリ専用で、スタイルクエリは指定なしでもデフォルトで全要素が暗黙のスタイルクエリコンテナとして扱われます。サイズクエリのようなcontainmentの指定は不要です。
+
+なお、`@container theme { ... }`のように条件を省略する書き方は、Chrome 148で追加されたname-only container queriesという別機能で、カスタムプロパティの値は見ません。スタイルクエリとして条件分岐したい場合は`style()`の中に条件を書きます。
+
+## サイズクエリとの違い
+
+`@container (width > 600px)`のようなサイズクエリは、コンテナの寸法を条件にしてレイアウトを変えるのが目的です。スタイルクエリの目的はそれとは別で、親に立っている値（テーマ、サイズスケール、状態など）に追従して子のスタイルを変えることにあります。
+
+条件として見るものも違います。サイズクエリはコンテナの幅や高さを見るので、親側に`container-type: inline-size`などのcontainment指定が必要です。スタイルクエリはコンテナのカスタムプロパティを見るだけなので、追加の`container-type`は必要ありません。
+
+## カスタムプロパティを使う
+
+`.surface`に立てた`--size`の値に応じて、子孫の`.button`のパディングを切り替える例です。
+
+```css
+.surface {
+  container-name: surface;
+  --size: md;
+}
+
+@container surface style(--size: md) {
+  .button {
+    padding: 8px 16px;
+  }
+}
+
+@container surface style(--size: sm) {
+  .button {
+    padding: 4px 8px;
+  }
+}
+```
+
+子コンポーネントに`size`用のクラスを増やさずに、親側で`--size`を切り替えるだけでまとめて反映されます。
+
+## 階層を超えて効かせる
+
+カスタムプロパティはCSSの継承に乗るので、`container-name`で祖先を固定しておけば、深い子孫からでも一番上の祖先を見に行けます。途中の要素が同じカスタムプロパティを上書きしていても、`container-name`で対象を固定しておけば影響を受けません。
+
+```html
+<section class="theme" style="--theme: dark">
+  <article style="--theme: light">
+    <p class="card">深い場所のカード</p>
+  </article>
+</section>
+```
+
+```css
+.theme {
+  container-name: theme;
+}
+
+@container theme style(--theme: dark) {
+  .card {
+    background: black;
+    color: white;
+  }
+}
+```
+
+`@container theme`はクエリの対象を`container-name: theme`が付いている祖先に固定しているので、`article`が`--theme: light`に上書きしていても、`section`の`dark`で判定されて`.card`にはdark側のスタイルが当たります。
+
+`container-name`を付けずに`@container style(--theme: dark)`と書くと、対象はもっとも近い祖先のスタイルクエリコンテナになります。CSS Conditional Rules Module Level 5の`container-type`の定義で、スタイルクエリは「any element can be a query container」と明記されているので、もっとも近い祖先のスタイルクエリコンテナは実質的にスタイルを当てる要素の親要素です。上の例だと`article`の`--theme: light`が見えて`.card`にはdark側が当たりません。テーマやモードのような上から降ってくる文脈は、名前付きで明示しておくのが安全です。
+
+<Playground title="Container style queriesで親のテーマに追従するカード">
+  <ContainerStyleQueriesDemo />
+</Playground>
+
+## おわりに
+
+Container style queriesは、テーマやサイズスケールといった親の文脈に追従する子のスタイルを素直にCSSだけで書く道具です。Baseline 2026で主要ブラウザに揃ったので、子コンポーネントに対してテーマ用のクラスや属性を配って回る処理を減らし、子側のCSSが親の値を読みに行く形に書き直していけます。

--- a/packages/database/migrations/0050_tense_energizer.sql
+++ b/packages/database/migrations/0050_tense_energizer.sql
@@ -1,0 +1,13 @@
+-- 新しいタグの追加
+INSERT INTO tags (id, name) VALUES (138, 'Container Queries');--> statement-breakpoint
+INSERT INTO tags (id, name) VALUES (139, 'Container Style Queries');--> statement-breakpoint
+-- ブログレコードの追加
+INSERT INTO blogs (id, slug, published, created_at)
+VALUES (74, 'container-style-queries', 1, '2026-05-26T00:00:00.000Z');--> statement-breakpoint
+-- ビューカウント初期化
+INSERT INTO blog_views (blog_id, views) VALUES (74, 0);--> statement-breakpoint
+-- タグ紐付け (CSS: 30, Baseline 2026: 99, Container Queries: 138, Container Style Queries: 139)
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (74, 30);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (74, 99);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (74, 138);--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (74, 139);

--- a/packages/database/migrations/meta/0050_snapshot.json
+++ b/packages/database/migrations/meta/0050_snapshot.json
@@ -1,0 +1,1315 @@
+{
+  "id": "1c5d5782-58e6-46f4-b11f-423c66647216",
+  "prevId": "4eca708c-13fe-47f0-a606-1ca0d3db0358",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "tableTo": "article_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_id_idx": {
+          "name": "comments_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_tag": {
+      "name": "slide_tag",
+      "columns": {
+        "slide_id": {
+          "name": "slide_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slide_tag_slide_id_idx": {
+          "name": "slide_tag_slide_id_idx",
+          "columns": [
+            "slide_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_tag_id_idx": {
+          "name": "slide_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_unique_idx": {
+          "name": "slide_tag_unique_idx",
+          "columns": [
+            "slide_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "slide_tag_slide_id_slides_id_fk": {
+          "name": "slide_tag_slide_id_slides_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "tableTo": "slides",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "slide_tag_tag_id_tags_id_fk": {
+          "name": "slide_tag_tag_id_tags_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slides": {
+      "name": "slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slides_slug_idx": {
+          "name": "slides_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_id_idx": {
+          "name": "talks_id_idx",
+          "columns": [
+            "id"
+          ],
+          "isUnique": false
+        },
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1779174330690,
       "tag": "0049_sparkling_randall_flagg",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "6",
+      "when": 1779549007209,
+      "tag": "0050_tense_energizer",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

Baseline 2026に揃った Container style queries (`@container style()`でカスタムプロパティを条件にする機能) を解説するブログ記事を追加します。

## 動機

Baseline 2026の一連の記事の流れに合わせて、CSS側の新しい仕組みを1本追加します。サイズクエリと混同しやすい一方で、テーマやサイズスケールの分岐を子側のCSSだけで完結できる強みがあり、`data-theme`属性 + JSや、親+子の二重クラス当て込みのような従来パターンを置き換えていける道具なので、独立した記事に値する量があります。

## 詳細

- **記事**: `apps/main/src/app/blog/(articles)/container-style-queries/` に `page.mdx` / `layout.tsx` / `opengraph-image.tsx` を追加
  - 構成: はじめに / 基本構文 / サイズクエリとの違い / カスタムプロパティを使う / 階層を超えて効かせる / おわりに
  - 基本構文の例で `--theme: dark` も親に立てて条件側と整合させる
  - name-only container queries (Chrome 148で追加された別機能) との混同を防ぐ短い注記
  - 深い階層の例では、途中の`article`で `--theme: light` に上書きしても`container-name`で固定した`section`が見られることを示す
- **Playground**: `apps/main/src/app/_components/playgrounds/container-style-queries/` に Radio で `--csq-theme` を `light` / `dark` / `sepia` に切り替えるデモを追加
  - 途中のラッパーを `--csq-theme: light` で固定して、`container-name`で親に対象を固定するふるまいを視覚的に示す
  - テーマで背景色が変わる範囲は素の `<code>` を使い、`currentColor` を継承してコントラストが崩れないようにする
  - Radioの`name`は`useId()`から派生させ、同じデモが複数描画されても衝突しない
- **マイグレーション**: `packages/database/migrations/0050_tense_energizer.sql`
  - 新タグ: `Container Queries` (138), `Container Style Queries` (139)
  - ブログレコード: id=74, slug=`container-style-queries`, 公開済み, 2026-05-26
  - タグ紐付け: CSS (30) / Baseline 2026 (99) / 138 / 139

## 気をつけるポイント

- 記事内の `@container theme style(--theme: dark)` の例は、`.theme` に `container-name: theme` と `--theme: dark` の両方が立っている前提です。後者を落とすと条件側と整合しなくなります。
- Playgroundは「途中のラッパーが`--theme`を上書きしても親のテーマで判定される」ことを示すデモなので、`--csq-theme: light`を固定したラッパーは意図的なものです。

## 影響範囲

- 新規記事1本の追加のみ。既存ページのレイアウト・スタイル・ルーティングには影響しません。
- `playgrounds/index.ts` への追加は新しい`containerStyleQueriesSection`の登録のみで、既存セクションの順序・内容は変えていません。

## テスト

- `pnpm -w run type-check` 通過
- `pnpm -w run check` エラーなし (既存warnings 76件のみ)
- ローカルDBにマイグレーション適用済み (タグ名・公開日を確認)