### PR TITLE
chore(deps): @k8o/arte-odyssey を v10.0.0 へ更新

### DIFF
--- a/apps/admin/src/app/(authenticated)/_components/admin-sidebar/admin-sidebar.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/admin-sidebar/admin-sidebar.tsx
@@ -62,7 +62,7 @@ export const AdminSidebar: FC = () => {
       <div className="bg-bg-base border-border-mute flex items-center justify-between border-b px-4 py-3 md:hidden">
         <Brand />
         <IconButton
-          bg="transparent"
+          color="transparent"
           label="メニューを開く"
           onClick={() => {
             setIsOpen(true);

--- a/apps/admin/src/app/(authenticated)/baseline/_components/sync-baseline-button.tsx
+++ b/apps/admin/src/app/(authenticated)/baseline/_components/sync-baseline-button.tsx
@@ -31,7 +31,7 @@ export const SyncBaselineButton: FC = () => {
       disabled={isPending}
       onClick={handleSync}
       size="sm"
-      variant="outlined"
+      variant="outline"
     >
       {isPending ? '同期中...' : 'Baselineを同期'}
     </Button>

--- a/apps/admin/src/app/(authenticated)/blogs/_components/blog-table/blog-table.tsx
+++ b/apps/admin/src/app/(authenticated)/blogs/_components/blog-table/blog-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Badge, Card, Switch, useToast } from '@k8o/arte-odyssey';
-import { type ChangeEvent, type FC, useState } from 'react';
+import { type FC, useState } from 'react';
 
 import { EmptyState } from '@/app/(authenticated)/_components';
 import { setBlogPublished } from '@/features/blog/interface/actions';
@@ -15,8 +15,8 @@ const BlogRow: FC<{ blog: BlogRecord }> = ({ blog }) => {
   const { isPending, run } = useAsyncAction();
   const { onOpen } = useToast();
 
-  const handleToggle = (e: ChangeEvent<HTMLInputElement>): void => {
-    const next = e.target.checked;
+  const handleToggle = (checked: boolean): void => {
+    const next = checked;
     setPublished(next);
     run(() => setBlogPublished(blog.id, next), {
       onError: (message) => {

--- a/apps/admin/src/app/(authenticated)/comments/_components/comment-actions/comment-actions.tsx
+++ b/apps/admin/src/app/(authenticated)/comments/_components/comment-actions/comment-actions.tsx
@@ -63,7 +63,7 @@ export const CommentActions: FC<Props> = ({ id }) => {
                   onClick={() => {
                     setOpen(false);
                   }}
-                  variant="outlined"
+                  variant="outline"
                 >
                   キャンセル
                 </Button>
@@ -71,7 +71,7 @@ export const CommentActions: FC<Props> = ({ id }) => {
                   color="primary"
                   disabled={isPending}
                   onClick={handleDelete}
-                  variant="contained"
+                  variant="solid"
                 >
                   {isPending ? '削除中...' : '削除する'}
                 </Button>

--- a/apps/admin/src/app/(authenticated)/notifications/_components/push-send-form/push-send-form.tsx
+++ b/apps/admin/src/app/(authenticated)/notifications/_components/push-send-form/push-send-form.tsx
@@ -88,7 +88,7 @@ export const PushSendForm: FC = () => {
             onClick={() => {
               setOpen(true);
             }}
-            variant="contained"
+            variant="solid"
           >
             送信する
           </Button>
@@ -118,7 +118,7 @@ export const PushSendForm: FC = () => {
                   onClick={() => {
                     setOpen(false);
                   }}
-                  variant="outlined"
+                  variant="outline"
                 >
                   キャンセル
                 </Button>
@@ -126,7 +126,7 @@ export const PushSendForm: FC = () => {
                   color="primary"
                   disabled={isPending}
                   onClick={handleSend}
-                  variant="contained"
+                  variant="solid"
                 >
                   {isPending ? '送信中...' : '送信する'}
                 </Button>

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/add-article-link/add-article-link.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/add-article-link/add-article-link.tsx
@@ -13,7 +13,7 @@ export const AddArticleLink: FC = () => (
       </Link>
     )}
     size="sm"
-    variant="outlined"
+    variant="outline"
   >
     記事を追加
   </Button>

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/add-source-link/add-source-link.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/add-source-link/add-source-link.tsx
@@ -13,7 +13,7 @@ export const AddSourceLink: FC = () => (
       </Link>
     )}
     size="sm"
-    variant="contained"
+    variant="solid"
   >
     追加
   </Button>

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/article-form/article-form.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/article-form/article-form.tsx
@@ -43,7 +43,7 @@ export const ArticleForm: FC<ArticleFormProps> = ({
   return (
     <form action={formAction} className="flex flex-col gap-6">
       {state.error !== undefined && (
-        <Alert message={state.error} status="error" />
+        <Alert message={state.error} tone="error" />
       )}
       {sources !== undefined && (
         <FormControl
@@ -111,7 +111,7 @@ export const ArticleForm: FC<ArticleFormProps> = ({
           color="primary"
           disabled={isPending}
           type="submit"
-          variant="contained"
+          variant="solid"
         >
           {isPending ? '保存中...' : '保存'}
         </Button>

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/article-table/article-table.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/article-table/article-table.tsx
@@ -93,7 +93,7 @@ const DeleteButton: FC<{ id: number; title: string }> = ({ id, title }) => {
                   onClick={() => {
                     setOpen(false);
                   }}
-                  variant="outlined"
+                  variant="outline"
                 >
                   キャンセル
                 </Button>
@@ -101,7 +101,7 @@ const DeleteButton: FC<{ id: number; title: string }> = ({ id, title }) => {
                   color="primary"
                   disabled={isPending}
                   onClick={handleDelete}
-                  variant="contained"
+                  variant="solid"
                 >
                   {isPending ? '削除中...' : '削除する'}
                 </Button>

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/delete-source-button/delete-source-button.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/delete-source-button/delete-source-button.tsx
@@ -28,7 +28,7 @@ export const DeleteSourceButton = ({
           setOpen(true);
         }}
         size="sm"
-        variant="outlined"
+        variant="outline"
       >
         削除
       </Button>
@@ -59,7 +59,7 @@ export const DeleteSourceButton = ({
                   onClick={() => {
                     setOpen(false);
                   }}
-                  variant="outlined"
+                  variant="outline"
                 >
                   キャンセル
                 </Button>
@@ -67,7 +67,7 @@ export const DeleteSourceButton = ({
                   color="primary"
                   disabled={isPending}
                   onClick={handleDelete}
-                  variant="contained"
+                  variant="solid"
                 >
                   {isPending ? '削除中...' : '削除する'}
                 </Button>

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/source-form/source-form.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/source-form/source-form.tsx
@@ -7,7 +7,7 @@ import {
   Radio,
   TextField,
 } from '@k8o/arte-odyssey';
-import { type ChangeEvent, useActionState, useState } from 'react';
+import { useActionState, useState } from 'react';
 
 import type { ActionState } from '@/shared/actions/action-state';
 
@@ -38,7 +38,7 @@ export const SourceForm = ({ action, defaultValues }: SourceFormProps) => {
   return (
     <form action={formAction} className="flex flex-col gap-6">
       {state.error !== undefined && (
-        <Alert message={state.error} status="error" />
+        <Alert message={state.error} tone="error" />
       )}
       <FormControl
         label="タイトル"
@@ -84,9 +84,9 @@ export const SourceForm = ({ action, defaultValues }: SourceFormProps) => {
             aria-labelledby={ariaLabelledby}
             disabled={disabled}
             name="type"
-            onChange={(e: ChangeEvent<HTMLInputElement>) => {
-              if (isSourceType(e.target.value)) {
-                setType(e.target.value);
+            onChange={(value) => {
+              if (isSourceType(value)) {
+                setType(value);
               }
             }}
             options={TYPE_OPTIONS}
@@ -99,7 +99,7 @@ export const SourceForm = ({ action, defaultValues }: SourceFormProps) => {
           color="primary"
           disabled={isPending}
           type="submit"
-          variant="contained"
+          variant="solid"
         >
           {isPending ? '保存中...' : '保存'}
         </Button>

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/sync-button/sync-button.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/sync-button/sync-button.tsx
@@ -39,7 +39,7 @@ export const SyncButton: FC = () => {
       disabled={isPending}
       onClick={handleSync}
       size="sm"
-      variant="outlined"
+      variant="outline"
     >
       {isPending ? '同期中...' : '記事を同期'}
     </Button>

--- a/apps/admin/src/app/(authenticated)/slides/_components/slide-table/slide-table.tsx
+++ b/apps/admin/src/app/(authenticated)/slides/_components/slide-table/slide-table.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Badge, Card, Switch, useToast } from '@k8o/arte-odyssey';
-import { type ChangeEvent, type FC, useState } from 'react';
+import { type FC, useState } from 'react';
 
 import { EmptyState } from '@/app/(authenticated)/_components';
 import { setSlidePublished } from '@/features/slides/interface/actions';
@@ -15,8 +15,8 @@ const SlideRow: FC<{ slide: SlideRecord }> = ({ slide }) => {
   const { isPending, run } = useAsyncAction();
   const { onOpen } = useToast();
 
-  const handleToggle = (e: ChangeEvent<HTMLInputElement>): void => {
-    const next = e.target.checked;
+  const handleToggle = (checked: boolean): void => {
+    const next = checked;
     setPublished(next);
     run(() => setSlidePublished(slide.id, next), {
       onError: (message) => {

--- a/apps/admin/src/app/(authenticated)/tags/_components/tag-add-form/tag-add-form.tsx
+++ b/apps/admin/src/app/(authenticated)/tags/_components/tag-add-form/tag-add-form.tsx
@@ -11,7 +11,7 @@ export const TagAddForm: FC = () => {
   return (
     <form action={formAction} className="flex flex-col gap-3">
       {state.error !== undefined && (
-        <Alert message={state.error} status="error" />
+        <Alert message={state.error} tone="error" />
       )}
       <div className="flex items-center gap-3">
         <TextField
@@ -25,7 +25,7 @@ export const TagAddForm: FC = () => {
             color="primary"
             disabled={isPending}
             type="submit"
-            variant="contained"
+            variant="solid"
           >
             {isPending ? '追加中...' : '追加'}
           </Button>

--- a/apps/admin/src/app/(authenticated)/tags/_components/tag-list/tag-list.tsx
+++ b/apps/admin/src/app/(authenticated)/tags/_components/tag-list/tag-list.tsx
@@ -101,14 +101,14 @@ const TagRow: FC<{ tag: TagWithUsage }> = ({ tag }) => {
                 value={name}
               />
               <div className="flex justify-end gap-3">
-                <Button color="gray" onClick={closeRename} variant="outlined">
+                <Button color="gray" onClick={closeRename} variant="outline">
                   キャンセル
                 </Button>
                 <Button
                   color="primary"
                   disabled={isPending}
                   onClick={handleRename}
-                  variant="contained"
+                  variant="solid"
                 >
                   {isPending ? '保存中...' : '保存'}
                 </Button>
@@ -140,7 +140,7 @@ const TagRow: FC<{ tag: TagWithUsage }> = ({ tag }) => {
                   onClick={() => {
                     setDeleteOpen(false);
                   }}
-                  variant="outlined"
+                  variant="outline"
                 >
                   キャンセル
                 </Button>
@@ -148,7 +148,7 @@ const TagRow: FC<{ tag: TagWithUsage }> = ({ tag }) => {
                   color="primary"
                   disabled={isPending}
                   onClick={handleDelete}
-                  variant="contained"
+                  variant="solid"
                 >
                   {isPending ? '削除中...' : '削除する'}
                 </Button>

--- a/apps/admin/src/app/(authenticated)/talks/_components/add-talk-link/add-talk-link.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/_components/add-talk-link/add-talk-link.tsx
@@ -13,7 +13,7 @@ export const AddTalkLink: FC = () => (
       </Link>
     )}
     size="sm"
-    variant="contained"
+    variant="solid"
   >
     トークを追加
   </Button>

--- a/apps/admin/src/app/(authenticated)/talks/_components/talk-form/talk-form.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/_components/talk-form/talk-form.tsx
@@ -41,7 +41,7 @@ export const TalkForm: FC<TalkFormProps> = ({
   return (
     <form action={formAction} className="flex flex-col gap-6">
       {state.error !== undefined && (
-        <Alert message={state.error} status="error" />
+        <Alert message={state.error} tone="error" />
       )}
       <FormControl
         label="タイトル"
@@ -133,7 +133,7 @@ export const TalkForm: FC<TalkFormProps> = ({
           color="primary"
           disabled={isPending}
           type="submit"
-          variant="contained"
+          variant="solid"
         >
           {isPending ? '保存中...' : '保存'}
         </Button>

--- a/apps/admin/src/app/(authenticated)/talks/_components/talk-list/talk-list.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/_components/talk-list/talk-list.tsx
@@ -107,7 +107,7 @@ const TalkRow: FC<{ talk: TalkRecord }> = ({ talk }) => {
                   onClick={() => {
                     setOpen(false);
                   }}
-                  variant="outlined"
+                  variant="outline"
                 >
                   キャンセル
                 </Button>
@@ -115,7 +115,7 @@ const TalkRow: FC<{ talk: TalkRecord }> = ({ talk }) => {
                   color="primary"
                   disabled={isPending}
                   onClick={handleDelete}
-                  variant="contained"
+                  variant="solid"
                 >
                   {isPending ? '削除中...' : '削除する'}
                 </Button>

--- a/apps/admin/src/app/(public)/sign-in/_components/sign-in-form/sign-in-form.tsx
+++ b/apps/admin/src/app/(public)/sign-in/_components/sign-in-form/sign-in-form.tsx
@@ -26,7 +26,7 @@ export const SignInForm: FC = () => {
       fullWidth
       onClick={handleSignIn}
       startIcon={<GitHubIcon size="md" />}
-      variant="contained"
+      variant="solid"
     >
       GitHubでログイン
     </Button>

--- a/apps/main/src/app/_components/app-card/app-card.tsx
+++ b/apps/main/src/app/_components/app-card/app-card.tsx
@@ -21,10 +21,8 @@ export const AppCard = ({
 }) => {
   const isExternal = typeof link === 'string' && link.startsWith('https://');
 
-  // v10 で Card だけ dark モード用の subtle border が追加され InteractiveCard は据え置きのため、
-  // 上流(arte-odyssey)で揃うまで Card と同じ枠をカード本体側で補う暫定対応
   const content = (
-    <div className="dark:border-border-subtle flex h-full flex-col rounded-xl border border-transparent p-6 text-left">
+    <div className="flex h-full flex-col p-6 text-left">
       <div className="flex items-center gap-3">
         {accent === undefined ? null : (
           <div className="text-primary-fg flex size-8 shrink-0 items-center justify-center">

--- a/apps/main/src/app/_components/app-card/app-card.tsx
+++ b/apps/main/src/app/_components/app-card/app-card.tsx
@@ -21,8 +21,10 @@ export const AppCard = ({
 }) => {
   const isExternal = typeof link === 'string' && link.startsWith('https://');
 
+  // v10 で Card だけ dark モード用の subtle border が追加され InteractiveCard は据え置きのため、
+  // 上流(arte-odyssey)で揃うまで Card と同じ枠をカード本体側で補う暫定対応
   const content = (
-    <div className="flex h-full flex-col p-6 text-left">
+    <div className="dark:border-border-subtle flex h-full flex-col rounded-xl border border-transparent p-6 text-left">
       <div className="flex items-center gap-3">
         {accent === undefined ? null : (
           <div className="text-primary-fg flex size-8 shrink-0 items-center justify-center">

--- a/apps/main/src/app/_components/global-layout/background/background.tsx
+++ b/apps/main/src/app/_components/global-layout/background/background.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react';
 export const Background: FC = () => (
   <div
     aria-hidden="true"
-    className="fixed top-0 left-0 -z-10 size-full overflow-hidden bg-linear-65 from-(--cyan-100) to-(--teal-100) dark:bg-(--gray-950) dark:bg-none"
+    className="dark:bg-bg-surface fixed top-0 left-0 -z-10 size-full overflow-hidden bg-linear-65 from-(--cyan-100) to-(--teal-100) dark:bg-none"
   >
     <div className="absolute -top-24 -left-24 size-96 bg-linear-65 from-(--blue-400) to-(--cyan-400) opacity-60 blur-3xl dark:from-(--blue-900) dark:to-(--cyan-900)" />
     <div className="absolute -right-24 -bottom-24 size-96 bg-linear-65 from-(--teal-400) to-(--green-400) opacity-60 blur-3xl dark:from-(--teal-900) dark:to-(--green-900)" />

--- a/apps/main/src/app/_components/playgrounds/caret-position-from-point/caret-position-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/caret-position-from-point/caret-position-demo.tsx
@@ -97,7 +97,7 @@ export function CaretPositionDemo() {
               color="gray"
               onClick={handleReset}
               size="sm"
-              variant="outlined"
+              variant="outline"
             >
               リセット
             </Button>

--- a/apps/main/src/app/_components/playgrounds/caret-position-from-point/drag-drop-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/caret-position-from-point/drag-drop-demo.tsx
@@ -90,7 +90,7 @@ export function DragDropDemo() {
             {word}
           </span>
         ))}
-        <Button color="gray" onClick={handleReset} size="sm" variant="outlined">
+        <Button color="gray" onClick={handleReset} size="sm" variant="outline">
           リセット
         </Button>
       </div>

--- a/apps/main/src/app/_components/playgrounds/container-style-queries/container-style-queries-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/container-style-queries/container-style-queries-demo.tsx
@@ -71,10 +71,9 @@ export function ContainerStyleQueriesDemo() {
         <Radio
           aria-labelledby={labelId}
           name={`csq-theme-${labelId}`}
-          onChange={(event) => {
-            const next = event.target.value;
-            if (isTheme(next)) {
-              setTheme(next);
+          onChange={(value) => {
+            if (isTheme(value)) {
+              setTheme(value);
             }
           }}
           options={themeOptions}

--- a/apps/main/src/app/_components/playgrounds/event-timing/event-timing-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/event-timing/event-timing-demo.tsx
@@ -136,7 +136,7 @@ export function EventTimingDemo() {
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3">
         <Button onClick={handleClick}>クリックして計測</Button>
-        <Button color="gray" onClick={handleReset} size="sm" variant="outlined">
+        <Button color="gray" onClick={handleReset} size="sm" variant="outline">
           リセット
         </Button>
         <span className="text-fg-mute text-sm">

--- a/apps/main/src/app/_components/playgrounds/font-family-math/font-family-math-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/font-family-math/font-family-math-demo.tsx
@@ -16,8 +16,8 @@ export function FontFamilyMathDemo() {
     <div className="space-y-6">
       <Checkbox
         label="mathフォントを適用する"
-        onChange={(e) => {
-          setUseMathFont(e.target.checked);
+        onChange={(checked) => {
+          setUseMathFont(checked);
         }}
         value={useMathFont}
       />

--- a/apps/main/src/app/_components/playgrounds/input-file-webkitdirectory/webkit-relative-path-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/input-file-webkitdirectory/webkit-relative-path-demo.tsx
@@ -8,7 +8,7 @@ export const WebkitRelativePathDemo = () => (
       <FileField.Root webkitDirectory {...props}>
         <FileField.Trigger
           renderItem={({ disabled, onClick }) => (
-            <Button disabled={disabled} onClick={onClick} variant="outlined">
+            <Button disabled={disabled} onClick={onClick} variant="outline">
               ファイルを選択
             </Button>
           )}

--- a/apps/main/src/app/_components/playgrounds/largest-contentful-paint/lcp-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/largest-contentful-paint/lcp-demo.tsx
@@ -93,7 +93,7 @@ export function LCPDemo() {
   return (
     <div className="space-y-4">
       <div className="flex flex-wrap items-center gap-3">
-        <Button color="gray" onClick={handleReset} size="sm" variant="outlined">
+        <Button color="gray" onClick={handleReset} size="sm" variant="outline">
           リセット
         </Button>
         <span className="text-fg-mute text-sm">

--- a/apps/main/src/app/_components/playgrounds/popover/tooltip-dropdown-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/popover/tooltip-dropdown-demo.tsx
@@ -24,7 +24,7 @@ export const TooltipDropdownDemo: FC = () => (
       <div className="flex flex-col items-center gap-2">
         <p className="text-lg font-bold md:text-xl">Dropdown Menu</p>
         <DropdownMenu.Root>
-          <DropdownMenu.Trigger text="Options" variant="outlined" />
+          <DropdownMenu.Trigger text="Options" variant="outline" />
           <DropdownMenu.Content>
             <DropdownMenu.Item
               label="Item 1"

--- a/apps/main/src/app/_components/playgrounds/requestclose/dialog-requestclose-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/requestclose/dialog-requestclose-demo.tsx
@@ -82,7 +82,7 @@ export const DialogRequestCloseDemo: FC = () => {
               onClick={() => {
                 ref.current?.requestClose();
               }}
-              variant="outlined"
+              variant="outline"
             >
               閉じる
             </Button>

--- a/apps/main/src/app/_components/playgrounds/scrollend/scrollend-trigger-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/scrollend/scrollend-trigger-demo.tsx
@@ -87,7 +87,7 @@ export function ScrollendTriggerDemo() {
             {lastTrigger}
           </div>
         )}
-        <Button color="gray" onClick={reset} size="sm" variant="outlined">
+        <Button color="gray" onClick={reset} size="sm" variant="outline">
           リセット
         </Button>
       </div>

--- a/apps/main/src/app/_components/playgrounds/suspense-list/suspense-list-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/suspense-list/suspense-list-demo.tsx
@@ -46,22 +46,22 @@ export const SuspenseListDemo: FC = () => {
     <div className="flex flex-col gap-6">
       <Alert
         message="React v19.2、Nextjs v16で利用ができなくなったため、現在こちらの機能は利用できません。"
-        status="info"
+        tone="info"
       />
       <div className="flex flex-col gap-4">
         <Checkbox
           label="SuspenseListを利用する"
-          onChange={(e) => {
+          onChange={(checked) => {
             resetData();
-            setUseSuspenseList(e.target.checked);
+            setUseSuspenseList(checked);
           }}
           value={useSuspenseList}
         />
         <Checkbox
           label="フォルバックUIを表示する"
-          onChange={(e) => {
+          onChange={(checked) => {
             resetData();
-            setHasFallback(e.target.checked);
+            setHasFallback(checked);
           }}
           value={hasFallback}
         />

--- a/apps/main/src/app/_components/playgrounds/text-indent-keywords/text-indent-keywords-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/text-indent-keywords/text-indent-keywords-demo.tsx
@@ -41,15 +41,15 @@ export function TextIndentKeywordsDemo() {
         />
         <Checkbox
           label="each-line"
-          onChange={(e) => {
-            setUseEachLine(e.target.checked);
+          onChange={(checked) => {
+            setUseEachLine(checked);
           }}
           value={useEachLine}
         />
         <Checkbox
           label="hanging"
-          onChange={(e) => {
-            setUseHanging(e.target.checked);
+          onChange={(checked) => {
+            setUseHanging(checked);
           }}
           value={useHanging}
         />

--- a/apps/main/src/app/_components/playgrounds/toggleevent-source/toggleevent-source-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/toggleevent-source/toggleevent-source-demo.tsx
@@ -165,7 +165,7 @@ export function ToggleEventSourceDemo() {
             popoverTarget={POPOVER_ID}
             popoverTargetAction="hide"
             size="sm"
-            variant="outlined"
+            variant="outline"
           >
             閉じる
           </Button>

--- a/apps/main/src/app/artifacts/_components/artifact-card/artifact-card.tsx
+++ b/apps/main/src/app/artifacts/_components/artifact-card/artifact-card.tsx
@@ -50,7 +50,7 @@ export const ArtifactCard: FC<Artifact> = ({
           )}
           size="sm"
           startIcon={<GitHubIcon size="sm" />}
-          variant="outlined"
+          variant="outline"
         >
           GitHubで見る
         </Button>
@@ -68,7 +68,7 @@ export const ArtifactCard: FC<Artifact> = ({
             )}
             size="sm"
             startIcon={<ExternalLinkIcon size="sm" />}
-            variant="outlined"
+            variant="outline"
           >
             サイトで見る
           </Button>
@@ -87,7 +87,7 @@ export const ArtifactCard: FC<Artifact> = ({
             )}
             size="sm"
             startIcon={<ExternalLinkIcon size="sm" />}
-            variant="outlined"
+            variant="outline"
           >
             npmで見る
           </Button>

--- a/apps/main/src/app/base-converter/_components/base-converter/base-converter.tsx
+++ b/apps/main/src/app/base-converter/_components/base-converter/base-converter.tsx
@@ -94,7 +94,7 @@ export const BaseConverter = () => {
                     {...props}
                   />
                   <IconButton
-                    bg="base"
+                    color="base"
                     label={`${label}をコピー`}
                     onClick={() => {
                       handleCopy(values[base], label);

--- a/apps/main/src/app/blog/(articles)/react-children-props/page.mdx
+++ b/apps/main/src/app/blog/(articles)/react-children-props/page.mdx
@@ -31,7 +31,7 @@ const ParentComponent: FC<PropsWithChildren> = ({
 ## cloneElement
 
 <Alert
-  status="warning"
+  tone="warning"
   message="ここで紹介するcloneElementとisValidElementはReactのレガシーAPIです。推奨されるAPIではないため新しく実装する場合はこの後に紹介するrender propパターンを使ってください。"
 />
 

--- a/apps/main/src/app/blog/(articles)/spelling-grammar-error/page.mdx
+++ b/apps/main/src/app/blog/(articles)/spelling-grammar-error/page.mdx
@@ -18,7 +18,7 @@ import { Playground } from '@/app/_components/playgrounds';
 ## はじめに
 
 <Alert
-  status="warning"
+  tone="warning"
   message="【連絡】この記事では以前、紹介する機能がFirefox 140のリリースによってBaseline入りしたと記述していましたが、実際には導入されていませんでしたのでその部分を修正しています。"
 />
 

--- a/apps/main/src/app/blog/(articles)/suspense-list/page.mdx
+++ b/apps/main/src/app/blog/(articles)/suspense-list/page.mdx
@@ -13,7 +13,7 @@ import { Playground } from '@/app/_components/playgrounds';
 # 複数のSuspenseの表示を制御するSuspenseList
 
 <Alert
-  status="warning"
+  tone="warning"
   message="SuspenseListは実験中の機能です。今後一部の機能や名前が変更される恐れがあります。"
 />
 

--- a/apps/main/src/app/blog/(articles)/tanstack-router-introduction/page.mdx
+++ b/apps/main/src/app/blog/(articles)/tanstack-router-introduction/page.mdx
@@ -13,7 +13,7 @@ import icon from './_images/icon.png';
 # Reactの新しいルーティングライブラリ、TanStackRouterを学ぶ
 
 <Alert
-  status="warning"
+  tone="warning"
   message="この記事の内容は2023年7月時点のTanStack Routerがbeta版であったときの内容です。現在の機能とは大きく異なっていることが考えられるので、最新の情報は公式ドキュメントを参照してください。"
 />
 

--- a/apps/main/src/app/blog/_components/blog-layout/slide-link-button.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/slide-link-button.tsx
@@ -17,7 +17,7 @@ export const SlideLinkButton: FC<{ href: string }> = ({ href }) => (
     )}
     size="sm"
     startIcon={<SlideIcon size="sm" />}
-    variant="outlined"
+    variant="outline"
   >
     スライドを見る
   </Button>

--- a/apps/main/src/app/blog/_components/blog-layout/writing-mode/writing-mode-switcher.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/writing-mode/writing-mode-switcher.tsx
@@ -18,7 +18,7 @@ export const WritingModeSwitcher: FC = () => {
   return (
     <IconButton
       aria-pressed={isVertical}
-      bg="base"
+      color="base"
       label={label}
       onAction={toggle}
       size="md"

--- a/apps/main/src/app/blog/_components/external-blog/external-blog.tsx
+++ b/apps/main/src/app/blog/_components/external-blog/external-blog.tsx
@@ -6,7 +6,7 @@ import type { FC } from 'react';
 export const ExternalBlog: FC = () => (
   <div className="flex gap-4">
     <IconButton
-      bg="base"
+      color="base"
       label="Qiitaのアカウント"
       renderItem={({
         className,
@@ -29,7 +29,7 @@ export const ExternalBlog: FC = () => (
       <QiitaIcon />
     </IconButton>
     <IconButton
-      bg="base"
+      color="base"
       label="RSSフィード"
       renderItem={({
         className,

--- a/apps/main/src/app/color-converter/_components/color-converter/color-converter.tsx
+++ b/apps/main/src/app/color-converter/_components/color-converter/color-converter.tsx
@@ -141,7 +141,7 @@ export const ColorConverter = () => {
                 <span className="text-fg-mute">#</span>
                 <TextField onChange={handleChangeHex} value={hex} {...props} />
                 <IconButton
-                  bg="base"
+                  color="base"
                   label="HEXをコピー"
                   onClick={() => {
                     handleCopy(`#${hex}`, 'HEX');
@@ -250,7 +250,7 @@ export const ColorConverter = () => {
               />
             </div>
             <IconButton
-              bg="base"
+              color="base"
               label="RGBをコピー"
               onClick={() => {
                 handleCopy(rgbCopyValue, 'RGB');
@@ -357,7 +357,7 @@ export const ColorConverter = () => {
               />
             </div>
             <IconButton
-              bg="base"
+              color="base"
               label="HSLをコピー"
               onClick={() => {
                 handleCopy(hslCopyValue, 'HSL');

--- a/apps/main/src/app/contrast-checker/_components/check-contrast/check-contrast.tsx
+++ b/apps/main/src/app/contrast-checker/_components/check-contrast/check-contrast.tsx
@@ -47,7 +47,7 @@ export const CheckContrast: FC = () => {
       {contrast < WCAG_THRESHOLDS.LOW_VISIBILITY_WARNING && (
         <Alert
           message="コントラスト比が非常に低いため、テキストが見えにくい場合があります"
-          status="warning"
+          tone="warning"
         />
       )}
       <section

--- a/apps/main/src/app/japanese-text-fixer/_components/complete-phase/complete-phase.tsx
+++ b/apps/main/src/app/japanese-text-fixer/_components/complete-phase/complete-phase.tsx
@@ -44,12 +44,9 @@ export const CompletePhase: FC = () => {
   return (
     <div className="flex flex-col gap-6">
       {hadErrors ? (
-        <Alert message="校正が完了しました" status="success" />
+        <Alert message="校正が完了しました" tone="success" />
       ) : (
-        <Alert
-          message="テキストに問題は見つかりませんでした"
-          status="success"
-        />
+        <Alert message="テキストに問題は見つかりませんでした" tone="success" />
       )}
       <section className="flex flex-col gap-2">
         <div className="flex items-center justify-between">
@@ -74,7 +71,7 @@ export const CompletePhase: FC = () => {
             <Button
               disabled={isChecking || displayText === ''}
               onClick={handleRecheck}
-              variant="outlined"
+              variant="outline"
             >
               {isChecking ? '校正中...' : 'もう一度校正する'}
             </Button>
@@ -82,7 +79,7 @@ export const CompletePhase: FC = () => {
               onClick={() => {
                 dispatch({ type: 'RESET' });
               }}
-              variant="outlined"
+              variant="outline"
             >
               新しいテキストを校正する
             </Button>

--- a/apps/main/src/app/japanese-text-fixer/_components/review-phase/review-phase.tsx
+++ b/apps/main/src/app/japanese-text-fixer/_components/review-phase/review-phase.tsx
@@ -151,7 +151,7 @@ export const ReviewPhase: FC = () => {
             <Button
               disabled={isChecking || reviewText === ''}
               onClick={handleRecheck}
-              variant="outlined"
+              variant="outline"
             >
               {isChecking ? '校正中...' : 'もう一度校正する'}
             </Button>

--- a/apps/main/src/app/notifications/_components/push-subscribe/push-subscribe.tsx
+++ b/apps/main/src/app/notifications/_components/push-subscribe/push-subscribe.tsx
@@ -140,18 +140,18 @@ export const PushSubscribe: FC<Props> = ({ vapidPublicKey }) => {
         </p>
         {!isSupported && (
           <Alert
-            status="warning"
+            tone="warning"
             message="このブラウザはプッシュ通知に対応していません。iOSではホーム画面に追加したアプリから開いてください。"
           />
         )}
-        {error !== null && <Alert status="error" message={error} />}
-        {isSubscribed && <Alert status="success" message="通知を購読中です" />}
+        {error !== null && <Alert tone="error" message={error} />}
+        {isSubscribed && <Alert tone="success" message="通知を購読中です" />}
         {isSupported && (
           <div>
             {isSubscribed ? (
               <Button
                 color="gray"
-                variant="outlined"
+                variant="outline"
                 disabled={isLoading}
                 onClick={() => void unsubscribe()}
                 startIcon={<SubscribeIcon />}
@@ -161,7 +161,7 @@ export const PushSubscribe: FC<Props> = ({ vapidPublicKey }) => {
             ) : (
               <Button
                 color="primary"
-                variant="contained"
+                variant="solid"
                 disabled={isLoading}
                 onClick={() => void subscribe()}
                 startIcon={<SubscribeIcon />}

--- a/apps/main/src/app/qr-generator/_components/qr-generator/qr-generator.tsx
+++ b/apps/main/src/app/qr-generator/_components/qr-generator/qr-generator.tsx
@@ -123,7 +123,7 @@ export const QrGenerator = () => {
                   }}
                 />
               </div>
-              <Button onClick={handleDownload} variant="contained">
+              <Button onClick={handleDownload} variant="solid">
                 SVGをダウンロード
               </Button>
             </>

--- a/apps/main/src/app/radius-maker/_components/control-panel/control-panel.tsx
+++ b/apps/main/src/app/radius-maker/_components/control-panel/control-panel.tsx
@@ -233,7 +233,7 @@ export const ControlPanel: FC = () => {
             }}
             size="sm"
             startIcon={<CopyIcon size="sm" />}
-            variant="outlined"
+            variant="outline"
           >
             コピー
           </Button>

--- a/apps/main/src/app/radius-maker/_components/template-selector/template-selector.tsx
+++ b/apps/main/src/app/radius-maker/_components/template-selector/template-selector.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button, RadioCard } from '@k8o/arte-odyssey';
-import { type ChangeEventHandler, type FC, useCallback, useId } from 'react';
+import { type FC, useCallback, useId } from 'react';
 
 import type { RadiusPosition } from '../../_types/radius-position';
 import { positionToBorderRadius } from '../../_utils/position-to-border-radius';
@@ -161,9 +161,9 @@ export const TemplateSelector: FC<Props> = ({ onSelect, currentPosition }) => {
       ),
     )?.name ?? '';
 
-  const handleChange: ChangeEventHandler<HTMLInputElement> = useCallback(
-    (e) => {
-      const template = TEMPLATES.find((t) => t.name === e.target.value);
+  const handleChange = useCallback(
+    (value: string) => {
+      const template = TEMPLATES.find((t) => t.name === value);
       if (template) {
         onSelect(template.position);
       }
@@ -188,7 +188,7 @@ export const TemplateSelector: FC<Props> = ({ onSelect, currentPosition }) => {
           onSelect(generateRandomPosition());
         }}
         size="sm"
-        variant="outlined"
+        variant="outline"
       >
         ランダム
       </Button>

--- a/apps/main/src/app/reading-list/_components/reading-list-content/reading-list-content.tsx
+++ b/apps/main/src/app/reading-list/_components/reading-list-content/reading-list-content.tsx
@@ -151,7 +151,7 @@ export const ReadingListContent: FC<Props> = ({ articles, sources, cards }) => {
               }}
               size="sm"
               startIcon={<ListIcon />}
-              variant="outlined"
+              variant="outline"
             >
               絞り込み
             </Button>

--- a/apps/main/src/app/reading-list/_components/rss-link/rss-link.tsx
+++ b/apps/main/src/app/reading-list/_components/rss-link/rss-link.tsx
@@ -5,7 +5,7 @@ import type { FC } from 'react';
 
 export const RssLink: FC = () => (
   <IconButton
-    bg="base"
+    color="base"
     label="RSSフィード"
     renderItem={({
       className,

--- a/apps/main/src/app/slides/_components/slide-deck/deck-viewer/deck-viewer.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/deck-viewer/deck-viewer.tsx
@@ -63,7 +63,7 @@ export const DeckViewer: FC<{
         <header className="flex items-center justify-between gap-4 px-4 py-2">
           <div className="flex items-center gap-2">
             <IconButton
-              bg="transparent"
+              color="transparent"
               label="Slides一覧へ戻る"
               renderItem={({
                 className,
@@ -118,7 +118,7 @@ export const DeckViewer: FC<{
         <div className="pointer-events-none absolute top-2 right-2 z-10">
           <div className="pointer-events-auto">
             <IconButton
-              bg="base"
+              color="base"
               label="発表者モードを終了"
               onClick={() => {
                 setIsPresenting(false);

--- a/apps/main/src/app/slides/_components/slide-deck/nav-button/nav-button.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/nav-button/nav-button.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 export const NavButton: FC<Props> = ({ direction, disabled, onAction }) => (
   <IconButton
-    bg="transparent"
+    color="transparent"
     label={direction === 'prev' ? '前のスライド' : '次のスライド'}
     onAction={onAction}
     renderItem={({

--- a/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns-by-form.tsx
+++ b/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns-by-form.tsx
@@ -177,10 +177,10 @@ const ColumnItem: FC<{
                     <Radio
                       aria-labelledby={ariaLabelledby}
                       disabled={disabled}
-                      onChange={(e) => {
+                      onChange={(value) => {
                         handleChangeColumn(id)({
                           ...column,
-                          nullable: e.target.value === '0',
+                          nullable: value === '0',
                         });
                       }}
                       options={[

--- a/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns-by-table.tsx
+++ b/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns-by-table.tsx
@@ -184,10 +184,10 @@ export const CreateColumnsByTable: FC<Props> = ({
                   <td className="px-3 py-2.5 text-center">
                     <Checkbox
                       label="NULL許容"
-                      onChange={(e) => {
+                      onChange={(checked) => {
                         handleChangeColumn(id)({
                           ...column,
-                          nullable: e.target.checked,
+                          nullable: checked,
                         });
                       }}
                       value={column.nullable}

--- a/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns.tsx
+++ b/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns.tsx
@@ -41,7 +41,7 @@ export const CreateColumns: FC<Props> = ({
             onClick={handleAddColumn}
             size="sm"
             startIcon={<PlusIcon />}
-            variant="outlined"
+            variant="outline"
           >
             カラムを追加
           </Button>
@@ -57,7 +57,7 @@ export const CreateColumns: FC<Props> = ({
             }}
             size="sm"
             startIcon={showTable ? <FormIcon /> : <TableIcon />}
-            variant="outlined"
+            variant="outline"
           >
             {showTable ? 'フォーム' : 'テーブル'}形式
           </Button>

--- a/apps/main/src/app/sql-table-builder/_components/create-columns/loading-create-columns.tsx
+++ b/apps/main/src/app/sql-table-builder/_components/create-columns/loading-create-columns.tsx
@@ -6,7 +6,7 @@ export const LoadingCreateColumns: FC = () => (
     {/* ツールバー */}
     <div className="flex flex-wrap items-center justify-between gap-3">
       <div className="flex items-center gap-2">
-        <Button size="sm" startIcon={<PlusIcon />} variant="outlined">
+        <Button size="sm" startIcon={<PlusIcon />} variant="outline">
           カラムを追加
         </Button>
         <span className="text-fg-mute text-sm">0個のカラム</span>

--- a/apps/main/src/app/sql-table-builder/_components/create-restrictions/create-restrictions.tsx
+++ b/apps/main/src/app/sql-table-builder/_components/create-restrictions/create-restrictions.tsx
@@ -145,7 +145,7 @@ export const CreateRestrictions: FC<Props> = ({
             onClick={handleAddRestriction}
             size="sm"
             startIcon={<PlusIcon />}
-            variant="outlined"
+            variant="outline"
           >
             制約を追加
           </Button>
@@ -178,7 +178,7 @@ export const CreateRestrictions: FC<Props> = ({
             onClick={handleAddRestriction}
             size="sm"
             startIcon={<PlusIcon />}
-            variant="outlined"
+            variant="outline"
           >
             制約を追加
           </Button>

--- a/apps/main/src/app/talks/_components/talk-card/talk-card.tsx
+++ b/apps/main/src/app/talks/_components/talk-card/talk-card.tsx
@@ -104,7 +104,7 @@ export const TalkCard: FC<{
           )}
           size="sm"
           startIcon={<SlideIcon size="sm" />}
-          variant="outlined"
+          variant="outline"
         >
           スライドを見る
         </Button>

--- a/apps/main/src/app/text-diff/_components/text-diff/text-diff.tsx
+++ b/apps/main/src/app/text-diff/_components/text-diff/text-diff.tsx
@@ -70,7 +70,7 @@ export const TextDiff = () => {
               setResultPosition('top');
             }}
             size="sm"
-            variant={resultPosition === 'top' ? 'contained' : 'outlined'}
+            variant={resultPosition === 'top' ? 'solid' : 'outline'}
           >
             上に表示
           </Button>
@@ -79,7 +79,7 @@ export const TextDiff = () => {
               setResultPosition('bottom');
             }}
             size="sm"
-            variant={resultPosition === 'bottom' ? 'contained' : 'outlined'}
+            variant={resultPosition === 'bottom' ? 'solid' : 'outline'}
           >
             下に表示
           </Button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@k8o/arte-odyssey':
-      specifier: 9.1.0
-      version: 9.1.0
+      specifier: 10.0.0
+      version: 10.0.0
     '@storybook/addon-a11y':
       specifier: 10.4.1
       version: 10.4.1
@@ -133,7 +133,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 9.1.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)
+        version: 10.0.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -227,7 +227,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 9.1.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)
+        version: 10.0.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
       '@mdx-js/loader':
         specifier: 3.1.1
         version: 3.1.1
@@ -1668,15 +1668,28 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@k8o/arte-odyssey@9.1.0':
-    resolution: {integrity: sha512-4APf/r+FMljyb3fQgYob+lAtBrxyMTaC/Z3E1GrczpjSzfG8U3ZDoqQ62WHl/DYRAZKXz+QCF1QcJbcbo8GlhA==}
+  '@k8o/arte-odyssey@10.0.0':
+    resolution: {integrity: sha512-8jb4ab3IBcCcGOrWGHM1+XbxTbXa8MWBJ4Ks+c331cG7XmosyD61hK9r0A3GujJgSrKQJWlxgB9mTcqavyObcA==}
     peerDependencies:
+      '@json-render/core': '>=0.19.0'
+      '@json-render/react': '>=0.19.0'
+      '@openuidev/react-lang': '>=0.2.6'
       '@types/react': '>=19.0.0'
       '@types/react-dom': '>=19.0.0'
       react: '>=19.0.0'
       react-dom: '>=19.0.0'
       tailwindcss: '>=4.0.0'
-      typescript: '>=5.9.0'
+      typescript: '>=6.0.0'
+      zod: '>=4.4.0'
+    peerDependenciesMeta:
+      '@json-render/core':
+        optional: true
+      '@json-render/react':
+        optional: true
+      '@openuidev/react-lang':
+        optional: true
+      zod:
+        optional: true
 
   '@k8o/oxc-config@0.1.2':
     resolution: {integrity: sha512-AsrHdwWPLI9UUCF4j+8UANLLDWHHRtLaIrGkC+KbW4cAIzb+ag30nAVzWKViVB7+tgKp7Du96iWfmApTSDC5fQ==}
@@ -4999,8 +5012,8 @@ packages:
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
-  lucide-react@1.14.0:
-    resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
+  lucide-react@1.17.0:
+    resolution: {integrity: sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
@@ -5185,8 +5198,8 @@ packages:
   motion-utils@12.39.0:
     resolution: {integrity: sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==}
 
-  motion@12.38.0:
-    resolution: {integrity: sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==}
+  motion@12.40.0:
+    resolution: {integrity: sha512-yjrHUrBFW6kQvjJwRsoiPSAhC5tRwRqNGJWmiJ4CrGnbKp0V88AdzkhBmDoqIsIPfarOe0Uddd37Xq43/gIocA==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^18.0.0 || ^19.0.0
@@ -5905,9 +5918,6 @@ packages:
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
     engines: {node: '>=20'}
-
-  tailwind-merge@3.5.0:
-    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -7210,20 +7220,22 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@k8o/arte-odyssey@9.1.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)':
+  '@k8o/arte-odyssey@10.0.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/react': 19.2.15
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
       baseline-status: 1.1.1
       clsx: 2.1.1
-      lucide-react: 1.14.0(react@19.2.6)
-      motion: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      lucide-react: 1.17.0(react@19.2.6)
+      motion: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      tailwind-merge: 3.5.0
+      tailwind-merge: 3.6.0
       tailwindcss: 4.3.0
       typescript: 6.0.3
+    optionalDependencies:
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
 
@@ -10160,7 +10172,7 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@1.14.0(react@19.2.6):
+  lucide-react@1.17.0(react@19.2.6):
     dependencies:
       react: 19.2.6
 
@@ -10555,7 +10567,7 @@ snapshots:
 
   motion-utils@12.39.0: {}
 
-  motion@12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+  motion@12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       framer-motion: 12.40.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       tslib: 2.8.1
@@ -11511,8 +11523,6 @@ snapshots:
   tabbable@6.4.0: {}
 
   tagged-tag@1.0.0: {}
-
-  tailwind-merge@3.5.0: {}
 
   tailwind-merge@3.6.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@k8o/arte-odyssey':
-      specifier: 10.0.0
-      version: 10.0.0
+      specifier: 10.0.1
+      version: 10.0.1
     '@storybook/addon-a11y':
       specifier: 10.4.1
       version: 10.4.1
@@ -133,7 +133,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.0.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.0.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -227,7 +227,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.0.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.0.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
       '@mdx-js/loader':
         specifier: 3.1.1
         version: 3.1.1
@@ -1317,6 +1317,9 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@iarna/toml@2.2.5':
+    resolution: {integrity: sha512-trnsAYxU3xnS1gPHPyU961coFyLkh4gAD/0zQ5mymY4yOZ+CYvsPqUbOFSw0aDM4y0tV7tiFxL/1XfXPNC6IPg==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -1668,8 +1671,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@k8o/arte-odyssey@10.0.0':
-    resolution: {integrity: sha512-8jb4ab3IBcCcGOrWGHM1+XbxTbXa8MWBJ4Ks+c331cG7XmosyD61hK9r0A3GujJgSrKQJWlxgB9mTcqavyObcA==}
+  '@k8o/arte-odyssey@10.0.1':
+    resolution: {integrity: sha512-lpPQ8FAEaS11A8DNtPWxgWKQaHX+3jelLhNZ3ChnOVfNxBks+jlXIAuts2Wn1M7G69aShSfwDGj5X6jTiKDtVQ==}
     peerDependencies:
       '@json-render/core': '>=0.19.0'
       '@json-render/react': '>=0.19.0'
@@ -2748,8 +2751,8 @@ packages:
   '@prisma/schema-files-loader@6.8.2':
     resolution: {integrity: sha512-JRXJ08xfA1cP30kgP15AMCOKZchy2ss2oN6nSHxN745euh2tijpzvW4yCD4Q/1ZtnDkfKae45Tcpx0Ytab7RPA==}
 
-  '@react-grab/cli@0.1.37':
-    resolution: {integrity: sha512-1ln28VkVHUbd5qy+ccXG68voWc0mgZMhBnwG0umxfD+wbkXUcvRzVrLjSqao7N8hCrDqp+Pt5j9Tsqef+9yQQQ==}
+  '@react-grab/cli@0.1.43':
+    resolution: {integrity: sha512-S+UBB0Mwu1g0Cjhff5YzsA33YFYu91DmazPL9uVvF1wDjsO2Lu9hKN/OzBCHYjWlxdBT7TLy2A6pNTS3Sx8o9w==}
     hasBin: true
 
   '@reduxjs/toolkit@2.12.0':
@@ -3745,6 +3748,10 @@ packages:
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agent-install@0.0.5:
+    resolution: {integrity: sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==}
+    hasBin: true
 
   ai@6.0.191:
     resolution: {integrity: sha512-zAxvjKebQE7YkSyyNIl0OM7i6/zygnKeF+yNUjD4nWOelYrG+LpDd6RnH6mjySI4zUpZ7o4wbnmAy8jc6u98vQ==}
@@ -5527,8 +5534,8 @@ packages:
     peerDependencies:
       react: ^19.2.6
 
-  react-grab@0.1.37:
-    resolution: {integrity: sha512-XVAc/qPyxsDT8Putu9UnP7iVHmAORMzvaN/3GDTOfbuLIRXWdOt7vebPOzM9RVTVUjucXv0135JI++kSVPSfYg==}
+  react-grab@0.1.43:
+    resolution: {integrity: sha512-3wplt0CobZE5k1Vf3PBqBm3vlNQnVWEpSGBMHRnnFcj/khYYwGXSMSTedW1s8MI5FqkdhU/CFoJ7hQqGwzqFIA==}
     hasBin: true
     peerDependencies:
       react: '>=17.0.0'
@@ -6942,6 +6949,8 @@ snapshots:
 
   '@floating-ui/utils@0.2.11': {}
 
+  '@iarna/toml@2.2.5': {}
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -7220,7 +7229,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@k8o/arte-odyssey@10.0.0(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)':
+  '@k8o/arte-odyssey@10.0.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@types/react': 19.2.15
@@ -8032,8 +8041,9 @@ snapshots:
       '@prisma/prisma-schema-wasm': 6.8.0-43.2060c79ba17c6bb9f5823312b6f6b7f4a845738e
       fs-extra: 11.3.0
 
-  '@react-grab/cli@0.1.37':
+  '@react-grab/cli@0.1.43':
     dependencies:
+      agent-install: 0.0.5
       commander: 14.0.3
       ignore: 7.0.5
       jsonc-parser: 3.3.1
@@ -8917,6 +8927,15 @@ snapshots:
   acorn@8.16.0: {}
 
   agent-base@7.1.4: {}
+
+  agent-install@0.0.5:
+    dependencies:
+      '@iarna/toml': 2.2.5
+      commander: 14.0.3
+      jsonc-parser: 3.3.1
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      yaml: 2.9.0
 
   ai@6.0.191(zod@4.4.3):
     dependencies:
@@ -11024,9 +11043,9 @@ snapshots:
       react: 19.2.6
       scheduler: 0.27.0
 
-  react-grab@0.1.37(react@19.2.6):
+  react-grab@0.1.43(react@19.2.6):
     dependencies:
-      '@react-grab/cli': 0.1.37
+      '@react-grab/cli': 0.1.43
       bippy: 0.5.41(react@19.2.6)
     optionalDependencies:
       react: 19.2.6
@@ -11062,7 +11081,7 @@ snapshots:
       prompts: 2.4.2
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-      react-grab: 0.1.37(react@19.2.6)
+      react-grab: 0.1.43(react@19.2.6)
     optionalDependencies:
       esbuild: 0.28.0
       unplugin: 2.1.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ allowBuilds:
 blockExoticSubdeps: true
 
 catalog:
-  '@k8o/arte-odyssey': 10.0.0
+  '@k8o/arte-odyssey': 10.0.1
   '@storybook/addon-a11y': 10.4.1
   '@storybook/addon-docs': 10.4.1
   '@storybook/addon-mcp': '0.6.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -13,7 +13,7 @@ allowBuilds:
 blockExoticSubdeps: true
 
 catalog:
-  '@k8o/arte-odyssey': 9.1.0
+  '@k8o/arte-odyssey': 10.0.0
   '@storybook/addon-a11y': 10.4.1
   '@storybook/addon-docs': 10.4.1
   '@storybook/addon-mcp': '0.6.0'


### PR DESCRIPTION
## 概要

`@k8o/arte-odyssey` を **9.1.0 → 10.0.0**（メジャー）へ更新し、v10 の破壊的変更に全面追従しました。catalog（`pnpm-workspace.yaml`）のバージョンを上げ、`apps/main` / `apps/admin` 両アプリの利用箇所を移行しています。

## 破壊的変更への対応（[リリースノート](https://github.com/k35o/arte-odyssey/releases/tag/%40k8o%2Farte-odyssey%4010.0.0)）

| 変更 | 内容 |
|------|------|
| **#518 語彙統一** | `Button`/`DropdownMenu.Trigger` の `variant`: `contained`→`solid` / `outlined`→`outline`。`IconButton` の `bg`→`color`。`Alert` の `status`→`tone`（`AlertIcon` の `status` は意味が異なるため**据え置き**） |
| **#517 onChange 値型化** | `Switch`/`Checkbox` → `(checked: boolean, event?)`、`Radio`/`RadioCard` → `(value: string)` に追従。不要になった `ChangeEvent`/`ChangeEventHandler` の import も削除 |
| **#516 peer 更新** | `typescript >=6.0.0`（catalog の `typescript 6.0.3` で充足済み） |
| **#519 Drawer** | controlled（`isOpen`+`onClose`）の既存利用はそのまま動作（型・テスト通過） |
| **#499 tokens / #497 Generative UI** | アプリ未使用のため影響なし |

## その他

- **#493（v10）で Card にのみ dark モード用の subtle border が追加**されたため、同じ `appearance="shadow"` を使う `InteractiveCard`（= Top の `AppCard`）が dark で浮かず違和感が出ていました。`InteractiveCard` は `className` を受け付けない型のため、`AppCard` のカード本体側に `border border-transparent dark:border-border-subtle` を補う**暫定対応**を入れています（`apps/main/.../app-card/app-card.tsx`）。本筋は上流 `InteractiveCard` 側で揃えること。

## 検証

- `pnpm type-check`: 全パッケージ成功
- `pnpm check`（lint/format）: 0 エラー（既存の 14 warning のみ、本変更と無関係）
- `pnpm test`: 全タスク成功（main 283 件・Storybook play 関数含む）
- AppCard の枠は Storybook で実測確認: dark = `border-border-subtle` 可視 / light = 透明（見た目変化なし）

## レビュアー向けメモ

- 変更の大半は機械的なリネーム（variant / bg→color / status→tone）。ロジック変更があるのはフォーム系 `onChange` の値型化のみ。
- `AppCard` の border は上流修正が入ったら剥がせる暫定対応です。