### PR TITLE
feat: トップページのプロフィールをヒーローレイアウトに刷新

### DIFF
--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -1,4 +1,4 @@
-import { ArteOdyssey, Badge, Card, Heading } from '@k8o/arte-odyssey';
+import { ArteOdyssey, Heading, Separator } from '@k8o/arte-odyssey';
 import Image from 'next/image';
 
 import { AppCard } from './_components/app-card';
@@ -13,40 +13,29 @@ export default function Home() {
   return (
     <div className="mx-auto w-full max-w-5xl">
       <div className="flex flex-col gap-12">
-        <Card>
-          <div className="p-6">
-            <div className="flex flex-col items-center gap-6 sm:flex-row sm:gap-8">
-              <Image
-                alt="k8oのアイコン"
-                className="size-24 rounded-md sm:size-32"
-                height={128}
-                src={k8o}
-                width={128}
-              />
-
-              <div className="flex min-w-0 flex-1 flex-col gap-4">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                  <Heading type="h3">k8o</Heading>
-                  <div className="flex flex-wrap items-center gap-2">
-                    <EmailTooltip />
-                    <SocialIcons />
-                  </div>
-                </div>
-
-                <div className="flex flex-wrap gap-2">
-                  <Badge size="sm" text="フロントエンド" />
-                  <Badge size="sm" text="TypeScript" />
-                  <Badge size="sm" text="デザイン" />
-                </div>
-
-                <p className="text-fg-mute text-sm leading-relaxed">
-                  WebフロントエンドとTypeScriptが好きで、Baselineを追いながらWeb標準の進化を楽しんでいます。
-                  デザインシステムの構築を通じて、デザインとフロントエンドの交差点を探っています。
-                </p>
-              </div>
+        <header className="grid grid-cols-[auto_1fr] items-center gap-x-4 gap-y-5 pt-2 lg:gap-x-10">
+          <Image
+            alt="k8oのアイコン"
+            className="size-16 rounded-full lg:row-span-2 lg:size-32"
+            height={128}
+            src={k8o}
+            width={128}
+          />
+          <div className="flex flex-col gap-3">
+            <Heading type="h1">k8o</Heading>
+            <div className="flex flex-wrap items-center gap-2">
+              <SocialIcons />
+              <EmailTooltip />
             </div>
           </div>
-        </Card>
+
+          <p className="text-fg-mute col-span-2 leading-relaxed lg:col-span-1 lg:col-start-2">
+            Webフロントエンドを軸足に、最近はBaselineに追加された機能の深掘りをブログに残しています。
+            デザインとの境界にも興味があり、デザインシステムArteOdysseyを育てています。
+          </p>
+        </header>
+
+        <Separator color="subtle" />
 
         <div className="flex flex-col gap-6">
           <div>

--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -40,6 +40,9 @@ export default function Home() {
         <div className="flex flex-col gap-6">
           <div>
             <Heading type="h2">Activity</Heading>
+            <p className="text-fg-mute text-sm">
+              最近の発信と、GitHubでの活動の記録。
+            </p>
           </div>
           <ActivityErrorBoundary
             fallback={


### PR DESCRIPTION
## 概要

トップページのプロフィールを `Card` から背景に直接置くヒーロー領域へ刷新し、自己紹介文を書き直した。

## 動機

プロフィール（主役）と Activity / Forge / Assist のカード群（脇役）が同じ白い角丸カードに入っており、ページ内の視覚階層が平坦だった。「箱の中の箱」をやめてプロフィールだけ別格の扱いにすることで、視線の着地点を作る。

## 詳細

- プロフィールの `Card` を撤去し、`header` として背景に直接配置
- 名前の見出しを `h3` → `h1` に引き上げ（従来はカードタイトルと同格だった）
- アバターを CSS Grid で配置換え: 小画面では名前の隣に 64px、`lg` 以上では左側 128px の 2 行ぶち抜き
- Badge のタグ行（フロントエンド / TypeScript / デザイン）を削除
- 自己紹介文を「立ち位置 → 行動 → 動機 → 実践」の流れに書き直し（ArteOdyssey を固有名で明記）
- ヒーローとコンテンツの境界に `Separator` を追加
- Activity セクションに説明文を追加し、Forge / Assist と見出し構成を統一

## 気をつけるポイント

- ヒーローの 2 カラム化は `lg`（64rem）以上のみ。それ未満は縦積みで、中間幅で本文が細くなる帯は作っていない
- アバター画像は 1 枚を CSS で配置換えしており、重複レンダリングはない（元画像 1280px、128px 表示でも劣化なし）

## 影響範囲

トップページ（`/`）のみ。変更ファイルは `apps/main/src/app/page.tsx` の 1 ファイル。

## テスト

- `vp check`（lint / format）と `pnpm -F main type-check` を実行し pass
- ローカル dev で 390px / 900px / 1024px / 1440px の各幅とライト / ダーク両テーマの表示を目視確認