### PR TITLE
docs: bot レビューへの inline reply を控える方針を追記

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,12 @@ type: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`
 - `main` - 本番 (Vercelデプロイ)
 - `feature/*`, `fix/*`, `refactor/*`
 
+## PR レビュー対応
+
+- bot（k8o-bot など自動レビュアー）の inline コメントには **返信しない**。返信するとさらに自動レビューが走り、ノイズが増える
+- bot レビューへの対応は、修正コミットを push するだけで完結させる（コメントスレッドの解決は人間が判断する）
+- 人間レビュアーへの reply は通常通り行ってよい
+
 ## Git Hooks (vite-plus)
 
 vite-plus (vp) 内蔵の hook 機構を使う。`vp config` が `.vite-hooks/_` にディスパッチャを生成し、`core.hooksPath` をそこに切り替える（pnpm install 時に自動実行）。


### PR DESCRIPTION
## 概要

AGENTS.md に「PR レビュー対応」セクションを追加し、bot 自動レビュアーへの inline reply を控える方針を明記する。

## 動機

PR #1785 でレビュー対応した際、bot の inline コメントに返信すると追加の自動レビューが走り、無駄なコメントが増えることが分かった。
作業ノイズが増えるため、bot レビューには返信せず、修正コミットの push のみで対応する運用に揃える。

## 詳細

- `AGENTS.md` の「ブランチ戦略」と「Git Hooks」の間に「PR レビュー対応」セクションを追加
- bot レビューには inline reply しない
- 修正コミットの push のみで対応を完結させる
- 人間レビュアーへの reply は通常通り行ってよい

## 影響範囲

- ドキュメントのみ。コードへの影響なし