### PR TITLE
refactor: date-fns依存を削除しformatDateを標準Date APIで再実装

### DIFF
--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -35,12 +35,7 @@ export default defineConfig({
           storybookTest({ configDir: path.join(dirname, '.storybook') }),
         ],
         optimizeDeps: {
-          include: [
-            'next/link',
-            'better-auth/react',
-            '@repo/helpers > date-fns',
-            '@repo/helpers > date-fns/locale',
-          ],
+          include: ['next/link', 'better-auth/react'],
         },
         test: {
           name: 'storybook',

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -82,7 +82,6 @@
   "dependencies": {
     "@vercel/functions": "3.6.0",
     "clsx": "2.1.1",
-    "date-fns": "4.3.0",
     "tailwind-merge": "3.6.0",
     "to-vfile": "8.0.0",
     "vfile-matter": "5.0.1"

--- a/packages/helpers/src/date/format.ts
+++ b/packages/helpers/src/date/format.ts
@@ -1,4 +1,3 @@
-// 日本語ロケール固定の日付フォーマッタ。標準のDate APIのみで実装し、外部依存を持たない。
 const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'] as const;
 
 const pad2 = (n: number): string => String(n).padStart(2, '0');

--- a/packages/helpers/src/date/format.ts
+++ b/packages/helpers/src/date/format.ts
@@ -1,8 +1,29 @@
-import { format } from 'date-fns';
-import { ja } from 'date-fns/locale';
+// 日本語ロケール固定の日付フォーマッタ。標準のDate APIのみで実装し、外部依存を持たない。
+const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'] as const;
 
-export const formatDate = (date: Date, formatStr = 'yyyy年M月d日(E)'): string =>
-  format(date, formatStr, { locale: ja });
+const pad2 = (n: number): string => String(n).padStart(2, '0');
+
+export const formatDate = (
+  date: Date,
+  formatStr = 'yyyy年M月d日(E)',
+): string => {
+  const replacements: Record<string, string> = {
+    yyyy: String(date.getFullYear()),
+    MM: pad2(date.getMonth() + 1),
+    M: String(date.getMonth() + 1),
+    dd: pad2(date.getDate()),
+    d: String(date.getDate()),
+    HH: pad2(date.getHours()),
+    mm: pad2(date.getMinutes()),
+    E: WEEKDAYS[date.getDay()] ?? '',
+  };
+
+  // 長いトークンを先に評価する（MM→M, dd→d, HH, mm, yyyy）
+  return formatStr.replaceAll(
+    /yyyy|MM|dd|HH|mm|M|d|E/g,
+    (token) => replacements[token] ?? token,
+  );
+};
 
 if (import.meta.vitest) {
   it('日付をデフォルト設定でフォーマットする', () => {
@@ -23,5 +44,14 @@ if (import.meta.vitest) {
     const result = formatDate(new Date(), 'yyyy年M月d日');
 
     expect(result).toBe(expected);
+  });
+
+  it('ゼロ埋め・時刻付きのフォーマットに対応する', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime('2022-03-05T09:08:00Z');
+
+    expect(formatDate(new Date(), 'yyyy/MM/dd HH:mm')).toBe('2022/03/05 09:08');
+    expect(formatDate(new Date(), 'M/d')).toBe('3/5');
+    expect(formatDate(new Date(), 'yyyy')).toBe('2022');
   });
 }

--- a/packages/helpers/src/date/format.ts
+++ b/packages/helpers/src/date/format.ts
@@ -20,7 +20,7 @@ export const formatDate = (
 
   // 長いトークンを先に評価する（MM→M, dd→d, HH, mm, yyyy）
   return formatStr.replaceAll(
-    /yyyy|MM|dd|HH|mm|M|d|E/g,
+    /yyyy|MM|dd|HH|mm|M|d|E/gu,
     (token) => replacements[token] ?? token,
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -444,9 +444,6 @@ importers:
       clsx:
         specifier: 2.1.1
         version: 2.1.1
-      date-fns:
-        specifier: 4.3.0
-        version: 4.3.0
       tailwind-merge:
         specifier: 3.6.0
         version: 3.6.0
@@ -4088,9 +4085,6 @@ packages:
   d3-timer@3.0.1:
     resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
     engines: {node: '>=12'}
-
-  date-fns@4.3.0:
-    resolution: {integrity: sha512-OYcL+3N/jyWbYdFGqoMAhytDgxP9pbYPUUiRCOgn4Fewaadk9l/Wam4Avciiyp2BgkpfQyBV9B+ehnVJych+eQ==}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -9507,8 +9501,6 @@ snapshots:
       d3-array: 3.2.4
 
   d3-timer@3.0.1: {}
-
-  date-fns@4.3.0: {}
 
   debug@4.4.3:
     dependencies:


### PR DESCRIPTION
## 概要

`@repo/helpers` の `formatDate` から `date-fns` 依存を撤去し、標準の `Date` API のみで再実装した。

## 背景・なぜ

調査の結果、`date-fns` はリポジトリ全体で `packages/helpers/src/date/format.ts` の `formatDate` **1箇所**でしか直接使われておらず、用途は「日本語ロケール付きのトークン整形」だけだった。

- ロケール・曜日表記は標準の `Intl` / `Date` でネイティブに表現できる
- 出力は日本語固定、使用フォーマットパターンも有限（`yyyy年M月d日(E)` / `yyyy/MM/dd HH:mm` / `M/d` / `yyyy` など7種）
- 唯一の日付演算 `compareDate` は既に素の `getTime()` 実装で date-fns 不要

このため「標準で十分に担保できる」と判断し、依存を1つ削減した。Temporal は表示用途では `Intl` に委譲するだけで利点がなく、見送り。

## 変更内容

- **`packages/helpers/src/date/format.ts`**: ローカル時刻の `Date` ゲッター + 曜日配列によるトークン置換で再実装。シグネチャ `(date, formatStr = 'yyyy年M月d日(E)')` は**据え置き**のため呼び出し側17ファイルは無変更。タイムゾーン基準も従来の「ローカル時刻」のまま。時刻/ゼロ埋め/曜日のテストケースを追加
- **`packages/helpers/package.json`**: `date-fns` 依存を削除
- **`apps/admin/vitest.config.ts`**: `optimizeDeps.include` から `date-fns` 系2行を削除

## レビュー観点

- 出力互換性は検証済み（既存の `2022年1月1日(土)` 等と完全一致）
- helpers テスト **87 passed** / 型チェック通過 / ソース・lockfile とも `date-fns` 参照ゼロ
- 時刻テストは helpers の `TZ: 'UTC'` 固定環境前提で安定