### PR TITLE
feat: 背景をクラゲの足のモチーフのデザインに刷新

### DIFF
--- a/apps/main/src/app/_components/global-layout/background/background.module.css
+++ b/apps/main/src/app/_components/global-layout/background/background.module.css
@@ -1,0 +1,69 @@
+/*
+ * サイト全体の装飾背景。
+ * - 下地: オフホワイト/深色 + 上部からのブランドカラー(ティール)のグロー
+ * - クラゲの足(細いライン)を四隅(左上・右下)から流す。傘は描かない。
+ * - 全面に極薄のグレイン
+ * ライト/ダークは独立したトーンで設計する（単純反転にしない）。
+ */
+
+.background {
+  --bg: oklch(0.975 0.009 195);
+  --glow: oklch(0.72 0.17 185 / 0.24);
+  --leg: oklch(0.6 0.09 195 / 0.5);
+  --grain-opacity: 0.04;
+
+  position: fixed;
+  inset: 0;
+  z-index: -10;
+  overflow: hidden;
+  background-color: var(--bg);
+  background-image: radial-gradient(
+    110% 50% at 50% -8%,
+    var(--glow),
+    transparent 60%
+  );
+}
+
+:global(.dark) .background {
+  --bg: oklch(0.16 0.006 235);
+  --glow: oklch(0.7 0.13 180 / 0.1);
+  --leg: oklch(0.78 0.1 195 / 0.38);
+  --grain-opacity: 0.05;
+}
+
+.corner {
+  position: absolute;
+  width: 280px;
+  height: 280px;
+}
+
+.topLeft {
+  top: 0;
+  left: 0;
+}
+
+.bottomRight {
+  right: 0;
+  bottom: 0;
+  width: 230px;
+  height: 230px;
+  transform: rotate(180deg);
+}
+
+.leg {
+  fill: none;
+  stroke: var(--leg);
+  stroke-width: 1.4;
+  stroke-linecap: round;
+}
+
+.dot {
+  fill: var(--leg);
+}
+
+.grain {
+  position: absolute;
+  inset: 0;
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='140' height='140'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.8' numOctaves='2' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+}

--- a/apps/main/src/app/_components/global-layout/background/background.tsx
+++ b/apps/main/src/app/_components/global-layout/background/background.tsx
@@ -1,11 +1,61 @@
 import type { FC } from 'react';
 
+import styles from './background.module.css';
+
+type Dot = { cx: number; cy: number; r: number };
+
+// 左上の足（多め・大きめ）。viewBox 0 0 240 240。
+const legPathsTopLeft = [
+  'M 6 -16 C 36 36, 18 86, 70 116 C 104 135, 92 182, 138 196',
+  'M -16 26 C 40 44, 72 78, 72 124 C 72 158, 104 176, 116 208',
+  'M -8 72 C 28 80, 44 104, 40 140 C 38 162, 52 176, 70 186',
+];
+
+const dotsTopLeft: Dot[] = [
+  { cx: 58, cy: 104, r: 2 },
+  { cx: 84, cy: 142, r: 2 },
+  { cx: 112, cy: 180, r: 2 },
+  { cx: 72, cy: 126, r: 1.8 },
+  { cx: 104, cy: 176, r: 1.8 },
+  { cx: 42, cy: 140, r: 1.8 },
+  { cx: 60, cy: 182, r: 1.6 },
+];
+
+// 右下の足（左上とは別カーブ・少なめ）。左右で非対称にする。
+const legPathsBottomRight = [
+  'M -10 12 C 52 32, 30 92, 80 126 C 112 148, 98 198, 134 216',
+  'M -6 52 C 32 72, 50 112, 46 152 C 43 186, 62 202, 82 216',
+];
+
+const dotsBottomRight: Dot[] = [
+  { cx: 62, cy: 108, r: 1.8 },
+  { cx: 96, cy: 160, r: 1.8 },
+  { cx: 50, cy: 150, r: 1.6 },
+];
+
+const Legs: FC<{ paths: string[]; dots: Dot[] }> = ({ paths, dots }) => (
+  <svg viewBox="0 0 240 240" fill="none" aria-hidden="true">
+    <g className={styles['leg']}>
+      {paths.map((d) => (
+        <path key={d} d={d} />
+      ))}
+    </g>
+    <g className={styles['dot']}>
+      {dots.map((dot) => (
+        <circle key={`${dot.cx}-${dot.cy}`} cx={dot.cx} cy={dot.cy} r={dot.r} />
+      ))}
+    </g>
+  </svg>
+);
+
 export const Background: FC = () => (
-  <div
-    aria-hidden="true"
-    className="dark:bg-bg-surface fixed top-0 left-0 -z-10 size-full overflow-hidden bg-linear-65 from-(--cyan-100) to-(--teal-100) dark:bg-none"
-  >
-    <div className="absolute -top-24 -left-24 size-96 bg-linear-65 from-(--blue-400) to-(--cyan-400) opacity-60 blur-3xl dark:from-(--blue-900) dark:to-(--cyan-900)" />
-    <div className="absolute -right-24 -bottom-24 size-96 bg-linear-65 from-(--teal-400) to-(--green-400) opacity-60 blur-3xl dark:from-(--teal-900) dark:to-(--green-900)" />
+  <div aria-hidden="true" className={styles['background']}>
+    <div className={`${styles['corner']} ${styles['topLeft']}`}>
+      <Legs paths={legPathsTopLeft} dots={dotsTopLeft} />
+    </div>
+    <div className={`${styles['corner']} ${styles['bottomRight']}`}>
+      <Legs paths={legPathsBottomRight} dots={dotsBottomRight} />
+    </div>
+    <div className={styles['grain']} />
   </div>
 );


### PR DESCRIPTION
## 概要
サイト全体の装飾背景を刷新。ぼかしたグラデーション(blob)を廃し、コーナーから流れる「クラゲの足」(細いライン)を配した落ち着いた背景にした。

## 動機
従来の blur gradient blob は量産型・汎用的な見た目で、サイトの個性が出ていなかった。色ではなく形と質感で、k8o(クラゲ)らしさを出す。

## 変更点
- 背景モチーフを blob グラデから「クラゲの足(細いライン + 点)」へ変更。左上・右下に配置し、形・本数・大きさを変えて**左右非対称**に
- 下地をオフホワイト/深色のトーンに整え、上部にブランドカラー(ティール)のグロー、全面に極薄のグレインを重ねる
- ライト/ダークは単純反転せず独立したトーンで設計
- 実装をインライン style から CSS Module(`background.module.css`)へ分離。ダーク切り替えは `:global(.dark)`

## 影響範囲
- 全ページ共通の背景(`apps/main/src/app/_components/global-layout/background`)。装飾のみで挙動への影響なし(`aria-hidden` / `z-index` 背面)

## 気をつけるポイント
- 色・トーンはライト基準で設計。ダークは独立トーン
- 背面レイヤーのみで `pointer-events` に影響しない

## テスト
- ライト/ダーク両モードで `/blog`・各ツールページの表示を確認
- lint(`vp check`) / 型(`tsgo --noEmit`) / `ls-lint` パス