### PR TITLE
feat: adminにお問い合わせ閲覧ページを追加

### DIFF
--- a/apps/admin/src/app/(authenticated)/_components/admin-header/admin-header.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/admin-header/admin-header.tsx
@@ -23,6 +23,12 @@ export const AdminHeader = () => (
           </Link>
           <Link
             className="text-fg-mute hover:text-fg-base text-sm transition-colors"
+            href="/comments"
+          >
+            お問い合わせ
+          </Link>
+          <Link
+            className="text-fg-mute hover:text-fg-base text-sm transition-colors"
             href="/reports"
           >
             レポート

--- a/apps/admin/src/app/(authenticated)/comments/_components/comment-list/comment-list.tsx
+++ b/apps/admin/src/app/(authenticated)/comments/_components/comment-list/comment-list.tsx
@@ -1,0 +1,69 @@
+import { formatDate } from '@repo/helpers/date/format';
+import type { FC } from 'react';
+
+import type { CommentItem } from '@/features/comments/interface/queries';
+
+const BLOG_BASE_URL = 'https://k8o.me/blog';
+
+export const CommentList: FC<{ items: CommentItem[] }> = ({ items }) => {
+  if (items.length === 0) {
+    return (
+      <p className="text-fg-mute py-12 text-center text-sm">
+        まだお問い合わせはありません。
+      </p>
+    );
+  }
+
+  return (
+    <ol className="flex flex-col gap-3">
+      {items.map((item) => (
+        <li
+          className="border-border-base bg-bg-base flex flex-col gap-3 rounded-xl border p-5"
+          key={item.id}
+        >
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="flex flex-wrap items-center gap-2 text-xs">
+              {item.feedbackName !== null && (
+                <span className="bg-bg-mute text-fg-base rounded-full px-2 py-0.5 font-medium">
+                  {item.feedbackName}
+                </span>
+              )}
+              {item.blogSlug !== null && (
+                <a
+                  className="text-fg-mute hover:text-fg-base inline-flex items-center gap-1 underline transition-colors"
+                  href={`${BLOG_BASE_URL}/${item.blogSlug}`}
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  /blog/{item.blogSlug}
+                </a>
+              )}
+              {item.blogSlug === null && (
+                <span className="text-fg-subtle text-xs">未紐づけ</span>
+              )}
+            </div>
+            <div className="text-fg-subtle flex items-center gap-3 text-xs">
+              <time dateTime={item.createdAt}>
+                {formatDate(new Date(item.createdAt), 'yyyy年M月d日 HH:mm')}
+              </time>
+              <span>
+                {item.sentAt === null ? (
+                  <span className="text-fg-warning">未通知</span>
+                ) : (
+                  '通知済み'
+                )}
+              </span>
+            </div>
+          </div>
+          {item.message !== null && item.message !== '' ? (
+            <p className="text-fg-base text-sm leading-relaxed whitespace-pre-wrap">
+              {item.message}
+            </p>
+          ) : (
+            <p className="text-fg-subtle text-sm italic">本文なし</p>
+          )}
+        </li>
+      ))}
+    </ol>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/comments/_components/comment-list/index.ts
+++ b/apps/admin/src/app/(authenticated)/comments/_components/comment-list/index.ts
@@ -1,0 +1,1 @@
+export { CommentList } from './comment-list';

--- a/apps/admin/src/app/(authenticated)/comments/page.tsx
+++ b/apps/admin/src/app/(authenticated)/comments/page.tsx
@@ -1,0 +1,41 @@
+import { StatCard } from '@/app/(authenticated)/_components/stat-card/stat-card';
+import { getComments } from '@/features/comments/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+
+import { CommentList } from './_components/comment-list';
+
+export default async function CommentsPage() {
+  await verifySession();
+
+  const items = await getComments();
+  const total = items.length;
+  const unsent = items.filter((item) => item.sentAt === null).length;
+  const sent = total - unsent;
+  const blogLinked = items.filter((item) => item.blogSlug !== null).length;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div>
+        <h2 className="text-2xl font-bold">お問い合わせ</h2>
+        <p className="text-fg-mute mt-2 text-sm">
+          ブログ記事のフィードバックフォーム経由で届いたお問い合わせとコメントを確認します。
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+        <StatCard label="総件数" value={String(total)} />
+        <StatCard
+          description={`通知済み: ${sent}件`}
+          label="未通知"
+          value={String(unsent)}
+        />
+        <StatCard label="ブログ紐付け" value={String(blogLinked)} />
+      </div>
+
+      <section className="flex flex-col gap-4">
+        <h3 className="text-lg font-bold">一覧</h3>
+        <CommentList items={items} />
+      </section>
+    </div>
+  );
+}

--- a/apps/admin/src/features/comments/application/get-comments.ts
+++ b/apps/admin/src/features/comments/application/get-comments.ts
@@ -1,44 +1,8 @@
-import { db } from '@repo/database';
-import { desc, eq } from 'drizzle-orm';
+import {
+  type CommentRecord,
+  findComments,
+} from '../infrastructure/comment-repository';
 
-export type CommentItem = {
-  id: number;
-  message: string | null;
-  createdAt: string;
-  sentAt: string | null;
-  feedbackName: string | null;
-  blogSlug: string | null;
-};
+export type CommentItem = CommentRecord;
 
-/**
- * 第三者から届いた問い合わせ・フィードバックを取得する。
- * blog_comment 経由でブログ記事に紐づいている場合は slug も返す。
- */
-export const getComments = async (): Promise<CommentItem[]> => {
-  const rows = await db
-    .select({
-      id: db._schema.comments.id,
-      message: db._schema.comments.message,
-      createdAt: db._schema.comments.createdAt,
-      sentAt: db._schema.comments.sentAt,
-      feedbackName: db._schema.feedbacks.name,
-      blogSlug: db._schema.blogs.slug,
-    })
-    .from(db._schema.comments)
-    .leftJoin(
-      db._schema.feedbacks,
-      eq(db._schema.comments.feedbackId, db._schema.feedbacks.id),
-    )
-    .leftJoin(
-      db._schema.blogComment,
-      eq(db._schema.blogComment.commentId, db._schema.comments.id),
-    )
-    .leftJoin(
-      db._schema.blogs,
-      eq(db._schema.blogs.id, db._schema.blogComment.blogId),
-    )
-    .orderBy(desc(db._schema.comments.createdAt))
-    .limit(200);
-
-  return rows;
-};
+export const getComments = (): Promise<CommentItem[]> => findComments();

--- a/apps/admin/src/features/comments/application/get-comments.ts
+++ b/apps/admin/src/features/comments/application/get-comments.ts
@@ -1,0 +1,44 @@
+import { db } from '@repo/database';
+import { desc, eq } from 'drizzle-orm';
+
+export type CommentItem = {
+  id: number;
+  message: string | null;
+  createdAt: string;
+  sentAt: string | null;
+  feedbackName: string | null;
+  blogSlug: string | null;
+};
+
+/**
+ * 第三者から届いた問い合わせ・フィードバックを取得する。
+ * blog_comment 経由でブログ記事に紐づいている場合は slug も返す。
+ */
+export const getComments = async (): Promise<CommentItem[]> => {
+  const rows = await db
+    .select({
+      id: db._schema.comments.id,
+      message: db._schema.comments.message,
+      createdAt: db._schema.comments.createdAt,
+      sentAt: db._schema.comments.sentAt,
+      feedbackName: db._schema.feedbacks.name,
+      blogSlug: db._schema.blogs.slug,
+    })
+    .from(db._schema.comments)
+    .leftJoin(
+      db._schema.feedbacks,
+      eq(db._schema.comments.feedbackId, db._schema.feedbacks.id),
+    )
+    .leftJoin(
+      db._schema.blogComment,
+      eq(db._schema.blogComment.commentId, db._schema.comments.id),
+    )
+    .leftJoin(
+      db._schema.blogs,
+      eq(db._schema.blogs.id, db._schema.blogComment.blogId),
+    )
+    .orderBy(desc(db._schema.comments.createdAt))
+    .limit(200);
+
+  return rows;
+};

--- a/apps/admin/src/features/comments/infrastructure/comment-repository.ts
+++ b/apps/admin/src/features/comments/infrastructure/comment-repository.ts
@@ -1,8 +1,73 @@
 import { db } from '@repo/database';
-import { and, eq, inArray, isNull } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull } from 'drizzle-orm';
 
 export type ClaimedComment = {
   id: number;
+};
+
+export type CommentRecord = {
+  id: number;
+  message: string | null;
+  createdAt: string;
+  sentAt: string | null;
+  feedbackName: string | null;
+  blogSlug: string | null;
+};
+
+/**
+ * 第三者から届いた問い合わせ・フィードバック一覧を取得する。
+ * blog_comment.commentId に unique 制約が無く 1:N の可能性があるため、
+ * 一覧本体と blog 紐付けを別クエリで取得して JS でマージする。
+ */
+export const findComments = async (limit = 200): Promise<CommentRecord[]> => {
+  const commentRows = await db
+    .select({
+      id: db._schema.comments.id,
+      message: db._schema.comments.message,
+      createdAt: db._schema.comments.createdAt,
+      sentAt: db._schema.comments.sentAt,
+      feedbackName: db._schema.feedbacks.name,
+    })
+    .from(db._schema.comments)
+    .leftJoin(
+      db._schema.feedbacks,
+      eq(db._schema.comments.feedbackId, db._schema.feedbacks.id),
+    )
+    .orderBy(desc(db._schema.comments.createdAt))
+    .limit(limit);
+
+  if (commentRows.length === 0) {
+    return [];
+  }
+
+  const commentIds = commentRows.map((row) => row.id);
+  const blogLinks = await db
+    .select({
+      commentId: db._schema.blogComment.commentId,
+      blogSlug: db._schema.blogs.slug,
+    })
+    .from(db._schema.blogComment)
+    .innerJoin(
+      db._schema.blogs,
+      eq(db._schema.blogs.id, db._schema.blogComment.blogId),
+    )
+    .where(inArray(db._schema.blogComment.commentId, commentIds));
+
+  const slugByCommentId = new Map<number, string>();
+  for (const link of blogLinks) {
+    if (!slugByCommentId.has(link.commentId)) {
+      slugByCommentId.set(link.commentId, link.blogSlug);
+    }
+  }
+
+  return commentRows.map((row) => ({
+    id: row.id,
+    message: row.message,
+    createdAt: row.createdAt,
+    sentAt: row.sentAt,
+    feedbackName: row.feedbackName,
+    blogSlug: slugByCommentId.get(row.id) ?? null,
+  }));
 };
 
 export const claimUnsentComments = async (

--- a/apps/admin/src/features/comments/interface/queries.ts
+++ b/apps/admin/src/features/comments/interface/queries.ts
@@ -1,0 +1,13 @@
+import { cacheLife } from 'next/cache';
+
+import { getComments as _getComments } from '@/features/comments/application/get-comments';
+
+export const getComments = async () => {
+  'use cache';
+  cacheLife('minutes');
+
+  const items = await _getComments();
+  return items;
+};
+
+export type { CommentItem } from '@/features/comments/application/get-comments';

--- a/apps/admin/src/features/comments/interface/queries.ts
+++ b/apps/admin/src/features/comments/interface/queries.ts
@@ -1,8 +1,11 @@
 import { cacheLife } from 'next/cache';
 
-import { getComments as _getComments } from '@/features/comments/application/get-comments';
+import {
+  type CommentItem,
+  getComments as _getComments,
+} from '@/features/comments/application/get-comments';
 
-export const getComments = async () => {
+export const getComments = async (): Promise<CommentItem[]> => {
   'use cache';
   cacheLife('minutes');
 


### PR DESCRIPTION
## 概要

admin に `/comments` ページを追加し、ブログのフィードバックフォーム経由で届いたお問い合わせを認証済み画面で確認できるようにする。

## 動機

お問い合わせの存在はこれまで Push 通知（k8o-push 経由）でのみ把握していた。
将来的に Push 購読を一般公開する想定だが、お問い合わせ内容は第三者から預かったものなので公開購読者に流れるのは好ましくない。
購読の公開とお問い合わせの可視化を切り離すため、まず admin 側に固定の閲覧場所を用意する。

## 詳細

- `/comments` ルートを `(authenticated)` 配下に追加（Better Auth で保護）
- ヘッダーナビに「お問い合わせ」リンクを追加（よんでいるもの の隣）
- StatCard で「総件数 / 未通知 / ブログ紐付け」のサマリーを表示
- `CommentList` で一覧表示
  - フィードバック種別バッジ（feedbacks.name: good / bad / informative など）
  - ブログ紐付けがあれば slug を `k8o.me/blog/<slug>` への外部リンクで表示、無ければ「未紐づけ」
  - 投稿日時（yyyy年M月d日 HH:mm）
  - 通知ステータス（未通知 / 通知済み）
  - メッセージ本文（whitespace-pre-wrap）
- `features/comments/application/get-comments.ts` で `comments` → `feedbacks` / `blog_comment` / `blogs` を leftJoin した1クエリで取得（200件 limit、createdAt DESC）
- `features/comments/interface/queries.ts` で `cacheLife('minutes')` の薄い wrapper

## 気をつけるポイント

- お問い合わせの内容は第三者の文章を含むため、このページは **必ず認証配下** に置く。直接 `verifySession()` を呼ぶ実装にしている
- 200件で打ち切っているので将来件数が増えたらページネーション検討
- ブログ「タイトル」は MDX フロントマターにあり apps/admin から読めないため、slug のみ表示。クリックで k8o.me 側の記事を確認可能

## 影響範囲

- admin: `/comments` の新規追加とナビ更新のみ。既存ページは影響なし
- DB: 読み取り専用、スキーマ変更なし
- main: 影響なし
- k8o-push: 影響なし

## 後続予定（このPRには含まない）

- お問い合わせ通知（comments cron）を Push 配信から外す
- Push 購読の公開・購読ページの apps/main への取り込み