### PR TITLE
fix: parseSafeHslでhが101〜360のとき100に丸められるバグを修正

### DIFF
--- a/packages/helpers/src/color/convert.ts
+++ b/packages/helpers/src/color/convert.ts
@@ -16,8 +16,11 @@ export const parseSafeHsl = (number: number, part: keyof HSL): number => {
   if (Number.isNaN(number)) {
     return 100;
   }
-  if (part === 'h' && (number < 0 || number > 360)) {
-    return 360;
+  if (part === 'h') {
+    if (number < 0 || number > 360) {
+      return 360;
+    }
+    return number;
   }
   if (part === 'a') {
     return parseSafeAlpha(number);
@@ -190,10 +193,10 @@ if (import.meta.vitest) {
       expect(parseSafeHsl(-1, 'h')).toBe(360);
     });
 
-    // 既知の挙動: hの上限チェックは>360のみで、その後の汎用clampにより
-    // 101〜360のhは100に丸められてしまう（抽出前からの挙動を保持）
-    it('hが101〜360の場合は100に丸められる（既存挙動）', () => {
-      expect(parseSafeHsl(180, 'h')).toBe(100);
+    it('hが0〜360の範囲内はそのまま返す', () => {
+      expect(parseSafeHsl(180, 'h')).toBe(180);
+      expect(parseSafeHsl(0, 'h')).toBe(0);
+      expect(parseSafeHsl(360, 'h')).toBe(360);
     });
 
     it('s/lは0〜100を超えると100に丸める', () => {


### PR DESCRIPTION
## 概要

`packages/helpers/src/color/convert.ts` の `parseSafeHsl` に存在する hue clamp のバグを修正する。

## 問題

`parseSafeHsl(number, part)` の hue（`part === 'h'`）チェックは上限 `number > 360` しか見ておらず早期 return していなかった。そのため有効値であるはずの **h=101〜360 が、後続の汎用 clamp `if (number < 0 || number > 100) return 100;` に巻き込まれ 100 に丸められていた**。

```ts
if (part === 'h' && (number < 0 || number > 360)) return 360;
// ...
if (number < 0 || number > 100) return 100; // ← h=180 などがここで100にclampされる
```

影響: `apps/main` の color-converter で HSL 入力に h>100 を入れると 100 に固定され、`hslToHex` 経由の変換結果も不正になっていた。

## 変更内容

- `part === 'h'` を独立ブロックにして早期 return し、0〜360 内はそのまま返すよう修正。範囲外（`<0` / `>360`）は、この `parseSafe*` 系の「範囲外→最大の安全既定値を返す」という一貫した設計、および既存テスト（`-1 → 360`）に合わせて **360** を維持。
- バグを保持していた in-source test `'hが101〜360の場合は100に丸められる（既存挙動）'` を、正しい期待挙動 `'hが0〜360の範囲内はそのまま返す'`（180→180 / 0→0 / 360→360）へ更新。

## 検証

- ✅ in-source test 14件すべてパス（`@repo/helpers`）
- ✅ `type-check`（tsgo）エラーなし
- ✅ `vp check`（lint / format）警告・エラーなし

## レビュアー向けメモ

- s/l（0〜100 clamp）と a（0〜1 clamp）の挙動は変更していない。
- hue 範囲外を `0` クランプではなく `360` にしている点は設計判断（上記理由）。`0` が望ましい場合は要相談。