### PR TITLE
chore(deps): chromaui/action を v17.3.0 へ更新

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,14 +18,14 @@ jobs:
       - name: Setup
         uses: ./.github/actions/setup
       - name: Publish Main to Chromatic
-        uses: chromaui/action@8ad69a40dea06755a3c6db290f300a39e011433b # v17.1.0
+        uses: chromaui/action@05812acac141ce7d317a3f787be88122bca27cf4 # v17.3.0
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           onlyChanged: true
           skip: 'renovate/**'
           workingDir: apps/main
       - name: Publish Admin to Chromatic
-        uses: chromaui/action@8ad69a40dea06755a3c6db290f300a39e011433b # v17.1.0
+        uses: chromaui/action@05812acac141ce7d317a3f787be88122bca27cf4 # v17.3.0
         with:
           projectToken: ${{ secrets.CHROMATIC_ADMIN_PROJECT_TOKEN }}
           onlyChanged: true


### PR DESCRIPTION
## 概要
`chromaui/action` を v17.1.0 → v17.3.0 へ更新し、Chromatic の publish 失敗を解消する。

## 背景
v17.1.0 では Chromatic API が以下を返し、Storybook の検証(`Verifying your Storybook`)で失敗していた。Storybook のビルド自体は成功しており、リポジトリ全体（main を含む直近の push）で発生していた。

```
✖ Failed to verify your Storybook
  Error communicating with the Chromatic API. Check if your Chromatic client is up-to-date.
  → INTERNAL_SERVER_ERROR: Invalid turboSnapBailReason in publishBuild
```

TurboSnap が package.json の差分で bail した際の bail 理由を新しい API が受け付けず、クライアント側が古いことが原因。`chromaui/action` を最新の v17.3.0 へ更新して解消する。

## 変更点
- `.github/workflows/chromatic.yml`: `chromaui/action` を v17.1.0 → v17.3.0（SHA ピン維持）。main / admin 両ジョブ

## 影響範囲
- CI の Chromatic ジョブのみ。アプリ挙動への影響なし
- catalog の `chromatic`(17.0.1) はローカル CLI 用で CI には不使用のため本 PR では据え置き（Renovate 追従でも可）