### PR TITLE
feat: SEO構造化データとエラーバウンダリを追加

### DIFF
--- a/apps/admin/src/app/error.tsx
+++ b/apps/admin/src/app/error.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { Button, Heading } from '@k8o/arte-odyssey';
+
+export default function ErrorPage({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-8 px-4 py-16 text-center">
+      <div className="flex flex-col gap-3">
+        <Heading type="h2">問題が発生しました</Heading>
+        <p className="text-fg-mute leading-relaxed">
+          予期しないエラーが発生しました。再試行しても解決しない場合は、時間をおいて再度お試しください。
+        </p>
+      </div>
+      <Button onClick={reset} size="lg">
+        再試行
+      </Button>
+    </div>
+  );
+}

--- a/apps/admin/src/app/global-error.tsx
+++ b/apps/admin/src/app/global-error.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Button, Heading } from '@k8o/arte-odyssey';
+
+import './_styles/globals.css';
+
+import { cn } from '@repo/helpers/cn';
+
+import { mPlus2, notoSansJp } from './_styles/font';
+
+// root layout ごと失敗した場合のフォールバックなので、Provider に依存しない最小構成にする
+export default function GlobalError({
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  return (
+    <html lang="ja">
+      <body
+        className={cn(
+          mPlus2.variable,
+          notoSansJp.variable,
+          'bg-bg-surface font-m-plus-2 font-medium text-fg-base antialiased',
+        )}
+      >
+        <div className="flex min-h-dvh flex-col items-center justify-center gap-8 px-4 text-center">
+          <div className="flex flex-col gap-3">
+            <Heading type="h1">問題が発生しました</Heading>
+            <p className="text-fg-mute leading-relaxed">
+              予期しないエラーが発生しました。再試行しても解決しない場合は、時間をおいて再度お試しください。
+            </p>
+          </div>
+          <Button onClick={reset} size="lg">
+            再試行
+          </Button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/main/src/app/_components/json-ld/home-json-ld.tsx
+++ b/apps/main/src/app/_components/json-ld/home-json-ld.tsx
@@ -1,0 +1,12 @@
+import type { FC } from 'react';
+
+import { personJsonLd, websiteJsonLd } from '@/shared/site/json-ld';
+
+import { JsonLd } from './json-ld';
+
+export const HomeJsonLd: FC = () => (
+  <>
+    <JsonLd data={websiteJsonLd()} />
+    <JsonLd data={personJsonLd()} />
+  </>
+);

--- a/apps/main/src/app/_components/json-ld/index.ts
+++ b/apps/main/src/app/_components/json-ld/index.ts
@@ -1,0 +1,2 @@
+export { HomeJsonLd } from './home-json-ld';
+export { JsonLd } from './json-ld';

--- a/apps/main/src/app/_components/json-ld/json-ld.tsx
+++ b/apps/main/src/app/_components/json-ld/json-ld.tsx
@@ -1,0 +1,10 @@
+import type { FC } from 'react';
+
+import { type JsonLdObject, serializeJsonLd } from '@/shared/site/json-ld';
+
+export const JsonLd: FC<{ data: JsonLdObject }> = ({ data }) => (
+  <script
+    dangerouslySetInnerHTML={{ __html: serializeJsonLd(data) }}
+    type="application/ld+json"
+  />
+);

--- a/apps/main/src/app/artifacts/_components/artifact-card/artifact-card.tsx
+++ b/apps/main/src/app/artifacts/_components/artifact-card/artifact-card.tsx
@@ -19,7 +19,7 @@ export const ArtifactCard: FC<Artifact> = ({
   npmPackageName,
   tags,
 }) => (
-  <article className="border-border-mute bg-bg-base flex h-full flex-col gap-5 rounded-xl border p-5 shadow-sm transition-colors md:px-6 md:py-6">
+  <article className="border-border-mute bg-bg-base flex h-full flex-col gap-5 rounded-xl border p-5 shadow-sm transition-colors md:p-6">
     <div className="flex flex-col gap-2">
       <Heading type="h3">{name}</Heading>
       <p className="text-fg-mute max-w-3xl text-sm leading-relaxed md:text-base">

--- a/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -14,11 +14,13 @@ import Link from 'next/link';
 import { type FC, type ReactNode, Suspense } from 'react';
 
 import { SilentErrorBoundary } from '@/app/_components/error-boundary';
+import { JsonLd } from '@/app/_components/json-ld';
 import {
   getBlogContent,
   type getBlogsByTags,
   getBlogToc,
 } from '@/features/blog/interface/queries';
+import { blogPostingJsonLd } from '@/shared/site/json-ld';
 
 import { END_OF_CONTENT_ID } from './constants';
 import { CopyMarkdownButton } from './copy-markdown-button';
@@ -152,8 +154,11 @@ export const BlogLayout: FC<BlogLayoutProps> = async ({ children, slug }) => {
   const headingTree = await getBlogToc(slug);
 
   return (
-    <BlogLayoutContent blog={blog} headingTree={headingTree} slug={slug}>
-      {children}
-    </BlogLayoutContent>
+    <>
+      <JsonLd data={blogPostingJsonLd(blog)} />
+      <BlogLayoutContent blog={blog} headingTree={headingTree} slug={slug}>
+        {children}
+      </BlogLayoutContent>
+    </>
   );
 };

--- a/apps/main/src/app/error.tsx
+++ b/apps/main/src/app/error.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { Button, Heading } from '@k8o/arte-odyssey';
+import Link from 'next/link';
+import { useEffect } from 'react';
+
+import { reportClientError } from '@/shared/browser/report-client-error';
+
+export default function ErrorPage({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    reportClientError(error);
+  }, [error]);
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-8 px-4 py-16 text-center">
+      <div className="flex flex-col gap-3">
+        <Heading type="h2">問題が発生しました</Heading>
+        <p className="text-fg-mute leading-relaxed">
+          予期しないエラーが発生しました。再試行しても解決しない場合は、時間をおいて再度お試しください。
+        </p>
+      </div>
+      <div className="flex flex-wrap items-center justify-center gap-4">
+        <Button onClick={reset} size="lg">
+          再試行
+        </Button>
+        <Button
+          color="gray"
+          renderItem={({ className, children }) => (
+            <Link className={className} href="/">
+              {children}
+            </Link>
+          )}
+          size="lg"
+          variant="outline"
+        >
+          トップへ戻る
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/app/global-error.tsx
+++ b/apps/main/src/app/global-error.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Button, Heading } from '@k8o/arte-odyssey';
+
+import './_styles/globals.css';
+
+import { cn } from '@repo/helpers/cn';
+import { useEffect } from 'react';
+
+import { reportClientError } from '@/shared/browser/report-client-error';
+
+import { mPlus2, notoSansJp } from './_styles/font';
+
+// root layout ごと失敗した場合のフォールバックなので、Provider に依存しない最小構成にする
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    reportClientError(error);
+  }, [error]);
+
+  return (
+    <html lang="ja">
+      <body
+        className={cn(
+          mPlus2.variable,
+          notoSansJp.variable,
+          'bg-bg-surface font-m-plus-2 font-medium text-fg-base tracking-none antialiased',
+        )}
+      >
+        <div className="flex min-h-dvh flex-col items-center justify-center gap-8 px-4 text-center">
+          <div className="flex flex-col gap-3">
+            <Heading type="h1">問題が発生しました</Heading>
+            <p className="text-fg-mute leading-relaxed">
+              予期しないエラーが発生しました。再試行しても解決しない場合は、時間をおいて再度お試しください。
+            </p>
+          </div>
+          <Button onClick={reset} size="lg">
+            再試行
+          </Button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -5,6 +5,7 @@ import { AppCard } from './_components/app-card';
 import { EmailTooltip } from './_components/email-tooltip';
 import { ActivityErrorBoundary } from './_components/error-boundary';
 import { GitHubContributionGraph } from './_components/github-contribution-graph';
+import { HomeJsonLd } from './_components/json-ld';
 import { RecentBlogs } from './_components/recent-blogs';
 import { SocialIcons } from './_components/social-icons';
 import k8o from './_images/k8o.jpg';
@@ -12,6 +13,7 @@ import k8o from './_images/k8o.jpg';
 export default function Home() {
   return (
     <div className="mx-auto w-full max-w-5xl">
+      <HomeJsonLd />
       <div className="flex flex-col gap-12">
         <header className="grid grid-cols-[auto_1fr] items-center gap-x-4 gap-y-5 pt-2 lg:gap-x-10">
           <Image

--- a/apps/main/src/app/robots.ts
+++ b/apps/main/src/app/robots.ts
@@ -1,0 +1,12 @@
+import type { MetadataRoute } from 'next';
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: '*',
+      allow: '/',
+      disallow: '/api/',
+    },
+    sitemap: 'https://k8o.me/sitemap.xml',
+  };
+}

--- a/apps/main/src/app/talks/page.tsx
+++ b/apps/main/src/app/talks/page.tsx
@@ -1,4 +1,6 @@
+import { JsonLd } from '@/app/_components/json-ld';
 import { getTalks } from '@/features/talks/interface/queries';
+import { talkEventsJsonLd } from '@/shared/site/json-ld';
 
 import { TalkCard } from './_components/talk-card';
 
@@ -6,6 +8,7 @@ export default async function Page() {
   const talks = await getTalks();
   return (
     <div className="flex flex-col gap-4">
+      <JsonLd data={talkEventsJsonLd(talks)} />
       {talks.map((talk) => (
         <TalkCard key={talk.id} {...talk} />
       ))}

--- a/apps/main/src/shared/browser/report-client-error.ts
+++ b/apps/main/src/shared/browser/report-client-error.ts
@@ -1,0 +1,25 @@
+// Reporting API のレポートと同じ形式で /api/reports に送る
+const MAX_STACK_LENGTH = 4096;
+
+type ClientError = Error & { digest?: string };
+
+export const reportClientError = (error: ClientError): void => {
+  const report = {
+    type: 'client-error',
+    age: 0,
+    url: window.location.href,
+    user_agent: window.navigator.userAgent,
+    body: {
+      name: error.name,
+      message: error.message,
+      digest: error.digest,
+      stack: error.stack?.slice(0, MAX_STACK_LENGTH),
+    },
+  };
+
+  // 送信失敗で新たなエラーを発生させないよう fire-and-forget で送る
+  window.navigator.sendBeacon(
+    '/api/reports',
+    new Blob([JSON.stringify([report])], { type: 'application/json' }),
+  );
+};

--- a/apps/main/src/shared/site/json-ld.test.ts
+++ b/apps/main/src/shared/site/json-ld.test.ts
@@ -1,0 +1,138 @@
+import {
+  blogPostingJsonLd,
+  personJsonLd,
+  serializeJsonLd,
+  talkEventsJsonLd,
+  websiteJsonLd,
+} from './json-ld';
+
+describe('serializeJsonLd', () => {
+  describe('正常系', () => {
+    it('オブジェクトをJSON文字列に変換するべき', () => {
+      expect(serializeJsonLd({ '@type': 'Thing', name: 'k8o' })).toBe(
+        '{"@type":"Thing","name":"k8o"}',
+      );
+    });
+
+    it('undefinedの値を持つキーを出力しないべき', () => {
+      expect(serializeJsonLd({ name: 'k8o', description: undefined })).toBe(
+        '{"name":"k8o"}',
+      );
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('script要素を閉じうる < をエスケープするべき', () => {
+      const serialized = serializeJsonLd({ name: '</script><script>' });
+      expect(serialized).not.toContain('<');
+      expect(JSON.parse(serialized)).toEqual({ name: '</script><script>' });
+    });
+  });
+});
+
+describe('websiteJsonLd', () => {
+  describe('正常系', () => {
+    it('WebSiteスキーマを返すべき', () => {
+      expect(websiteJsonLd()).toMatchObject({
+        '@context': 'https://schema.org',
+        '@type': 'WebSite',
+        name: 'k8o',
+        url: 'https://k8o.me',
+      });
+    });
+  });
+});
+
+describe('personJsonLd', () => {
+  describe('正常系', () => {
+    it('SNSアカウントをsameAsに含むPersonスキーマを返すべき', () => {
+      expect(personJsonLd()).toMatchObject({
+        '@context': 'https://schema.org',
+        '@type': 'Person',
+        name: 'k8o',
+        sameAs: [
+          'https://x.com/k8ome',
+          'https://github.com/k35o',
+          'https://qiita.com/k8o',
+        ],
+      });
+    });
+  });
+});
+
+describe('blogPostingJsonLd', () => {
+  const blog = {
+    slug: 'sample-post',
+    title: 'サンプル記事',
+    description: '記事の説明',
+    createdAt: '2025-01-01',
+    updatedAt: '2025-01-02',
+    tags: [{ name: 'CSS' }, { name: 'React' }],
+  };
+
+  describe('正常系', () => {
+    it('記事の情報からBlogPostingスキーマを返すべき', () => {
+      expect(blogPostingJsonLd(blog)).toMatchObject({
+        '@context': 'https://schema.org',
+        '@type': 'BlogPosting',
+        headline: 'サンプル記事',
+        description: '記事の説明',
+        url: 'https://k8o.me/blog/sample-post',
+        image: 'https://k8o.me/blog/sample-post/opengraph-image',
+        datePublished: '2025-01-01',
+        dateModified: '2025-01-02',
+        keywords: ['CSS', 'React'],
+      });
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('descriptionがnullの場合は出力に含めないべき', () => {
+      const jsonLd = blogPostingJsonLd({ ...blog, description: null });
+      expect(serializeJsonLd(jsonLd)).not.toContain('description');
+    });
+
+    it('タグが空の場合はkeywordsを出力に含めないべき', () => {
+      const jsonLd = blogPostingJsonLd({ ...blog, tags: [] });
+      expect(serializeJsonLd(jsonLd)).not.toContain('keywords');
+    });
+  });
+});
+
+describe('talkEventsJsonLd', () => {
+  const talk = {
+    title: 'サンプルトーク',
+    eventName: 'サンプルカンファレンス',
+    eventUrl: 'https://example.com/talks/1',
+    eventDate: '2025-05-24',
+    eventLocation: '東京',
+  };
+
+  describe('正常系', () => {
+    it('トークの一覧からItemListスキーマを返すべき', () => {
+      expect(talkEventsJsonLd([talk])).toMatchObject({
+        '@context': 'https://schema.org',
+        '@type': 'ItemList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            item: {
+              '@type': 'Event',
+              name: 'サンプルトーク',
+              startDate: '2025-05-24',
+              location: { '@type': 'Place', name: '東京' },
+            },
+          },
+        ],
+      });
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('開催場所がnullの場合はlocationを出力に含めないべき', () => {
+      const jsonLd = talkEventsJsonLd([{ ...talk, eventLocation: null }]);
+      expect(serializeJsonLd(jsonLd)).not.toContain('location');
+    });
+  });
+});

--- a/apps/main/src/shared/site/json-ld.ts
+++ b/apps/main/src/shared/site/json-ld.ts
@@ -1,0 +1,114 @@
+const SITE_URL = 'https://k8o.me';
+
+const PERSON = {
+  '@type': 'Person',
+  name: 'k8o',
+  url: SITE_URL,
+} as const;
+
+type JsonLdValue =
+  | string
+  | number
+  | boolean
+  | undefined
+  | JsonLdObject
+  | readonly JsonLdValue[];
+
+export type JsonLdObject = {
+  readonly [key: string]: JsonLdValue;
+};
+
+export function serializeJsonLd(data: JsonLdObject): string {
+  // script要素内に埋め込むため、HTMLとして解釈されうる < をエスケープする
+  return JSON.stringify(data).replaceAll('<', '\\u003c');
+}
+
+export function websiteJsonLd(): JsonLdObject {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'k8o',
+    url: SITE_URL,
+    description: 'k8oの活動や制作物をまとめた個人サイト',
+    inLanguage: 'ja',
+    publisher: PERSON,
+  };
+}
+
+export function personJsonLd(): JsonLdObject {
+  return {
+    '@context': 'https://schema.org',
+    ...PERSON,
+    sameAs: [
+      'https://x.com/k8ome',
+      'https://github.com/k35o',
+      'https://qiita.com/k8o',
+    ],
+  };
+}
+
+type BlogPostingInput = {
+  slug: string;
+  title: string;
+  description: string | null;
+  createdAt: string;
+  updatedAt: string;
+  tags: ReadonlyArray<{ name: string }>;
+};
+
+export function blogPostingJsonLd(blog: BlogPostingInput): JsonLdObject {
+  const url = `${SITE_URL}/blog/${blog.slug}`;
+
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BlogPosting',
+    headline: blog.title,
+    description: blog.description ?? undefined,
+    url,
+    mainEntityOfPage: url,
+    image: `${url}/opengraph-image`,
+    datePublished: blog.createdAt,
+    dateModified: blog.updatedAt,
+    inLanguage: 'ja',
+    author: PERSON,
+    keywords:
+      blog.tags.length > 0 ? blog.tags.map((tag) => tag.name) : undefined,
+  };
+}
+
+type TalkEventInput = {
+  title: string;
+  eventName: string;
+  eventUrl: string;
+  eventDate: string;
+  eventLocation: string | null;
+};
+
+export function talkEventsJsonLd(
+  talks: readonly TalkEventInput[],
+): JsonLdObject {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'ItemList',
+    itemListElement: talks.map((talk, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      item: {
+        '@type': 'Event',
+        name: talk.title,
+        startDate: talk.eventDate,
+        url: talk.eventUrl,
+        location:
+          talk.eventLocation === null
+            ? undefined
+            : { '@type': 'Place', name: talk.eventLocation },
+        organizer: {
+          '@type': 'Organization',
+          name: talk.eventName,
+          url: talk.eventUrl,
+        },
+        performer: PERSON,
+      },
+    })),
+  };
+}


### PR DESCRIPTION
## 概要

サイトの「障害耐性」と「SEO/機械可読性」を埋める3点を実装した。いずれも既存のデータソースと仕組みに乗せ、新規依存はゼロ。

## 変更内容

### 1. robots.ts（SEO）
- これまで robots は未配信だった。全クローラーに `/api/` のみ Disallow し、`sitemap.xml` への参照を返す `apps/main/src/app/robots.ts` を追加。

### 2. JSON-LD 構造化データ（SEO / LLM）
- 構造化データ（`application/ld+json`）の出力箇所がゼロだったため、schema.org に沿った構造化データを追加。
  - ブログ記事（全73本）: `BlogPosting`（タイトル・公開/更新日・著者・OG画像・タグ）
  - トップ: `WebSite` + `Person`（X / GitHub / Qiita を `sameAs`）
  - トーク: `ItemList` + `Event`（開催地は nullable のため存在時のみ出力）
- 生成ロジックは `shared/site/json-ld.ts`（非UI）、出力コンポーネントは `app/_components/json-ld` に配置。
- `</script>` 注入対策として `<` をエスケープ。ユニットテスト10件を追加。

### 3. エラーバウンダリ（障害耐性 / オブザーバビリティ）
- apps/main・apps/admin ともに `error.tsx` / `global-error.tsx` が無く、未捕捉エラーは Next.js のデフォルト画面が出ていた。両アプリに追加。
- apps/main はクライアントエラーを既存の `/api/reports`（Reporting API と同形式、`type: 'client-error'`）へ `sendBeacon` で送信。CSP違反と同じく admin の reports で確認できる。

## レビュー時の補足

- `pnpm run check:write` が既存 `artifact-card.tsx` に Tailwind 省略形の自動修正（`md:px-6 md:py-6` → `md:p-6`）を1件入れたため、`style:` コミットとして分離して含めている。
- ArteOdyssey の Button は本体 node_modules のドキュメント（`variant="outlined"`）と実際の型（`variant="outline"`）がズレていた。実装は実際の型に合わせている。

## 検証

- `pnpm run check` / `type-check` / `ls-lint`: いずれもパス（lint 0 errors）
- ユニットテスト 80件パス（うち JSON-LD 10件を新規追加）
- dev サーバー実機で robots.txt と3種の JSON-LD が期待どおり出力されることを確認
- ヘッドレスブラウザで DB を落としてエラーを誘発し、`error.tsx` の UI 描画と `/api/reports` への POST 発火を確認

## デプロイ後にやると良いこと

- [Googleリッチリザルトテスト](https://search.google.com/test/rich-results) / [Schema Markup Validator](https://validator.schema.org/) で構造化データを検証