### PR TITLE
refactor(admin): 動的部分のみを Suspense 境界に限定し PPR シェルを即時化

### DIFF
--- a/apps/admin/src/app/(authenticated)/_components/content-fallback/content-fallback.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/content-fallback/content-fallback.tsx
@@ -1,0 +1,13 @@
+import { Spinner } from '@k8o/arte-odyssey';
+import type { FC } from 'react';
+
+/**
+ * コンテンツ Suspense のフォールバック。
+ * 静的シェル（PageHeader 等）は即時表示し、データ依存の本体だけを
+ * この Spinner で穴埋めしてストリーミングする。
+ */
+export const ContentFallback: FC = () => (
+  <div className="flex items-center justify-center py-16">
+    <Spinner label="読み込み中" size="lg" />
+  </div>
+);

--- a/apps/admin/src/app/(authenticated)/_components/content-fallback/content-fallback.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/content-fallback/content-fallback.tsx
@@ -1,11 +1,7 @@
 import { Spinner } from '@k8o/arte-odyssey';
 import type { FC } from 'react';
 
-/**
- * コンテンツ Suspense のフォールバック。
- * 静的シェル（PageHeader 等）は即時表示し、データ依存の本体だけを
- * この Spinner で穴埋めしてストリーミングする。
- */
+// コンテンツ Suspense のフォールバック（静的シェルは即時表示し、本体のみストリーミング）
 export const ContentFallback: FC = () => (
   <div className="flex items-center justify-center py-16">
     <Spinner label="読み込み中" size="lg" />

--- a/apps/admin/src/app/(authenticated)/_components/content-fallback/index.ts
+++ b/apps/admin/src/app/(authenticated)/_components/content-fallback/index.ts
@@ -1,0 +1,1 @@
+export { ContentFallback } from './content-fallback';

--- a/apps/admin/src/app/(authenticated)/_components/dashboard-content/dashboard-content.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/dashboard-content/dashboard-content.tsx
@@ -8,10 +8,13 @@ import {
 } from '@/app/(authenticated)/_components';
 import { getTopViewedBlogs } from '@/features/blog/interface/queries';
 import { getDashboardSummary } from '@/features/dashboard/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
 
 const BLOG_BASE_URL = 'https://k8o.me/blog';
 
 export const DashboardContent = async () => {
+  await verifySession();
+
   const [
     { blogCount, totalViews, articleCount, sourceCount, recentArticles },
     topBlogs,

--- a/apps/admin/src/app/(authenticated)/_components/index.ts
+++ b/apps/admin/src/app/(authenticated)/_components/index.ts
@@ -1,5 +1,6 @@
 // 各ページで横断的に使うレイアウト/一覧プリミティブのまとめ。
 // ページ側の import 数を抑え、利用箇所を一貫させる。
+export { ContentFallback } from './content-fallback';
 export { EmptyState } from './empty-state';
 export { FilterSelect } from './filter-select';
 export { ListPagination } from './list-pagination';

--- a/apps/admin/src/app/(authenticated)/baseline/_components/baseline-content/baseline-content.tsx
+++ b/apps/admin/src/app/(authenticated)/baseline/_components/baseline-content/baseline-content.tsx
@@ -1,0 +1,75 @@
+import {
+  FilterSelect,
+  ListPagination,
+  SearchField,
+  SectionHeader,
+} from '@/app/(authenticated)/_components';
+import {
+  type BaselineStatus,
+  getBaselineSnapshots,
+} from '@/features/baseline/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+import {
+  firstParam,
+  getTotalPages,
+  parsePageParam,
+} from '@/shared/search-params';
+
+import { BaselineSnapshotList } from '../baseline-snapshot-list';
+import { BaselineSnapshotStats } from '../baseline-snapshot-stats';
+
+const PAGE_SIZE = 20;
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'すべて' },
+  { value: 'newly', label: 'Newly' },
+  { value: 'widely', label: 'Widely' },
+] as const;
+
+const parseStatus = (value: string | undefined): BaselineStatus | 'all' =>
+  value === 'newly' || value === 'widely' ? value : 'all';
+
+export const BaselineContent = async ({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) => {
+  await verifySession();
+
+  const sp = await searchParams;
+  const status = parseStatus(firstParam(sp['status']));
+  const q = firstParam(sp['q']) ?? '';
+  const page = parsePageParam(firstParam(sp['page']));
+
+  const { items, total } = await getBaselineSnapshots({
+    status,
+    q,
+    page,
+    pageSize: PAGE_SIZE,
+  });
+  const totalPages = getTotalPages(total, PAGE_SIZE);
+
+  return (
+    <>
+      <BaselineSnapshotStats />
+
+      <section className="flex flex-col gap-4">
+        <SectionHeader title="スナップショット一覧" />
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <SearchField placeholder="機能名で検索" />
+          <div className="sm:w-40">
+            <FilterSelect
+              label="ステータスで絞り込み"
+              options={STATUS_OPTIONS}
+              paramKey="status"
+            />
+          </div>
+        </div>
+        <BaselineSnapshotList snapshots={items} />
+        <div className="flex justify-center">
+          <ListPagination currentPage={page} totalPages={totalPages} />
+        </div>
+      </section>
+    </>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/baseline/page.tsx
+++ b/apps/admin/src/app/(authenticated)/baseline/page.tsx
@@ -1,56 +1,15 @@
-import {
-  FilterSelect,
-  ListPagination,
-  PageHeader,
-  SearchField,
-  SectionHeader,
-} from '@/app/(authenticated)/_components';
-import {
-  type BaselineStatus,
-  getBaselineSnapshots,
-} from '@/features/baseline/interface/queries';
-import { verifySession } from '@/shared/auth/verify-session';
-import {
-  firstParam,
-  getTotalPages,
-  parsePageParam,
-} from '@/shared/search-params';
+import { Suspense } from 'react';
 
-import { BaselineSnapshotList } from './_components/baseline-snapshot-list';
-import { BaselineSnapshotStats } from './_components/baseline-snapshot-stats';
+import { ContentFallback, PageHeader } from '@/app/(authenticated)/_components';
+
+import { BaselineContent } from './_components/baseline-content/baseline-content';
 import { SyncBaselineButton } from './_components/sync-baseline-button';
 
-const PAGE_SIZE = 20;
-
-const STATUS_OPTIONS = [
-  { value: 'all', label: 'すべて' },
-  { value: 'newly', label: 'Newly' },
-  { value: 'widely', label: 'Widely' },
-] as const;
-
-const parseStatus = (value: string | undefined): BaselineStatus | 'all' =>
-  value === 'newly' || value === 'widely' ? value : 'all';
-
-export default async function BaselinePage({
+export default function BaselinePage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  await verifySession();
-
-  const sp = await searchParams;
-  const status = parseStatus(firstParam(sp['status']));
-  const q = firstParam(sp['q']) ?? '';
-  const page = parsePageParam(firstParam(sp['page']));
-
-  const { items, total } = await getBaselineSnapshots({
-    status,
-    q,
-    page,
-    pageSize: PAGE_SIZE,
-  });
-  const totalPages = getTotalPages(total, PAGE_SIZE);
-
   return (
     <div className="flex flex-col gap-10">
       <PageHeader
@@ -58,25 +17,9 @@ export default async function BaselinePage({
         description="Baselineスナップショットの管理"
         title="Baseline"
       />
-      <BaselineSnapshotStats />
-
-      <section className="flex flex-col gap-4">
-        <SectionHeader title="スナップショット一覧" />
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-          <SearchField placeholder="機能名で検索" />
-          <div className="sm:w-40">
-            <FilterSelect
-              label="ステータスで絞り込み"
-              options={STATUS_OPTIONS}
-              paramKey="status"
-            />
-          </div>
-        </div>
-        <BaselineSnapshotList snapshots={items} />
-        <div className="flex justify-center">
-          <ListPagination currentPage={page} totalPages={totalPages} />
-        </div>
-      </section>
+      <Suspense fallback={<ContentFallback />}>
+        <BaselineContent searchParams={searchParams} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/blogs/_components/blogs-content/blogs-content.tsx
+++ b/apps/admin/src/app/(authenticated)/blogs/_components/blogs-content/blogs-content.tsx
@@ -1,0 +1,82 @@
+import {
+  FilterSelect,
+  ListPagination,
+  SearchField,
+} from '@/app/(authenticated)/_components';
+import {
+  type BlogSort,
+  type BlogStatus,
+  getBlogs,
+} from '@/features/blog/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+import {
+  firstParam,
+  getTotalPages,
+  parsePageParam,
+} from '@/shared/search-params';
+
+import { BlogTable } from '../blog-table';
+
+const PAGE_SIZE = 20;
+
+const STATUS_OPTIONS = [
+  { value: 'all', label: 'すべて' },
+  { value: 'published', label: '公開' },
+  { value: 'draft', label: '下書き' },
+] as const;
+
+const SORT_OPTIONS = [
+  { value: 'recent', label: '新着順' },
+  { value: 'views', label: '閲覧数順' },
+] as const;
+
+const parseStatus = (value: string | undefined): BlogStatus =>
+  value === 'published' || value === 'draft' ? value : 'all';
+
+const parseSort = (value: string | undefined): BlogSort =>
+  value === 'views' ? 'views' : 'recent';
+
+export const BlogsContent = async ({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) => {
+  await verifySession();
+
+  const sp = await searchParams;
+  const q = firstParam(sp['q']) ?? '';
+  const status = parseStatus(firstParam(sp['status']));
+  const sort = parseSort(firstParam(sp['sort']));
+  const page = parsePageParam(firstParam(sp['page']));
+
+  const { items, total } = await getBlogs({
+    q,
+    status,
+    sort,
+    page,
+    pageSize: PAGE_SIZE,
+  });
+  const totalPages = getTotalPages(total, PAGE_SIZE);
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+        <SearchField placeholder="slug で検索" />
+        <div className="sm:w-40">
+          <FilterSelect
+            label="公開状態で絞り込み"
+            options={STATUS_OPTIONS}
+            paramKey="status"
+          />
+        </div>
+        <div className="sm:w-40">
+          <FilterSelect label="並び順" options={SORT_OPTIONS} paramKey="sort" />
+        </div>
+      </div>
+      <BlogTable blogs={items} />
+      <div className="flex justify-center">
+        <ListPagination currentPage={page} totalPages={totalPages} />
+      </div>
+    </section>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/blogs/page.tsx
+++ b/apps/admin/src/app/(authenticated)/blogs/page.tsx
@@ -1,94 +1,23 @@
-import {
-  FilterSelect,
-  ListPagination,
-  PageHeader,
-  SearchField,
-} from '@/app/(authenticated)/_components';
-import {
-  type BlogSort,
-  type BlogStatus,
-  getBlogs,
-} from '@/features/blog/interface/queries';
-import { verifySession } from '@/shared/auth/verify-session';
-import {
-  firstParam,
-  getTotalPages,
-  parsePageParam,
-} from '@/shared/search-params';
+import { Suspense } from 'react';
 
-import { BlogTable } from './_components/blog-table';
+import { ContentFallback, PageHeader } from '@/app/(authenticated)/_components';
 
-const PAGE_SIZE = 20;
+import { BlogsContent } from './_components/blogs-content/blogs-content';
 
-const STATUS_OPTIONS = [
-  { value: 'all', label: 'すべて' },
-  { value: 'published', label: '公開' },
-  { value: 'draft', label: '下書き' },
-] as const;
-
-const SORT_OPTIONS = [
-  { value: 'recent', label: '新着順' },
-  { value: 'views', label: '閲覧数順' },
-] as const;
-
-const parseStatus = (value: string | undefined): BlogStatus =>
-  value === 'published' || value === 'draft' ? value : 'all';
-
-const parseSort = (value: string | undefined): BlogSort =>
-  value === 'views' ? 'views' : 'recent';
-
-export default async function BlogsPage({
+export default function BlogsPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  await verifySession();
-
-  const sp = await searchParams;
-  const q = firstParam(sp['q']) ?? '';
-  const status = parseStatus(firstParam(sp['status']));
-  const sort = parseSort(firstParam(sp['sort']));
-  const page = parsePageParam(firstParam(sp['page']));
-
-  const { items, total } = await getBlogs({
-    q,
-    status,
-    sort,
-    page,
-    pageSize: PAGE_SIZE,
-  });
-  const totalPages = getTotalPages(total, PAGE_SIZE);
-
   return (
     <div className="flex flex-col gap-10">
       <PageHeader
         description="記事の公開状態・閲覧数・コメント数を管理します（タイトル/本文は MDX 管理のため slug で表示）。"
         title="ブログ"
       />
-
-      <section className="flex flex-col gap-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-          <SearchField placeholder="slug で検索" />
-          <div className="sm:w-40">
-            <FilterSelect
-              label="公開状態で絞り込み"
-              options={STATUS_OPTIONS}
-              paramKey="status"
-            />
-          </div>
-          <div className="sm:w-40">
-            <FilterSelect
-              label="並び順"
-              options={SORT_OPTIONS}
-              paramKey="sort"
-            />
-          </div>
-        </div>
-        <BlogTable blogs={items} />
-        <div className="flex justify-center">
-          <ListPagination currentPage={page} totalPages={totalPages} />
-        </div>
-      </section>
+      <Suspense fallback={<ContentFallback />}>
+        <BlogsContent searchParams={searchParams} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/comments/_components/comments-content/comments-content.tsx
+++ b/apps/admin/src/app/(authenticated)/comments/_components/comments-content/comments-content.tsx
@@ -1,0 +1,72 @@
+import { BlogIcon, LinkIcon, MailIcon } from '@k8o/arte-odyssey';
+
+import {
+  ListPagination,
+  SearchField,
+  SectionHeader,
+  StatCard,
+} from '@/app/(authenticated)/_components';
+import {
+  getComments,
+  getCommentStats,
+} from '@/features/comments/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+import {
+  firstParam,
+  getTotalPages,
+  parsePageParam,
+} from '@/shared/search-params';
+
+import { CommentList } from '../comment-list';
+
+const PAGE_SIZE = 20;
+
+export const CommentsContent = async ({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) => {
+  await verifySession();
+
+  const sp = await searchParams;
+  const q = firstParam(sp['q']) ?? '';
+  const page = parsePageParam(firstParam(sp['page']));
+
+  const [stats, { items, total }] = await Promise.all([
+    getCommentStats(),
+    getComments({ q, page, pageSize: PAGE_SIZE }),
+  ]);
+
+  const totalPages = getTotalPages(total, PAGE_SIZE);
+
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+        <StatCard
+          icon={<MailIcon size="md" />}
+          label="総件数"
+          value={String(stats.total)}
+        />
+        <StatCard
+          icon={<BlogIcon size="md" />}
+          label="ブログ紐付け"
+          value={String(stats.blogLinked)}
+        />
+        <StatCard
+          icon={<LinkIcon size="md" />}
+          label="未紐づけ"
+          value={String(stats.unlinked)}
+        />
+      </div>
+
+      <section className="flex flex-col gap-4">
+        <SectionHeader title="一覧" />
+        <SearchField placeholder="本文で検索" />
+        <CommentList items={items} />
+        <div className="flex justify-center">
+          <ListPagination currentPage={page} totalPages={totalPages} />
+        </div>
+      </section>
+    </>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/comments/page.tsx
+++ b/apps/admin/src/app/(authenticated)/comments/page.tsx
@@ -1,78 +1,23 @@
-import { BlogIcon, LinkIcon, MailIcon } from '@k8o/arte-odyssey';
+import { Suspense } from 'react';
 
-import {
-  ListPagination,
-  PageHeader,
-  SearchField,
-  SectionHeader,
-  StatCard,
-} from '@/app/(authenticated)/_components';
-import {
-  getComments,
-  getCommentStats,
-} from '@/features/comments/interface/queries';
-import { verifySession } from '@/shared/auth/verify-session';
-import {
-  firstParam,
-  getTotalPages,
-  parsePageParam,
-} from '@/shared/search-params';
+import { ContentFallback, PageHeader } from '@/app/(authenticated)/_components';
 
-import { CommentList } from './_components/comment-list';
+import { CommentsContent } from './_components/comments-content/comments-content';
 
-const PAGE_SIZE = 20;
-
-export default async function CommentsPage({
+export default function CommentsPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  await verifySession();
-
-  const sp = await searchParams;
-  const q = firstParam(sp['q']) ?? '';
-  const page = parsePageParam(firstParam(sp['page']));
-
-  const [stats, { items, total }] = await Promise.all([
-    getCommentStats(),
-    getComments({ q, page, pageSize: PAGE_SIZE }),
-  ]);
-
-  const totalPages = getTotalPages(total, PAGE_SIZE);
-
   return (
     <div className="flex flex-col gap-10">
       <PageHeader
         description="ブログ記事のフィードバックフォーム経由で届いたお問い合わせとコメントを管理します。"
         title="お問い合わせ"
       />
-
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
-        <StatCard
-          icon={<MailIcon size="md" />}
-          label="総件数"
-          value={String(stats.total)}
-        />
-        <StatCard
-          icon={<BlogIcon size="md" />}
-          label="ブログ紐付け"
-          value={String(stats.blogLinked)}
-        />
-        <StatCard
-          icon={<LinkIcon size="md" />}
-          label="未紐づけ"
-          value={String(stats.unlinked)}
-        />
-      </div>
-
-      <section className="flex flex-col gap-4">
-        <SectionHeader title="一覧" />
-        <SearchField placeholder="本文で検索" />
-        <CommentList items={items} />
-        <div className="flex justify-center">
-          <ListPagination currentPage={page} totalPages={totalPages} />
-        </div>
-      </section>
+      <Suspense fallback={<ContentFallback />}>
+        <CommentsContent searchParams={searchParams} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/loading.tsx
+++ b/apps/admin/src/app/(authenticated)/loading.tsx
@@ -1,9 +1,0 @@
-import { Spinner } from '@k8o/arte-odyssey';
-
-export default function Loading() {
-  return (
-    <div className="flex items-center justify-center py-16">
-      <Spinner label="読み込み中" size="lg" />
-    </div>
-  );
-}

--- a/apps/admin/src/app/(authenticated)/notifications/_components/notifications-content/notifications-content.tsx
+++ b/apps/admin/src/app/(authenticated)/notifications/_components/notifications-content/notifications-content.tsx
@@ -1,0 +1,101 @@
+import { Card, HistoryIcon, SendIcon, SubscribeIcon } from '@k8o/arte-odyssey';
+import { formatDate } from '@repo/helpers/date/format';
+
+import {
+  ListPagination,
+  SectionHeader,
+  StatCard,
+} from '@/app/(authenticated)/_components';
+import {
+  getPushLogs,
+  getPushOverview,
+} from '@/features/push-notification/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+import {
+  firstParam,
+  getTotalPages,
+  parsePageParam,
+} from '@/shared/search-params';
+
+import { PushLogTable } from '../push-log-table';
+import { PushSendForm } from '../push-send-form';
+
+const PAGE_SIZE = 20;
+
+export const NotificationsContent = async ({
+  searchParams,
+}: {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+}) => {
+  await verifySession();
+
+  const sp = await searchParams;
+  const page = parsePageParam(firstParam(sp['page']));
+
+  const [overview, { items, total }] = await Promise.all([
+    getPushOverview(),
+    getPushLogs({ page, pageSize: PAGE_SIZE }),
+  ]);
+  const totalPages = getTotalPages(total, PAGE_SIZE);
+
+  const lastSentLabel =
+    overview.lastSentAt === null
+      ? '送信履歴なし'
+      : `直近: ${formatDate(new Date(overview.lastSentAt), 'yyyy/MM/dd HH:mm')}`;
+
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+        <StatCard
+          description={`${String(overview.hostCounts.length)} ホスト`}
+          icon={<SubscribeIcon size="md" />}
+          label="購読者数"
+          value={String(overview.subscriberCount)}
+        />
+        <StatCard
+          description={`失敗 ${String(overview.lastFailed)}・${lastSentLabel}`}
+          icon={<SendIcon size="md" />}
+          label="直近の送信成功"
+          value={String(overview.lastSucceeded)}
+        />
+        <StatCard
+          icon={<HistoryIcon size="md" />}
+          label="送信ログ件数"
+          value={String(total)}
+        />
+      </div>
+
+      {overview.hostCounts.length > 0 && (
+        <section className="flex flex-col gap-4">
+          <SectionHeader title="購読ホスト" />
+          <Card appearance="shadow">
+            {overview.hostCounts.map((host) => (
+              <div
+                className="border-border-mute flex items-center justify-between gap-3 border-b px-5 py-3 text-sm last:border-b-0"
+                key={host.host}
+              >
+                <span className="min-w-0 truncate">{host.host}</span>
+                <span className="text-fg-mute shrink-0 tabular-nums">
+                  {host.count}
+                </span>
+              </div>
+            ))}
+          </Card>
+        </section>
+      )}
+
+      <section className="flex flex-col gap-4">
+        <SectionHeader title="手動送信" />
+        <PushSendForm />
+      </section>
+
+      <section className="flex flex-col gap-4">
+        <SectionHeader title="送信ログ" />
+        <PushLogTable logs={items} />
+        <div className="flex justify-center">
+          <ListPagination currentPage={page} totalPages={totalPages} />
+        </div>
+      </section>
+    </>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/notifications/page.tsx
+++ b/apps/admin/src/app/(authenticated)/notifications/page.tsx
@@ -1,107 +1,23 @@
-import { Card, HistoryIcon, SendIcon, SubscribeIcon } from '@k8o/arte-odyssey';
-import { formatDate } from '@repo/helpers/date/format';
+import { Suspense } from 'react';
 
-import {
-  ListPagination,
-  PageHeader,
-  SectionHeader,
-  StatCard,
-} from '@/app/(authenticated)/_components';
-import {
-  getPushLogs,
-  getPushOverview,
-} from '@/features/push-notification/interface/queries';
-import { verifySession } from '@/shared/auth/verify-session';
-import {
-  firstParam,
-  getTotalPages,
-  parsePageParam,
-} from '@/shared/search-params';
+import { ContentFallback, PageHeader } from '@/app/(authenticated)/_components';
 
-import { PushLogTable } from './_components/push-log-table';
-import { PushSendForm } from './_components/push-send-form';
+import { NotificationsContent } from './_components/notifications-content/notifications-content';
 
-const PAGE_SIZE = 20;
-
-export default async function NotificationsPage({
+export default function NotificationsPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  await verifySession();
-
-  const sp = await searchParams;
-  const page = parsePageParam(firstParam(sp['page']));
-
-  const [overview, { items, total }] = await Promise.all([
-    getPushOverview(),
-    getPushLogs({ page, pageSize: PAGE_SIZE }),
-  ]);
-  const totalPages = getTotalPages(total, PAGE_SIZE);
-
-  const lastSentLabel =
-    overview.lastSentAt === null
-      ? '送信履歴なし'
-      : `直近: ${formatDate(new Date(overview.lastSentAt), 'yyyy/MM/dd HH:mm')}`;
-
   return (
     <div className="flex flex-col gap-10">
       <PageHeader
         description="Web Push の購読状況と送信ログを確認し、手動送信します。"
         title="通知"
       />
-
-      <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
-        <StatCard
-          description={`${String(overview.hostCounts.length)} ホスト`}
-          icon={<SubscribeIcon size="md" />}
-          label="購読者数"
-          value={String(overview.subscriberCount)}
-        />
-        <StatCard
-          description={`失敗 ${String(overview.lastFailed)}・${lastSentLabel}`}
-          icon={<SendIcon size="md" />}
-          label="直近の送信成功"
-          value={String(overview.lastSucceeded)}
-        />
-        <StatCard
-          icon={<HistoryIcon size="md" />}
-          label="送信ログ件数"
-          value={String(total)}
-        />
-      </div>
-
-      {overview.hostCounts.length > 0 && (
-        <section className="flex flex-col gap-4">
-          <SectionHeader title="購読ホスト" />
-          <Card appearance="shadow">
-            {overview.hostCounts.map((host) => (
-              <div
-                className="border-border-mute flex items-center justify-between gap-3 border-b px-5 py-3 text-sm last:border-b-0"
-                key={host.host}
-              >
-                <span className="min-w-0 truncate">{host.host}</span>
-                <span className="text-fg-mute shrink-0 tabular-nums">
-                  {host.count}
-                </span>
-              </div>
-            ))}
-          </Card>
-        </section>
-      )}
-
-      <section className="flex flex-col gap-4">
-        <SectionHeader title="手動送信" />
-        <PushSendForm />
-      </section>
-
-      <section className="flex flex-col gap-4">
-        <SectionHeader title="送信ログ" />
-        <PushLogTable logs={items} />
-        <div className="flex justify-center">
-          <ListPagination currentPage={page} totalPages={totalPages} />
-        </div>
-      </section>
+      <Suspense fallback={<ContentFallback />}>
+        <NotificationsContent searchParams={searchParams} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/page.tsx
+++ b/apps/admin/src/app/(authenticated)/page.tsx
@@ -1,14 +1,16 @@
-import { PageHeader } from '@/app/(authenticated)/_components/page-header';
-import { verifySession } from '@/shared/auth/verify-session';
+import { Suspense } from 'react';
+
+import { ContentFallback, PageHeader } from '@/app/(authenticated)/_components';
 
 import { DashboardContent } from './_components/dashboard-content/dashboard-content';
 
-export default async function Home() {
-  await verifySession();
+export default function Home() {
   return (
     <div className="flex flex-col gap-10">
       <PageHeader description="k8o サイト全体の概況" title="ダッシュボード" />
-      <DashboardContent />
+      <Suspense fallback={<ContentFallback />}>
+        <DashboardContent />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/edit-article-content/edit-article-content.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/edit-article-content/edit-article-content.tsx
@@ -1,0 +1,40 @@
+import { Card } from '@k8o/arte-odyssey';
+import { notFound } from 'next/navigation';
+
+import { updateArticle } from '@/features/reading-list/interface/article-actions';
+import { getArticleForEdit } from '@/features/reading-list/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+
+import { ArticleForm } from '../article-form/article-form';
+
+export const EditArticleContent = async ({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) => {
+  await verifySession();
+  const { id } = await params;
+  const article = await getArticleForEdit(id);
+
+  if (!article) {
+    notFound();
+  }
+
+  const action = updateArticle.bind(null, article.id);
+
+  return (
+    <Card appearance="shadow">
+      <div className="p-8">
+        <ArticleForm
+          action={action}
+          defaultValues={{
+            title: article.title,
+            url: article.url,
+            publishedAt: article.publishedAt,
+            description: article.description,
+          }}
+        />
+      </div>
+    </Card>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/edit-source-content/edit-source-content.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/edit-source-content/edit-source-content.tsx
@@ -3,11 +3,18 @@ import { notFound } from 'next/navigation';
 
 import { getArticleSourceForEdit } from '@/features/reading-list/interface/queries';
 import { updateSource } from '@/features/reading-list/interface/source-actions';
+import { verifySession } from '@/shared/auth/verify-session';
 
 import { DeleteSourceButton } from '../delete-source-button/delete-source-button';
 import { SourceForm } from '../source-form/source-form';
 
-export const EditSourceContent = async ({ id }: { id: string }) => {
+export const EditSourceContent = async ({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) => {
+  await verifySession();
+  const { id } = await params;
   const source = await getArticleSourceForEdit(id);
 
   if (!source) {

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/new-article-content/new-article-content.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/new-article-content/new-article-content.tsx
@@ -1,0 +1,23 @@
+import { Card } from '@k8o/arte-odyssey';
+
+import { createArticle } from '@/features/reading-list/interface/article-actions';
+import { getReadingListContentData } from '@/features/reading-list/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+
+import { ArticleForm } from '../article-form/article-form';
+
+export const NewArticleContent = async () => {
+  await verifySession();
+  const { sources } = await getReadingListContentData();
+
+  return (
+    <Card appearance="shadow">
+      <div className="p-8">
+        <ArticleForm
+          action={createArticle}
+          sources={sources.map((s) => ({ id: s.id, title: s.title }))}
+        />
+      </div>
+    </Card>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/new-source-content/new-source-content.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/new-source-content/new-source-content.tsx
@@ -1,0 +1,18 @@
+import { Card } from '@k8o/arte-odyssey';
+
+import { createSource } from '@/features/reading-list/interface/source-actions';
+import { verifySession } from '@/shared/auth/verify-session';
+
+import { SourceForm } from '../source-form/source-form';
+
+export const NewSourceContent = async () => {
+  await verifySession();
+
+  return (
+    <Card appearance="shadow">
+      <div className="p-8">
+        <SourceForm action={createSource} />
+      </div>
+    </Card>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/reading-list-content/reading-list-content.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/reading-list-content/reading-list-content.tsx
@@ -10,7 +10,12 @@ import {
   getArticles,
   getReadingListContentData,
 } from '@/features/reading-list/interface/queries';
-import { getTotalPages } from '@/shared/search-params';
+import { verifySession } from '@/shared/auth/verify-session';
+import {
+  firstParam,
+  getTotalPages,
+  parsePageParam,
+} from '@/shared/search-params';
 
 import { AddArticleLink } from '../add-article-link';
 import { AddSourceLink } from '../add-source-link';
@@ -21,12 +26,16 @@ import { SyncButton } from '../sync-button/sync-button';
 const PAGE_SIZE = 20;
 
 export const ReadingListContent = async ({
-  q,
-  page,
+  searchParams,
 }: {
-  q: string;
-  page: number;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) => {
+  await verifySession();
+
+  const sp = await searchParams;
+  const q = firstParam(sp['q']) ?? '';
+  const page = parsePageParam(firstParam(sp['page']));
+
   const [{ sources, feedCount, articleCount }, { items, total }] =
     await Promise.all([
       getReadingListContentData(),

--- a/apps/admin/src/app/(authenticated)/reading-list/articles/[id]/page.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/articles/[id]/page.tsx
@@ -1,27 +1,15 @@
-import { Breadcrumb, Card, Heading } from '@k8o/arte-odyssey';
-import { notFound } from 'next/navigation';
+import { Breadcrumb, Heading } from '@k8o/arte-odyssey';
+import { Suspense } from 'react';
 
-import { updateArticle } from '@/features/reading-list/interface/article-actions';
-import { getArticleForEdit } from '@/features/reading-list/interface/queries';
-import { verifySession } from '@/shared/auth/verify-session';
+import { ContentFallback } from '@/app/(authenticated)/_components';
 
-import { ArticleForm } from '../../_components/article-form/article-form';
+import { EditArticleContent } from '../../_components/edit-article-content/edit-article-content';
 
-export default async function EditArticlePage({
+export default function EditArticlePage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  await verifySession();
-  const { id } = await params;
-  const article = await getArticleForEdit(id);
-
-  if (!article) {
-    notFound();
-  }
-
-  const action = updateArticle.bind(null, article.id);
-
   return (
     <div className="flex flex-col gap-6">
       <Breadcrumb.List>
@@ -32,19 +20,9 @@ export default async function EditArticlePage({
         <Breadcrumb.Item>記事を編集</Breadcrumb.Item>
       </Breadcrumb.List>
       <Heading type="h1">記事を編集</Heading>
-      <Card appearance="shadow">
-        <div className="p-8">
-          <ArticleForm
-            action={action}
-            defaultValues={{
-              title: article.title,
-              url: article.url,
-              publishedAt: article.publishedAt,
-              description: article.description,
-            }}
-          />
-        </div>
-      </Card>
+      <Suspense fallback={<ContentFallback />}>
+        <EditArticleContent params={params} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/reading-list/articles/new/page.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/articles/new/page.tsx
@@ -1,15 +1,11 @@
-import { Breadcrumb, Card, Heading } from '@k8o/arte-odyssey';
+import { Breadcrumb, Heading } from '@k8o/arte-odyssey';
+import { Suspense } from 'react';
 
-import { createArticle } from '@/features/reading-list/interface/article-actions';
-import { getReadingListContentData } from '@/features/reading-list/interface/queries';
-import { verifySession } from '@/shared/auth/verify-session';
+import { ContentFallback } from '@/app/(authenticated)/_components';
 
-import { ArticleForm } from '../../_components/article-form/article-form';
+import { NewArticleContent } from '../../_components/new-article-content/new-article-content';
 
-export default async function NewArticlePage() {
-  await verifySession();
-  const { sources } = await getReadingListContentData();
-
+export default function NewArticlePage() {
   return (
     <div className="flex flex-col gap-6">
       <Breadcrumb.List>
@@ -20,14 +16,9 @@ export default async function NewArticlePage() {
         <Breadcrumb.Item>記事を追加</Breadcrumb.Item>
       </Breadcrumb.List>
       <Heading type="h1">記事を追加</Heading>
-      <Card appearance="shadow">
-        <div className="p-8">
-          <ArticleForm
-            action={createArticle}
-            sources={sources.map((s) => ({ id: s.id, title: s.title }))}
-          />
-        </div>
-      </Card>
+      <Suspense fallback={<ContentFallback />}>
+        <NewArticleContent />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/reading-list/page.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/page.tsx
@@ -1,27 +1,23 @@
-import { PageHeader } from '@/app/(authenticated)/_components';
-import { verifySession } from '@/shared/auth/verify-session';
-import { firstParam, parsePageParam } from '@/shared/search-params';
+import { Suspense } from 'react';
+
+import { ContentFallback, PageHeader } from '@/app/(authenticated)/_components';
 
 import { ReadingListContent } from './_components/reading-list-content/reading-list-content';
 
-export default async function ReadingListPage({
+export default function ReadingListPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  await verifySession();
-
-  const sp = await searchParams;
-  const q = firstParam(sp['q']) ?? '';
-  const page = parsePageParam(firstParam(sp['page']));
-
   return (
     <div className="flex flex-col gap-10">
       <PageHeader
         description="RSSフィードと手動ソースから集めた記事を管理します"
         title="よんでいるもの"
       />
-      <ReadingListContent page={page} q={q} />
+      <Suspense fallback={<ContentFallback />}>
+        <ReadingListContent searchParams={searchParams} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/reading-list/sources/[id]/page.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/sources/[id]/page.tsx
@@ -1,18 +1,19 @@
-import { verifySession } from '@/shared/auth/verify-session';
+import { Suspense } from 'react';
+
+import { ContentFallback } from '@/app/(authenticated)/_components';
 
 import { EditSourceContent } from '../../_components/edit-source-content/edit-source-content';
 
-export default async function EditSourcePage({
+export default function EditSourcePage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  await verifySession();
-  const { id } = await params;
-
   return (
     <div className="flex flex-col gap-6">
-      <EditSourceContent id={id} />
+      <Suspense fallback={<ContentFallback />}>
+        <EditSourceContent params={params} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/reading-list/sources/new/page.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/sources/new/page.tsx
@@ -1,12 +1,11 @@
-import { Breadcrumb, Card, Heading } from '@k8o/arte-odyssey';
+import { Breadcrumb, Heading } from '@k8o/arte-odyssey';
+import { Suspense } from 'react';
 
-import { createSource } from '@/features/reading-list/interface/source-actions';
-import { verifySession } from '@/shared/auth/verify-session';
+import { ContentFallback } from '@/app/(authenticated)/_components';
 
-import { SourceForm } from '../../_components/source-form/source-form';
+import { NewSourceContent } from '../../_components/new-source-content/new-source-content';
 
-export default async function NewSourcePage() {
-  await verifySession();
+export default function NewSourcePage() {
   return (
     <div className="flex flex-col gap-6">
       <Breadcrumb.List>
@@ -17,11 +16,9 @@ export default async function NewSourcePage() {
         <Breadcrumb.Item>ソースを追加</Breadcrumb.Item>
       </Breadcrumb.List>
       <Heading type="h1">ソースを追加</Heading>
-      <Card appearance="shadow">
-        <div className="p-8">
-          <SourceForm action={createSource} />
-        </div>
-      </Card>
+      <Suspense fallback={<ContentFallback />}>
+        <NewSourceContent />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/reports/_components/reports-content/reports-content.tsx
+++ b/apps/admin/src/app/(authenticated)/reports/_components/reports-content/reports-content.tsx
@@ -11,21 +11,29 @@ import {
   getReports,
   getReportTypeCounts,
 } from '@/features/reports/interface/queries';
-import { getTotalPages } from '@/shared/search-params';
+import { verifySession } from '@/shared/auth/verify-session';
+import {
+  firstParam,
+  getTotalPages,
+  parsePageParam,
+} from '@/shared/search-params';
 
 import { ReportTable } from '../report-table/report-table';
 
 const PAGE_SIZE = 20;
 
 export const ReportsContent = async ({
-  type,
-  q,
-  page,
+  searchParams,
 }: {
-  type: string;
-  q: string;
-  page: number;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) => {
+  await verifySession();
+
+  const sp = await searchParams;
+  const type = firstParam(sp['type']) ?? '';
+  const q = firstParam(sp['q']) ?? '';
+  const page = parsePageParam(firstParam(sp['page']));
+
   const [{ typeCounts, totalCount }, { items, total }] = await Promise.all([
     getReportTypeCounts(),
     getReports({ type, q, page, pageSize: PAGE_SIZE }),

--- a/apps/admin/src/app/(authenticated)/reports/page.tsx
+++ b/apps/admin/src/app/(authenticated)/reports/page.tsx
@@ -1,28 +1,23 @@
-import { PageHeader } from '@/app/(authenticated)/_components';
-import { verifySession } from '@/shared/auth/verify-session';
-import { firstParam, parsePageParam } from '@/shared/search-params';
+import { Suspense } from 'react';
+
+import { ContentFallback, PageHeader } from '@/app/(authenticated)/_components';
 
 import { ReportsContent } from './_components/reports-content/reports-content';
 
-export default async function ReportsPage({
+export default function ReportsPage({
   searchParams,
 }: {
   searchParams: Promise<Record<string, string | string[] | undefined>>;
 }) {
-  await verifySession();
-
-  const sp = await searchParams;
-  const type = firstParam(sp['type']) ?? '';
-  const q = firstParam(sp['q']) ?? '';
-  const page = parsePageParam(firstParam(sp['page']));
-
   return (
     <div className="flex flex-col gap-10">
       <PageHeader
         description="Reporting APIから収集したブラウザレポート"
         title="レポート"
       />
-      <ReportsContent page={page} q={q} type={type} />
+      <Suspense fallback={<ContentFallback />}>
+        <ReportsContent searchParams={searchParams} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/slides/_components/slides-content/slides-content.tsx
+++ b/apps/admin/src/app/(authenticated)/slides/_components/slides-content/slides-content.tsx
@@ -1,0 +1,11 @@
+import { getSlides } from '@/features/slides/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+
+import { SlideTable } from '../slide-table';
+
+export const SlidesContent = async () => {
+  await verifySession();
+  const slides = await getSlides();
+
+  return <SlideTable slides={slides} />;
+};

--- a/apps/admin/src/app/(authenticated)/slides/page.tsx
+++ b/apps/admin/src/app/(authenticated)/slides/page.tsx
@@ -1,20 +1,19 @@
-import { PageHeader } from '@/app/(authenticated)/_components';
-import { getSlides } from '@/features/slides/interface/queries';
-import { verifySession } from '@/shared/auth/verify-session';
+import { Suspense } from 'react';
 
-import { SlideTable } from './_components/slide-table';
+import { ContentFallback, PageHeader } from '@/app/(authenticated)/_components';
 
-export default async function SlidesPage() {
-  await verifySession();
-  const slides = await getSlides();
+import { SlidesContent } from './_components/slides-content/slides-content';
 
+export default function SlidesPage() {
   return (
     <div className="flex flex-col gap-10">
       <PageHeader
         description="スライドの公開状態を管理します（タイトル/本文は MDX 管理のため slug で表示）。"
         title="スライド"
       />
-      <SlideTable slides={slides} />
+      <Suspense fallback={<ContentFallback />}>
+        <SlidesContent />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/tags/_components/tags-content/tags-content.tsx
+++ b/apps/admin/src/app/(authenticated)/tags/_components/tags-content/tags-content.tsx
@@ -1,0 +1,17 @@
+import { SectionHeader } from '@/app/(authenticated)/_components';
+import { getTags } from '@/features/tags/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+
+import { TagList } from '../tag-list';
+
+export const TagsContent = async () => {
+  await verifySession();
+  const tags = await getTags();
+
+  return (
+    <section className="flex flex-col gap-4">
+      <SectionHeader title={`一覧（${String(tags.length)}）`} />
+      <TagList tags={tags} />
+    </section>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/tags/page.tsx
+++ b/apps/admin/src/app/(authenticated)/tags/page.tsx
@@ -1,14 +1,15 @@
-import { PageHeader, SectionHeader } from '@/app/(authenticated)/_components';
-import { getTags } from '@/features/tags/interface/queries';
-import { verifySession } from '@/shared/auth/verify-session';
+import { Suspense } from 'react';
+
+import {
+  ContentFallback,
+  PageHeader,
+  SectionHeader,
+} from '@/app/(authenticated)/_components';
 
 import { TagAddForm } from './_components/tag-add-form';
-import { TagList } from './_components/tag-list';
+import { TagsContent } from './_components/tags-content/tags-content';
 
-export default async function TagsPage() {
-  await verifySession();
-  const tags = await getTags();
-
+export default function TagsPage() {
   return (
     <div className="flex flex-col gap-10">
       <PageHeader
@@ -19,10 +20,9 @@ export default async function TagsPage() {
         <SectionHeader title="タグを追加" />
         <TagAddForm />
       </section>
-      <section className="flex flex-col gap-4">
-        <SectionHeader title={`一覧（${String(tags.length)}）`} />
-        <TagList tags={tags} />
-      </section>
+      <Suspense fallback={<ContentFallback />}>
+        <TagsContent />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/talks/[id]/page.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/[id]/page.tsx
@@ -1,60 +1,19 @@
-import { Breadcrumb, Card, Heading } from '@k8o/arte-odyssey';
-import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
 
-import { updateTalk } from '@/features/talks/interface/actions';
-import {
-  getBlogOptions,
-  getTalkForEdit,
-} from '@/features/talks/interface/queries';
-import { verifySession } from '@/shared/auth/verify-session';
+import { ContentFallback } from '@/app/(authenticated)/_components';
 
-import { TalkForm } from '../_components/talk-form';
+import { EditTalkContent } from '../_components/edit-talk-content/edit-talk-content';
 
-export default async function EditTalkPage({
+export default function EditTalkPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  await verifySession();
-  const { id } = await params;
-  const [talk, blogs] = await Promise.all([
-    getTalkForEdit(id),
-    getBlogOptions(),
-  ]);
-
-  if (!talk) {
-    notFound();
-  }
-
-  const action = updateTalk.bind(null, talk.id);
-
   return (
     <div className="flex flex-col gap-6">
-      <Breadcrumb.List>
-        <Breadcrumb.Item>
-          <Breadcrumb.Link href="/talks">トーク</Breadcrumb.Link>
-        </Breadcrumb.Item>
-        <Breadcrumb.Separator />
-        <Breadcrumb.Item>{talk.title}</Breadcrumb.Item>
-      </Breadcrumb.List>
-      <Heading type="h1">トークを編集</Heading>
-      <Card appearance="shadow">
-        <div className="p-8">
-          <TalkForm
-            action={action}
-            blogs={blogs}
-            defaultValues={{
-              title: talk.title,
-              eventName: talk.eventName,
-              eventDate: talk.eventDate,
-              eventLocation: talk.eventLocation,
-              eventUrl: talk.eventUrl,
-              slideUrl: talk.slideUrl,
-              blogId: talk.blogId,
-            }}
-          />
-        </div>
-      </Card>
+      <Suspense fallback={<ContentFallback />}>
+        <EditTalkContent params={params} />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/talks/_components/edit-talk-content/edit-talk-content.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/_components/edit-talk-content/edit-talk-content.tsx
@@ -1,0 +1,60 @@
+import { Breadcrumb, Card, Heading } from '@k8o/arte-odyssey';
+import { notFound } from 'next/navigation';
+
+import { updateTalk } from '@/features/talks/interface/actions';
+import {
+  getBlogOptions,
+  getTalkForEdit,
+} from '@/features/talks/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+
+import { TalkForm } from '../talk-form';
+
+export const EditTalkContent = async ({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) => {
+  await verifySession();
+  const { id } = await params;
+  const [talk, blogs] = await Promise.all([
+    getTalkForEdit(id),
+    getBlogOptions(),
+  ]);
+
+  if (!talk) {
+    notFound();
+  }
+
+  const action = updateTalk.bind(null, talk.id);
+
+  return (
+    <>
+      <Breadcrumb.List>
+        <Breadcrumb.Item>
+          <Breadcrumb.Link href="/talks">トーク</Breadcrumb.Link>
+        </Breadcrumb.Item>
+        <Breadcrumb.Separator />
+        <Breadcrumb.Item>{talk.title}</Breadcrumb.Item>
+      </Breadcrumb.List>
+      <Heading type="h1">トークを編集</Heading>
+      <Card appearance="shadow">
+        <div className="p-8">
+          <TalkForm
+            action={action}
+            blogs={blogs}
+            defaultValues={{
+              title: talk.title,
+              eventName: talk.eventName,
+              eventDate: talk.eventDate,
+              eventLocation: talk.eventLocation,
+              eventUrl: talk.eventUrl,
+              slideUrl: talk.slideUrl,
+              blogId: talk.blogId,
+            }}
+          />
+        </div>
+      </Card>
+    </>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/talks/_components/new-talk-content/new-talk-content.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/_components/new-talk-content/new-talk-content.tsx
@@ -1,0 +1,20 @@
+import { Card } from '@k8o/arte-odyssey';
+
+import { createTalk } from '@/features/talks/interface/actions';
+import { getBlogOptions } from '@/features/talks/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+
+import { TalkForm } from '../talk-form';
+
+export const NewTalkContent = async () => {
+  await verifySession();
+  const blogs = await getBlogOptions();
+
+  return (
+    <Card appearance="shadow">
+      <div className="p-8">
+        <TalkForm action={createTalk} blogs={blogs} />
+      </div>
+    </Card>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/talks/_components/talks-content/talks-content.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/_components/talks-content/talks-content.tsx
@@ -1,0 +1,11 @@
+import { getTalks } from '@/features/talks/interface/queries';
+import { verifySession } from '@/shared/auth/verify-session';
+
+import { TalkList } from '../talk-list';
+
+export const TalksContent = async () => {
+  await verifySession();
+  const talks = await getTalks();
+
+  return <TalkList talks={talks} />;
+};

--- a/apps/admin/src/app/(authenticated)/talks/new/page.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/new/page.tsx
@@ -1,15 +1,11 @@
-import { Breadcrumb, Card, Heading } from '@k8o/arte-odyssey';
+import { Breadcrumb, Heading } from '@k8o/arte-odyssey';
+import { Suspense } from 'react';
 
-import { createTalk } from '@/features/talks/interface/actions';
-import { getBlogOptions } from '@/features/talks/interface/queries';
-import { verifySession } from '@/shared/auth/verify-session';
+import { ContentFallback } from '@/app/(authenticated)/_components';
 
-import { TalkForm } from '../_components/talk-form';
+import { NewTalkContent } from '../_components/new-talk-content/new-talk-content';
 
-export default async function NewTalkPage() {
-  await verifySession();
-  const blogs = await getBlogOptions();
-
+export default function NewTalkPage() {
   return (
     <div className="flex flex-col gap-6">
       <Breadcrumb.List>
@@ -20,11 +16,9 @@ export default async function NewTalkPage() {
         <Breadcrumb.Item>トークを追加</Breadcrumb.Item>
       </Breadcrumb.List>
       <Heading type="h1">トークを追加</Heading>
-      <Card appearance="shadow">
-        <div className="p-8">
-          <TalkForm action={createTalk} blogs={blogs} />
-        </div>
-      </Card>
+      <Suspense fallback={<ContentFallback />}>
+        <NewTalkContent />
+      </Suspense>
     </div>
   );
 }

--- a/apps/admin/src/app/(authenticated)/talks/page.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/page.tsx
@@ -1,14 +1,11 @@
-import { PageHeader } from '@/app/(authenticated)/_components';
-import { getTalks } from '@/features/talks/interface/queries';
-import { verifySession } from '@/shared/auth/verify-session';
+import { Suspense } from 'react';
+
+import { ContentFallback, PageHeader } from '@/app/(authenticated)/_components';
 
 import { AddTalkLink } from './_components/add-talk-link';
-import { TalkList } from './_components/talk-list';
+import { TalksContent } from './_components/talks-content/talks-content';
 
-export default async function TalksPage() {
-  await verifySession();
-  const talks = await getTalks();
-
+export default function TalksPage() {
   return (
     <div className="flex flex-col gap-10">
       <PageHeader
@@ -16,7 +13,9 @@ export default async function TalksPage() {
         description="登壇・スライドのイベント情報を管理します"
         title="トーク"
       />
-      <TalkList talks={talks} />
+      <Suspense fallback={<ContentFallback />}>
+        <TalksContent />
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## What

admin の全 (authenticated) ページを cacheComponents 本来の「静的シェル即時表示 + 動的部分のみ Suspense ストリーミング」構成に統一しました。

- 各ページを「静的シェル(同期) + コンテンツ Suspense」に分割
  - `PageHeader` / `Breadcrumb` / `Heading` 等の静的シェルは即時描画
  - `verifySession`・`searchParams`/`params`・DB クエリ・`useSearchParams` 系（`SearchField` / `FilterSelect` / `ListPagination`）はコンテンツコンポーネントへ集約し `<Suspense fallback={<ContentFallback />}>` で包む
  - `searchParams` / `params` は page で await せず Promise のまま渡す（await した時点で動的化するため）
- 共有フォールバック `ContentFallback` を追加し、route 直下の `loading.tsx` を削除
- サイドバーの `usePathname` Suspense は cacheComponents 下で必須のため**据え置き**

## Why

cacheComponents 下で各ページが先頭で `verifySession` / `searchParams` / DB を await し、`loading.tsx` がコンテンツ領域全体を全画面スピナーにしていた。静的シェルが即時描画されず、ローディング中はページの素性（タイトル/説明）すら見えなかった。ローディングを「コンテンツに関わる部分だけ」に限定する。

## 検証

- `pnpm -F admin build` で全 (authenticated) ルートが **Partial Prerender (◐)** になることを確認
- `type-check` / `check`(lint・format) / `ls-lint` パス
- ローカル（実 DB 接続）で「静的シェル即時表示 → コンテンツがストリーム解決」を確認

## 留意点

- 認証は middleware ではなく各ページの `verifySession` のみ。本変更で静的シェル（タイトル等の非機密 chrome）は認証前に prerender 配信され、未認証時は一瞬シェルが見えてから `/sign-in` へリダイレクトされる。機密データ（DB 内容）は `verifySession` 後のコンテンツ内に留まるため漏れない。多重防御が必要なら middleware 認証を別途検討。
