### PR TITLE
chore(deps): @k8o/arte-odyssey を 10.1.1 へ更新

### DIFF
--- a/apps/main/src/app/_components/app-card/app-card.tsx
+++ b/apps/main/src/app/_components/app-card/app-card.tsx
@@ -2,7 +2,7 @@ import {
   ChevronIcon,
   ExternalLinkIcon,
   Heading,
-  InteractiveCard,
+  Card,
 } from '@k8o/arte-odyssey';
 import type { Route } from 'next';
 import Link from 'next/link';
@@ -49,7 +49,7 @@ export const AppCard = ({
   );
 
   return (
-    <InteractiveCard>
+    <Card interactive>
       {isExternal ? (
         <a
           className="group"
@@ -64,6 +64,6 @@ export const AppCard = ({
           {content}
         </Link>
       )}
-    </InteractiveCard>
+    </Card>
   );
 };

--- a/apps/main/src/app/_components/recent-blogs/blog-card.tsx
+++ b/apps/main/src/app/_components/recent-blogs/blog-card.tsx
@@ -1,7 +1,7 @@
 import {
   Badge,
   Heading,
-  InteractiveCard,
+  Card,
   PublishDateIcon,
   TagIcon,
 } from '@k8o/arte-odyssey';
@@ -25,7 +25,7 @@ export const BlogCard: FC<BlogCardProps> = ({
   tags,
   createdAt,
 }) => (
-  <InteractiveCard>
+  <Card interactive>
     <Link className="group block h-full" href={`/blog/${slug}` as Route}>
       <div className="flex h-full flex-col justify-between gap-4 p-4">
         <div className="group-hover:text-primary-fg flex flex-col gap-1">
@@ -52,5 +52,5 @@ export const BlogCard: FC<BlogCardProps> = ({
         </div>
       </div>
     </Link>
-  </InteractiveCard>
+  </Card>
 );

--- a/apps/main/src/app/artifacts/_components/artifact-card/artifact-card.tsx
+++ b/apps/main/src/app/artifacts/_components/artifact-card/artifact-card.tsx
@@ -19,7 +19,7 @@ export const ArtifactCard: FC<Artifact> = ({
   npmPackageName,
   tags,
 }) => (
-  <article className="border-border-mute bg-bg-base flex h-full flex-col gap-5 rounded-xl border px-5 py-5 shadow-sm transition-colors md:px-6 md:py-6">
+  <article className="border-border-mute bg-bg-base flex h-full flex-col gap-5 rounded-xl border p-5 shadow-sm transition-colors md:px-6 md:py-6">
     <div className="flex flex-col gap-2">
       <Heading type="h3">{name}</Heading>
       <p className="text-fg-mute max-w-3xl text-sm leading-relaxed md:text-base">

--- a/apps/main/src/app/blog/_components/blog-card/blog-card.tsx
+++ b/apps/main/src/app/blog/_components/blog-card/blog-card.tsx
@@ -1,7 +1,7 @@
 import {
   Badge,
   Heading,
-  InteractiveCard,
+  Card,
   PublishDateIcon,
   TagIcon,
   UpdateDateIcon,
@@ -28,7 +28,7 @@ export const BlogCard: FC<BlogCardProps> = ({
   createdAt,
   updatedAt,
 }) => (
-  <InteractiveCard>
+  <Card interactive>
     <Link className="group block h-full" href={`/blog/${slug}` as Route}>
       <div className="flex h-full flex-col justify-between gap-4 p-4">
         <div className="group-hover:text-primary-fg flex flex-col gap-1">
@@ -65,5 +65,5 @@ export const BlogCard: FC<BlogCardProps> = ({
         </div>
       </div>
     </Link>
-  </InteractiveCard>
+  </Card>
 );

--- a/apps/main/src/app/blog/_components/blog-layout/recommend/recommend.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/recommend/recommend.tsx
@@ -1,7 +1,7 @@
 import {
   Badge,
   Heading,
-  InteractiveCard,
+  Card,
   PublishDateIcon,
   TagIcon,
 } from '@k8o/arte-odyssey';
@@ -26,7 +26,7 @@ export const RecommendContent: FC<RecommendProps> = ({ blogs }) => {
       <Heading type="h3">関連記事</Heading>
       <div className="grid-cols-auto-fit-80 grid gap-4">
         {blogs.map((blog) => (
-          <InteractiveCard key={blog.id}>
+          <Card interactive key={blog.id}>
             <Link href={`/blog/${blog.slug}` as Route}>
               <div className="flex flex-col gap-4 p-4">
                 <Heading type="h4">{blog.title}</Heading>
@@ -47,7 +47,7 @@ export const RecommendContent: FC<RecommendProps> = ({ blogs }) => {
                 </div>
               </div>
             </Link>
-          </InteractiveCard>
+          </Card>
         ))}
       </div>
     </div>

--- a/apps/main/src/app/blog/_components/link-card/fallback.tsx
+++ b/apps/main/src/app/blog/_components/link-card/fallback.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon, InteractiveCard } from '@k8o/arte-odyssey';
+import { ExternalLinkIcon, Card } from '@k8o/arte-odyssey';
 import type { FC } from 'react';
 
 export type LinkCardAppearance = 'shadow' | 'bordered';
@@ -8,7 +8,7 @@ export const LinkCardFallback: FC<{
   appearance?: LinkCardAppearance;
 }> = ({ href, appearance = 'shadow' }) => (
   <div className="vertical:max-w-container-md">
-    <InteractiveCard appearance={appearance}>
+    <Card interactive appearance={appearance}>
       <a
         aria-label={href}
         className="group block h-full"
@@ -26,6 +26,6 @@ export const LinkCardFallback: FC<{
           </div>
         </div>
       </a>
-    </InteractiveCard>
+    </Card>
   </div>
 );

--- a/apps/main/src/app/blog/_components/link-card/link-card.tsx
+++ b/apps/main/src/app/blog/_components/link-card/link-card.tsx
@@ -1,8 +1,4 @@
-import {
-  ExternalLinkIcon,
-  InteractiveCard,
-  PublishDateIcon,
-} from '@k8o/arte-odyssey';
+import { ExternalLinkIcon, Card, PublishDateIcon } from '@k8o/arte-odyssey';
 import { formatDate } from '@repo/helpers/date/format';
 import { type FC, Suspense } from 'react';
 
@@ -16,7 +12,7 @@ const LinkCardLoading: FC<{
   appearance?: LinkCardAppearance;
 }> = ({ href, appearance = 'shadow' }) => (
   <div className="vertical:max-w-container-md">
-    <InteractiveCard appearance={appearance}>
+    <Card interactive appearance={appearance}>
       <a
         aria-label={`${href}（読み込み中）`}
         className="block"
@@ -35,7 +31,7 @@ const LinkCardLoading: FC<{
           </div>
         </div>
       </a>
-    </InteractiveCard>
+    </Card>
   </div>
 );
 
@@ -61,7 +57,7 @@ const Content: FC<{
 
   return (
     <div className="vertical:max-w-container-md">
-      <InteractiveCard appearance={appearance}>
+      <Card interactive appearance={appearance}>
         <a
           className="group block h-full"
           href={href}
@@ -102,7 +98,7 @@ const Content: FC<{
             </div>
           </div>
         </a>
-      </InteractiveCard>
+      </Card>
     </div>
   );
 };

--- a/apps/main/src/app/contrast-checker/_components/result-table/result-table.tsx
+++ b/apps/main/src/app/contrast-checker/_components/result-table/result-table.tsx
@@ -15,7 +15,7 @@ type StatusCellProps = {
 };
 
 const StatusCell: FC<StatusCellProps> = ({ isInvalid }) => (
-  <td className="px-2 py-2 sm:py-3">
+  <td className="p-2 sm:py-3">
     {isInvalid ? (
       <div className="text-fg-error flex items-center justify-center gap-1">
         <AlertIcon size="sm" status="error" />

--- a/apps/main/src/app/reading-list/_components/reading-card/reading-card.tsx
+++ b/apps/main/src/app/reading-list/_components/reading-card/reading-card.tsx
@@ -1,8 +1,4 @@
-import {
-  ExternalLinkIcon,
-  InteractiveCard,
-  PublishDateIcon,
-} from '@k8o/arte-odyssey';
+import { ExternalLinkIcon, Card, PublishDateIcon } from '@k8o/arte-odyssey';
 import { formatDate } from '@repo/helpers/date/format';
 import type { FC } from 'react';
 
@@ -31,7 +27,7 @@ export const ReadingCard: FC<ReadingCardProps> = ({
   sourceTitle,
 }) => (
   <div className="vertical:max-w-container-md">
-    <InteractiveCard appearance="shadow">
+    <Card interactive appearance="shadow">
       <div className="group vertical:flex-row relative isolate flex h-full flex-col overflow-hidden sm:flex-row">
         {imageUrl !== null && <ReadingCardImage src={imageUrl} />}
         <div className="flex flex-1 flex-col gap-2 p-4">
@@ -66,6 +62,6 @@ export const ReadingCard: FC<ReadingCardProps> = ({
           </div>
         </div>
       </div>
-    </InteractiveCard>
+    </Card>
   </div>
 );

--- a/apps/main/src/app/reading-list/_components/reading-card/skeleton.tsx
+++ b/apps/main/src/app/reading-list/_components/reading-card/skeleton.tsx
@@ -1,9 +1,9 @@
-import { InteractiveCard } from '@k8o/arte-odyssey';
+import { Card } from '@k8o/arte-odyssey';
 import type { FC } from 'react';
 
 export const ReadingCardSkeleton: FC = () => (
   <div className="vertical:max-w-container-md">
-    <InteractiveCard appearance="shadow">
+    <Card interactive appearance="shadow">
       <div className="vertical:flex-row flex animate-pulse flex-col overflow-hidden sm:flex-row">
         <div className="bg-bg-mute vertical:w-48 vertical:shrink-0 vertical:rounded-s-xl vertical:rounded-e-none w-full rounded-t-xl sm:w-48 sm:shrink-0 sm:rounded-s-xl sm:rounded-e-none">
           <div className="bg-bg-mute aspect-video w-full" />
@@ -14,6 +14,6 @@ export const ReadingCardSkeleton: FC = () => (
           <div className="bg-bg-mute mt-auto h-3 w-1/3 rounded-md" />
         </div>
       </div>
-    </InteractiveCard>
+    </Card>
   </div>
 );

--- a/apps/main/src/app/slides/_components/slide-card/slide-card.tsx
+++ b/apps/main/src/app/slides/_components/slide-card/slide-card.tsx
@@ -1,7 +1,7 @@
 import {
   Badge,
   Heading,
-  InteractiveCard,
+  Card,
   PublishDateIcon,
   TagIcon,
   UpdateDateIcon,
@@ -28,7 +28,7 @@ export const SlideCard: FC<SlideCardProps> = ({
   createdAt,
   updatedAt,
 }) => (
-  <InteractiveCard>
+  <Card interactive>
     <Link className="group block h-full" href={`/slides/${slug}` as Route}>
       <div className="flex h-full flex-col justify-between gap-4 p-4">
         <div className="group-hover:text-primary-fg flex flex-col gap-1">
@@ -65,5 +65,5 @@ export const SlideCard: FC<SlideCardProps> = ({
         </div>
       </div>
     </Link>
-  </InteractiveCard>
+  </Card>
 );

--- a/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns-by-form.tsx
+++ b/apps/main/src/app/sql-table-builder/_components/create-columns/create-columns-by-form.tsx
@@ -86,7 +86,7 @@ const ColumnItem: FC<{
       {/* コンテンツ */}
       {isOpen && (
         <div>
-          <div className="border-border-base border-t px-4 py-4">
+          <div className="border-border-base border-t p-4">
             <div className="grid gap-4 sm:grid-cols-2">
               <FormControl
                 errorText={columnError?.name}

--- a/apps/main/src/app/sql-table-builder/_components/create-restrictions/create-restrictions.tsx
+++ b/apps/main/src/app/sql-table-builder/_components/create-restrictions/create-restrictions.tsx
@@ -90,7 +90,7 @@ const RestrictionItem: FC<{
       </div>
 
       {isOpen && (
-        <div className="border-border-base overflow-hidden border-t px-4 py-4">
+        <div className="border-border-base overflow-hidden border-t p-4">
           <CreateRestriction
             columns={columns}
             restriction={restriction}

--- a/apps/main/src/app/sql-table-builder/page.tsx
+++ b/apps/main/src/app/sql-table-builder/page.tsx
@@ -38,7 +38,7 @@ const StepIndicator = ({
 }) => (
   <div className="flex items-center gap-2 sm:gap-3">
     <div
-      className={`flex size-6 items-center justify-center rounded-full text-xs font-bold transition-colors sm:h-8 sm:w-8 sm:text-sm ${
+      className={`flex size-6 items-center justify-center rounded-full text-xs font-bold transition-colors sm:size-8 sm:text-sm ${
         isActive ? 'bg-primary-bg text-primary-fg' : 'bg-bg-mute text-fg-mute'
       }`}
     >
@@ -187,7 +187,7 @@ export default function Page() {
             <div className="p-4 sm:p-6">
               <div className="mb-4 flex items-center justify-between gap-2">
                 <div className="flex items-center gap-2 sm:gap-3">
-                  <div className="bg-bg-success text-fg-success flex size-6 items-center justify-center rounded-full sm:h-8 sm:w-8">
+                  <div className="bg-bg-success text-fg-success flex size-6 items-center justify-center rounded-full sm:size-8">
                     <span className="text-xs sm:text-sm">✓</span>
                   </div>
                   <h3 className="text-base font-bold sm:text-lg">

--- a/apps/main/src/app/tags/_components/tag-card/tag-card.tsx
+++ b/apps/main/src/app/tags/_components/tag-card/tag-card.tsx
@@ -1,4 +1,4 @@
-import { ChevronIcon, InteractiveCard, Separator } from '@k8o/arte-odyssey';
+import { ChevronIcon, Card, Separator } from '@k8o/arte-odyssey';
 import { cn } from '@repo/helpers/cn';
 import type { Route } from 'next';
 import Link from 'next/link';
@@ -11,7 +11,7 @@ export const TagCard: FC<{
   label: string;
   linkLabel: string;
 }> = ({ title, href, count, label, linkLabel }) => (
-  <InteractiveCard width="fit">
+  <Card interactive width="fit">
     <Link
       aria-label={linkLabel}
       className={cn(
@@ -37,5 +37,5 @@ export const TagCard: FC<{
         </span>
       </div>
     </Link>
-  </InteractiveCard>
+  </Card>
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@k8o/arte-odyssey':
-      specifier: 10.0.1
-      version: 10.0.1
+      specifier: 10.1.1
+      version: 10.1.1
     '@storybook/addon-a11y':
       specifier: 10.4.2
       version: 10.4.2
@@ -133,7 +133,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.0.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.1.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -227,7 +227,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.0.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.1.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
       '@mdx-js/loader':
         specifier: 3.1.1
         version: 3.1.1
@@ -1730,8 +1730,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@k8o/arte-odyssey@10.0.1':
-    resolution: {integrity: sha512-lpPQ8FAEaS11A8DNtPWxgWKQaHX+3jelLhNZ3ChnOVfNxBks+jlXIAuts2Wn1M7G69aShSfwDGj5X6jTiKDtVQ==}
+  '@k8o/arte-odyssey@10.1.1':
+    resolution: {integrity: sha512-7CSStKtaqE1V6XuLWumFmsEOwTWZer9yEM8DwWr4Ec9PdsE0OGWKUF11xR4xwG2bUNOb8z8Okv+QS8878hoifg==}
     peerDependencies:
       '@json-render/core': '>=0.19.0'
       '@json-render/react': '>=0.19.0'
@@ -8047,7 +8047,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@k8o/arte-odyssey@10.0.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)':
+  '@k8o/arte-odyssey@10.1.1(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react': 19.2.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ allowBuilds:
 blockExoticSubdeps: true
 
 catalog:
-  '@k8o/arte-odyssey': 10.0.1
+  '@k8o/arte-odyssey': 10.1.1
   '@storybook/addon-a11y': 10.4.2
   '@storybook/addon-docs': 10.4.2
   '@storybook/addon-mcp': '0.6.0'


### PR DESCRIPTION
ArteOdyssey 10.1.1 への追従。10.1.0 で `InteractiveCard` が `Card` の `interactive` prop に統合されたため、使用箇所 10 ファイルを `<Card interactive>` へ置き換えた。`appearance` / `width` prop は値域が変わらないためそのまま引き継いでいる。

あわせて `vp check --fix` が正規化する Tailwind クラスの省略形（`px-5 py-5` → `p-5` など）を反映した。

lint / type-check pass、ホーム・/blog・/tags・/reading-list の表示をローカルで目視確認済み。