### PR TITLE
feat(reading-list): 要約を「続きを読む」で全文展開できるようにする

### DIFF
--- a/apps/main/src/app/reading-list/_components/reading-card/body.tsx
+++ b/apps/main/src/app/reading-list/_components/reading-card/body.tsx
@@ -88,6 +88,8 @@ export const ReadingCardBody: FC<{
             // カードを覆う overlay リンクより前面に出して、独立操作可能にする
             <button
               aria-controls={bodyId}
+              // 展開後はボタン自体を消すため常に collapsed。disclosure として属性は明示する
+              aria-expanded={false}
               className="text-fg-mute hover:text-fg-base relative z-10 cursor-pointer self-start text-xs underline underline-offset-2"
               onClick={(e) => {
                 e.preventDefault();

--- a/apps/main/src/app/reading-list/_components/reading-card/body.tsx
+++ b/apps/main/src/app/reading-list/_components/reading-card/body.tsx
@@ -18,8 +18,7 @@ const CLAMP_CLASS =
   'vertical:block vertical:max-block-[8em] vertical:overflow-hidden line-clamp-2';
 
 // 本文がクランプで切り詰められているか（＝展開の余地があるか）を監視する。
-// 展開中は計測しない。クランプ解除で scrollHeight === clientHeight になり
-// 「閉じる」トグルが消えてしまうのを防ぐため、直近の判定を保持する。
+// 展開後は「続きを読む」を出さないので計測も不要。enabled=false で止める。
 const useIsClamped = (
   enabled: boolean,
   body: string | undefined,
@@ -49,7 +48,7 @@ const useIsClamped = (
 
 // 本文（要約優先・無ければ説明文）と「AIで要約」ボタンを表示する。
 // 要約が無い記事だけボタンを出し、押すと生成→その場で表示に反映する。
-// 本文が2行を超える場合は「続きを読む」で全文展開できる。
+// 本文が2行を超える場合は「続きを読む」で全文展開する（展開後はボタンを消す一方向）。
 export const ReadingCardBody: FC<{
   articleId: number;
   description: string | null;
@@ -85,20 +84,19 @@ export const ReadingCardBody: FC<{
           >
             {body}
           </p>
-          {(isClamped || expanded) && (
+          {!expanded && isClamped && (
             // カードを覆う overlay リンクより前面に出して、独立操作可能にする
             <button
               aria-controls={bodyId}
-              aria-expanded={expanded}
               className="text-fg-mute hover:text-fg-base relative z-10 cursor-pointer self-start text-xs underline underline-offset-2"
               onClick={(e) => {
                 e.preventDefault();
                 e.stopPropagation();
-                setExpanded((prev) => !prev);
+                setExpanded(true);
               }}
               type="button"
             >
-              {expanded ? '閉じる' : '続きを読む'}
+              続きを読む
             </button>
           )}
         </>

--- a/apps/main/src/app/reading-list/_components/reading-card/body.tsx
+++ b/apps/main/src/app/reading-list/_components/reading-card/body.tsx
@@ -1,22 +1,67 @@
 'use client';
 
 import { Button } from '@k8o/arte-odyssey';
-import { type FC, useState } from 'react';
+import {
+  type FC,
+  type RefObject,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+} from 'react';
 
 import { generateArticleSummary } from '@/features/reading-list/interface/article-actions';
 import { useAsyncAction } from '@/shared/hooks/use-async-action';
 
+// 折りたたみ時のクランプ（横書きは2行、縦書きは block 方向 8em で省略）
+const CLAMP_CLASS =
+  'vertical:block vertical:max-block-[8em] vertical:overflow-hidden line-clamp-2';
+
+// 本文がクランプで切り詰められているか（＝展開の余地があるか）を監視する。
+// 展開中は計測しない。クランプ解除で scrollHeight === clientHeight になり
+// 「閉じる」トグルが消えてしまうのを防ぐため、直近の判定を保持する。
+const useIsClamped = (
+  enabled: boolean,
+  body: string | undefined,
+): [RefObject<HTMLParagraphElement | null>, boolean] => {
+  const ref = useRef<HTMLParagraphElement>(null);
+  const [isClamped, setIsClamped] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (el === null || !enabled) {
+      return undefined;
+    }
+    const measure = (): void => {
+      setIsClamped(el.scrollHeight > el.clientHeight);
+    };
+    measure();
+    // 折り返し行数は要素幅に依存するため、リサイズに追従して再計測する
+    const observer = new ResizeObserver(measure);
+    observer.observe(el);
+    return () => {
+      observer.disconnect();
+    };
+  }, [enabled, body]);
+
+  return [ref, isClamped];
+};
+
 // 本文（要約優先・無ければ説明文）と「AIで要約」ボタンを表示する。
 // 要約が無い記事だけボタンを出し、押すと生成→その場で表示に反映する。
+// 本文が2行を超える場合は「続きを読む」で全文展開できる。
 export const ReadingCardBody: FC<{
   articleId: number;
   description: string | null;
   initialSummary: string | null;
 }> = ({ articleId, description, initialSummary }) => {
   const [summary, setSummary] = useState(initialSummary);
+  const [expanded, setExpanded] = useState(false);
   const { isPending, error, run } = useAsyncAction();
 
   const body = summary ?? description ?? undefined;
+  const [bodyRef, isClamped] = useIsClamped(!expanded, body);
+  const bodyId = useId();
 
   const handleGenerate = () => {
     run(() => generateArticleSummary(articleId), {
@@ -31,12 +76,32 @@ export const ReadingCardBody: FC<{
   return (
     <>
       {body !== undefined && (
-        <p
-          aria-live="polite"
-          className="text-fg-mute vertical:block vertical:max-block-[8em] vertical:overflow-hidden line-clamp-2 text-sm"
-        >
-          {body}
-        </p>
+        <>
+          <p
+            aria-live="polite"
+            className={`text-fg-mute text-sm ${expanded ? '' : CLAMP_CLASS}`}
+            id={bodyId}
+            ref={bodyRef}
+          >
+            {body}
+          </p>
+          {(isClamped || expanded) && (
+            // カードを覆う overlay リンクより前面に出して、独立操作可能にする
+            <button
+              aria-controls={bodyId}
+              aria-expanded={expanded}
+              className="text-fg-mute hover:text-fg-base relative z-10 cursor-pointer self-start text-xs underline underline-offset-2"
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                setExpanded((prev) => !prev);
+              }}
+              type="button"
+            >
+              {expanded ? '閉じる' : '続きを読む'}
+            </button>
+          )}
+        </>
       )}
       {summary === null && (
         // カードを覆う overlay リンクより前面に出して、ボタンを独立操作可能にする

--- a/apps/main/src/app/reading-list/_components/reading-card/reading-card.stories.tsx
+++ b/apps/main/src/app/reading-list/_components/reading-card/reading-card.stories.tsx
@@ -71,6 +71,28 @@ export const GenerateSummary: Story = {
   },
 };
 
+// 本文が長い記事。2行で省略し、「続きを読む」で全文展開／「閉じる」で再び折りたたむ。
+export const ExpandableBody: Story = {
+  args: {
+    summary:
+      '型安全なルーティングを提供するTanStack Routerの入門記事。ファイルベースルーティング、検索パラメータの型付け、データローダー、コード分割、認証ガードまで、実プロジェクトで必要になる要素を一通り順を追って解説しており、Next.jsやReact Routerからの移行も具体例つきで触れられている。',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const expand = await canvas.findByRole('button', { name: '続きを読む' });
+    await userEvent.click(expand);
+
+    const collapse = await canvas.findByRole('button', { name: '閉じる' });
+    await expect(collapse).toBeInTheDocument();
+
+    await userEvent.click(collapse);
+    await expect(
+      await canvas.findByRole('button', { name: '続きを読む' }),
+    ).toBeInTheDocument();
+  },
+};
+
 // OGP 画像が取得できなかった記事。テキストのみで成立させる。
 export const NoImage: Story = {
   args: {

--- a/apps/main/src/app/reading-list/_components/reading-card/reading-card.stories.tsx
+++ b/apps/main/src/app/reading-list/_components/reading-card/reading-card.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { expect, userEvent, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { ReadingCard } from './reading-card';
 
@@ -71,7 +71,7 @@ export const GenerateSummary: Story = {
   },
 };
 
-// 本文が長い記事。2行で省略し、「続きを読む」で全文展開／「閉じる」で再び折りたたむ。
+// 本文が長い記事。2行で省略し、「続きを読む」で全文展開する（展開後はボタンが消える）。
 export const ExpandableBody: Story = {
   args: {
     summary:
@@ -83,13 +83,12 @@ export const ExpandableBody: Story = {
     const expand = await canvas.findByRole('button', { name: '続きを読む' });
     await userEvent.click(expand);
 
-    const collapse = await canvas.findByRole('button', { name: '閉じる' });
-    await expect(collapse).toBeInTheDocument();
-
-    await userEvent.click(collapse);
-    await expect(
-      await canvas.findByRole('button', { name: '続きを読む' }),
-    ).toBeInTheDocument();
+    // 展開後は一方向。ボタンが消え、畳むためのコントロールは出さない。
+    await waitFor(() => {
+      expect(
+        canvas.queryByRole('button', { name: '続きを読む' }),
+      ).not.toBeInTheDocument();
+    });
   },
 };
 


### PR DESCRIPTION
## 概要

Readings カードの要約/説明文が `line-clamp-2` で常に2行に省略され、全文を読めなかった。本文が溢れているときだけ「続きを読む」トグル（disclosure）を表示し、全文展開／折りたたみできるようにする。

## 変更点

- `body.tsx`
  - `useIsClamped` フックを追加。`ResizeObserver` で `scrollHeight > clientHeight` を監視し、**本文が実際に2行を超えているときだけ**トグルを表示する（短い本文には出さない）。展開中は再計測を止め、クランプ解除で「閉じる」が消えないよう直近の判定を保持する。
  - トグルは ArteOdyssey トークン（`text-fg-mute` / `hover:text-fg-base`）のプレーンな `<button>`。`aria-expanded` / `aria-controls` 付き。
  - カード全面が `::after` のリンクなので、既存「AIで要約」ボタンと同様に `relative z-10` + `stopPropagation` で前面に配置し、トグル操作がカード遷移を誘発しないようにした。
- `reading-card.stories.tsx`
  - 長文ケースの `ExpandableBody` ストーリーを追加。続きを読む→閉じる→続きを読むの往復を play 関数で検証。

## レビュー時の補足

- 折りたたみ時の既定は **2行**（`CLAMP_CLASS` の `line-clamp-2`）。増やす場合はこの値を変えるだけで、トグルの出現条件はそのまま機能する。
- ResizeObserver 同期は React 方針どおり `useEffect` の正当な用途としてカスタムフックへ抽出している。
- `vertical:`（縦書き）変種は blog の WritingMode 配下専用で reading-list では発火しないため横書きのみ対応（既存クラスは無害なので保持）。

## 検証

- `pnpm run type-check` ✅
- `pnpm run check`（lint/format）✅ 0 errors
- Storybook テスト（reading-card）✅ 6/6 パス（新規 `ExpandableBody` 含む）