### PR TITLE
feat: ブログのOGP画像に代表コードのエディタ風パネルを追加

### DIFF
--- a/apps/main/src/app/_components/og-image/og-code-image.tsx
+++ b/apps/main/src/app/_components/og-image/og-code-image.tsx
@@ -1,0 +1,339 @@
+import { highlightCode } from '@repo/code-highlight/tokenize';
+import { loadDefaultJapaneseParser } from 'budoux';
+import { ImageResponse } from 'next/og';
+
+import { getIconDataUrl } from '@/shared/og/get-icon-data-url';
+import { getJellyfishLegsDataUrl } from '@/shared/og/get-jellyfish-legs-data-url';
+import { getJetBrainsMonoFont } from '@/shared/og/get-jetbrains-mono-font';
+import { getMPlus2Font } from '@/shared/og/get-m-plus-2-font';
+
+type OgCodeImageProps = {
+  title: string;
+  code: {
+    lang: string;
+    code: string;
+  };
+};
+
+const PANEL_WIDTH = 470;
+const PANEL_HEIGHT = 470;
+const PANEL_HEADER_HEIGHT = 42;
+const CODE_PADDING_X = 24;
+const CODE_PADDING_Y = 20;
+const CODE_LINE_HEIGHT = 1.5;
+// JetBrains Monoの字送りは0.6em固定
+const CODE_CHAR_WIDTH = 0.6;
+
+// 左カラム幅: カード内幅1020 - gap36 - パネル470 - 左padding16
+const TITLE_AREA_WIDTH = 498;
+const TITLE_MAX_HEIGHT = 320;
+const TITLE_LINE_HEIGHT = 1.35;
+
+// 全角=1, 半角=0.55として概算し、BudouXの塊単位折り返しの空きを見込んで30%の余裕を持たせる。
+// 推定4行以内に収まる最大サイズを選ぶ
+const calcTitleFontSize = (title: string): number => {
+  let units = 0;
+  for (const char of title) {
+    units += (char.codePointAt(0) ?? 0) < 128 ? 0.55 : 1;
+  }
+  for (const size of [42, 38, 34, 30]) {
+    const lines = Math.ceil((units * 1.3 * size) / TITLE_AREA_WIDTH);
+    if (lines <= 4 && lines * size * TITLE_LINE_HEIGHT <= TITLE_MAX_HEIGHT) {
+      return size;
+    }
+  }
+  return 28;
+};
+
+const calcCodeFontSize = (lineCount: number, maxLineLength: number) => {
+  const areaHeight = PANEL_HEIGHT - PANEL_HEADER_HEIGHT - CODE_PADDING_Y * 2;
+  const areaWidth = PANEL_WIDTH - CODE_PADDING_X * 2;
+  const fitByHeight = areaHeight / (Math.max(lineCount, 1) * CODE_LINE_HEIGHT);
+  const fitByWidth = areaWidth / (Math.max(maxLineLength, 1) * CODE_CHAR_WIDTH);
+  return Math.max(
+    11,
+    Math.min(20, Math.floor(Math.min(fitByHeight, fitByWidth))),
+  );
+};
+
+export async function OgCodeImage({ title, code }: OgCodeImageProps) {
+  const words = loadDefaultJapaneseParser().parse(title);
+  const iconDataUrl = getIconDataUrl();
+  const highlighted = await highlightCode(code.code, code.lang);
+
+  const codeLines = code.code.split('\n');
+  const maxLineLength = Math.max(...codeLines.map((line) => line.length), 1);
+  const codeFontSize = calcCodeFontSize(
+    highlighted.tokens.length,
+    maxLineLength,
+  );
+  const codeLineHeight = codeFontSize * CODE_LINE_HEIGHT;
+  const maxVisibleLines = Math.floor(
+    (PANEL_HEIGHT - PANEL_HEADER_HEIGHT - CODE_PADDING_Y * 2) / codeLineHeight,
+  );
+  const visibleLines = highlighted.tokens.slice(0, maxVisibleLines);
+
+  const titleFontSize = calcTitleFontSize(title);
+  const fontText = `${title}k8o`;
+  const [font450, monoFont] = await Promise.all([
+    getMPlus2Font({ text: fontText }),
+    getJetBrainsMonoFont({ text: `${code.code}${code.lang}` }),
+  ]);
+
+  return new ImageResponse(
+    <div
+      style={{
+        alignItems: 'center',
+        display: 'flex',
+        backgroundImage: 'linear-gradient(135deg, #cffafe 0%, #dbeafe 100%)',
+        justifyContent: 'center',
+        width: '100%',
+        height: '100%',
+        position: 'relative',
+        fontFamily: '"M PLUS 2"',
+      }}
+    >
+      {/* 装飾的なグラデーション円 */}
+      <div
+        style={{
+          position: 'absolute',
+          width: 600,
+          height: 600,
+          borderRadius: 9999,
+          background: 'linear-gradient(135deg, #22d3ee, #5eead4)',
+          filter: 'blur(100px)',
+          top: -200,
+          right: -100,
+          display: 'flex',
+          opacity: 0.4,
+        }}
+      />
+      <div
+        style={{
+          position: 'absolute',
+          width: 500,
+          height: 500,
+          borderRadius: 9999,
+          background: 'linear-gradient(135deg, #60a5fa, #2dd4bf)',
+          filter: 'blur(100px)',
+          bottom: -150,
+          left: -100,
+          display: 'flex',
+          opacity: 0.4,
+        }}
+      />
+      <div
+        style={{
+          background: '#ffffff',
+          width: 1100,
+          height: 550,
+          display: 'flex',
+          gap: 36,
+          padding: 40,
+          borderRadius: 32,
+          boxShadow: '0 25px 50px -12px #27272a',
+          position: 'relative',
+          overflow: 'hidden',
+          opacity: 0.98,
+        }}
+      >
+        {/* クラゲの足: サイト背景と同じ装飾をカードの左下に流す */}
+        {/* ogなので */}
+        <img
+          alt=""
+          height={230}
+          src={getJellyfishLegsDataUrl('bottom-left')}
+          style={{ position: 'absolute', bottom: 0, left: 0 }}
+          width={230}
+        />
+        {/* 左カラム: タイトルとブランド */}
+        {/* flexBasis 0 + minWidth 0 がないとタイトルのmax-content幅でパネルが押し出される */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            justifyContent: 'space-between',
+            flexGrow: 1,
+            flexBasis: 0,
+            minWidth: 0,
+            paddingTop: 24,
+            paddingBottom: 8,
+            paddingLeft: 16,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              justifyContent: 'flex-start',
+              flexWrap: 'wrap',
+              alignItems: 'flex-start',
+              color: '#0f172a',
+              fontSize: titleFontSize,
+              fontWeight: 450,
+              lineHeight: TITLE_LINE_HEIGHT,
+              letterSpacing: '-0.02em',
+            }}
+          >
+            {words.map((word, index) => (
+              <span
+                key={`${word}-${index.toString()}`}
+                style={{
+                  display: 'block',
+                  color: '#0f172a',
+                }}
+              >
+                {word}
+              </span>
+            ))}
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 20,
+            }}
+          >
+            {/* ogなので */}
+            <img
+              alt="アイコン"
+              height={72}
+              src={iconDataUrl}
+              style={{
+                borderRadius: 9999,
+                objectFit: 'cover',
+                boxShadow: '0 10px 25px -5px #27272a',
+              }}
+              width={72}
+            />
+            <span
+              style={{
+                color: '#18181b',
+                fontSize: 36,
+                fontWeight: 450,
+              }}
+            >
+              k8o
+            </span>
+          </div>
+        </div>
+        {/* 右カラム: エディタ風コードパネル */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            width: PANEL_WIDTH,
+            height: PANEL_HEIGHT,
+            flexShrink: 0,
+            borderRadius: 20,
+            backgroundColor: '#21252b',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              height: PANEL_HEADER_HEIGHT,
+              paddingLeft: 20,
+              paddingRight: 20,
+              borderBottom: '1px solid rgba(255, 255, 255, 0.08)',
+            }}
+          >
+            <div style={{ display: 'flex', gap: 8 }}>
+              <div
+                style={{
+                  width: 13,
+                  height: 13,
+                  borderRadius: 9999,
+                  background: '#ff5f57',
+                  display: 'flex',
+                }}
+              />
+              <div
+                style={{
+                  width: 13,
+                  height: 13,
+                  borderRadius: 9999,
+                  background: '#febc2e',
+                  display: 'flex',
+                }}
+              />
+              <div
+                style={{
+                  width: 13,
+                  height: 13,
+                  borderRadius: 9999,
+                  background: '#28c840',
+                  display: 'flex',
+                }}
+              />
+            </div>
+            <span
+              style={{
+                fontFamily: '"JetBrains Mono"',
+                fontSize: 14,
+                color: 'rgba(255, 255, 255, 0.45)',
+              }}
+            >
+              {code.lang}
+            </span>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              paddingTop: CODE_PADDING_Y,
+              paddingBottom: CODE_PADDING_Y,
+              paddingLeft: CODE_PADDING_X,
+              paddingRight: CODE_PADDING_X,
+              fontFamily: '"JetBrains Mono"',
+              fontSize: codeFontSize,
+            }}
+          >
+            {visibleLines.map((line, lineIndex) => (
+              <div
+                key={`line-${lineIndex.toString()}`}
+                style={{
+                  display: 'flex',
+                  height: codeLineHeight,
+                  alignItems: 'center',
+                }}
+              >
+                {line.map((token, tokenIndex) => (
+                  <span
+                    key={`${lineIndex.toString()}-${tokenIndex.toString()}`}
+                    style={{
+                      color: token.color ?? highlighted.fg,
+                      whiteSpace: 'pre',
+                    }}
+                  >
+                    {token.content}
+                  </span>
+                ))}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>,
+    {
+      width: 1200,
+      height: 630,
+      fonts: [
+        {
+          name: 'M PLUS 2',
+          data: font450,
+          style: 'normal',
+          weight: 400,
+        },
+        {
+          name: 'JetBrains Mono',
+          data: monoFont,
+          style: 'normal',
+          weight: 400,
+        },
+      ],
+    },
+  );
+}

--- a/apps/main/src/app/_components/og-image/og-image.tsx
+++ b/apps/main/src/app/_components/og-image/og-image.tsx
@@ -4,12 +4,28 @@ import { ImageResponse } from 'next/og';
 import { getIconDataUrl } from '@/shared/og/get-icon-data-url';
 import { getMPlus2Font } from '@/shared/og/get-m-plus-2-font';
 
+import { OgCodeImage } from './og-code-image';
+
 type OgImageProps = {
   title: string;
-  category?: string;
+  category?: string | undefined;
+  code?:
+    | {
+        lang: string;
+        code: string;
+      }
+    | undefined;
 };
 
-export async function OgImage({ title, category }: OgImageProps) {
+export function OgImage({ title, category, code }: OgImageProps) {
+  // 代表コードがあるときはコードパネル付きレイアウトで描画する
+  if (code) {
+    return OgCodeImage({ title, code });
+  }
+  return OgTextImage({ title, category });
+}
+
+async function OgTextImage({ title, category }: Omit<OgImageProps, 'code'>) {
   const words = loadDefaultJapaneseParser().parse(title);
   const iconDataUrl = getIconDataUrl();
   const fontText = `${title}${category ?? ''}${(category ?? '').toUpperCase()}k8oK8O`;

--- a/apps/main/src/app/blog/(articles)/abs-sign/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/abs-sign/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'CSSのabs()とsign()関数で数値の符号を使ったスタイリングを行う';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('abs-sign');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('abs-sign'),
+    getBlogOgCode('abs-sign'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/active-view-transition/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/active-view-transition/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   ':active-view-transition-type()で遷移タイプごとに異なるアニメーションを適用する';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('active-view-transition');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('active-view-transition'),
+    getBlogOgCode('active-view-transition'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/async-clipboard/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/async-clipboard/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '任意のデータをコピー&ペーストするClipboard API';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('async-clipboard');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('async-clipboard'),
+    getBlogOgCode('async-clipboard'),
+  ]);
 
   return OgImage({
     title: blog.title,
     category: 'Blog',
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/atomics-pause/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/atomics-pause/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Atomicsで共有メモリ上のデータを安全に取り扱う';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('atomics-pause');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('atomics-pause'),
+    getBlogOgCode('atomics-pause'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/atomics-wait-async/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/atomics-wait-async/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Atomics.waitAsyncで非同期に共有メモリ上のデータを待機する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('atomics-wait-async');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('atomics-wait-async'),
+    getBlogOgCode('atomics-wait-async'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/baseline-shift/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/baseline-shift/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'baseline-shiftでテキストのベースラインをずらす';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('baseline-shift');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('baseline-shift'),
+    getBlogOgCode('baseline-shift'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/chromatic-storybook-publish/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/chromatic-storybook-publish/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'ChromaticにStorybookをPublishすることで広がる恩恵';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('chromatic-storybook-publish');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('chromatic-storybook-publish'),
+    getBlogOgCode('chromatic-storybook-publish'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/color-certification-uc/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/color-certification-uc/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '色彩検定UC級に合格しました！';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('color-certification-uc');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('color-certification-uc'),
+    getBlogOgCode('color-certification-uc'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/color-contrast/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/color-contrast/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '色のコントラスト比は重要だけどどうやって求めるんだっけ？';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('color-contrast');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('color-contrast'),
+    getBlogOgCode('color-contrast'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/color-perception/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/color-perception/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '色覚タイプとその分類';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('color-perception');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('color-perception'),
+    getBlogOgCode('color-perception'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/composed-ranges/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/composed-ranges/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'Shadow DOM境界を跨いだ選択範囲の処理を可能にするgetComposedRanges';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('composed-ranges');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('composed-ranges'),
+    getBlogOgCode('composed-ranges'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/container-style-queries/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/container-style-queries/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'Container style queriesでカスタムプロパティの値からスタイルを切り替える';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('container-style-queries');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('container-style-queries'),
+    getBlogOgCode('container-style-queries'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/content-visibility/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/content-visibility/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   '要素のレイアウトとレンダリングを必要なタイミングまでスキップさせるCSSのcontent-visibilityプロパティ';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('content-visibility');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('content-visibility'),
+    getBlogOgCode('content-visibility'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/contenteditable-plaintextonly/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/contenteditable-plaintextonly/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'contenteditableな要素でテキストだけを編集可能にする';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('contenteditable-plaintextonly');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('contenteditable-plaintextonly'),
+    getBlogOgCode('contenteditable-plaintextonly'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/contrast-color/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/contrast-color/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'contrast-color()で背景色に応じた読みやすい文字色を自動で割り当てる';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('contrast-color');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('contrast-color'),
+    getBlogOgCode('contrast-color'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/crisp-edges/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/crisp-edges/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'image-rendering: crisp-edges';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('crisp-edges');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('crisp-edges'),
+    getBlogOgCode('crisp-edges'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/csp-violation-reports/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/csp-violation-reports/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'CSP violation reports';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('csp-violation-reports');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('csp-violation-reports'),
+    getBlogOgCode('csp-violation-reports'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/details-content/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/details-content/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('details-content');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('details-content'),
+    getBlogOgCode('details-content'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/document-caretpositionfrompoint/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/document-caretpositionfrompoint/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'document.caretPositionFromPointで座標からキャレット位置を取得する';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('document-caretpositionfrompoint');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('document-caretpositionfrompoint'),
+    getBlogOgCode('document-caretpositionfrompoint'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/event-timing/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/event-timing/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Performance Event Timing APIで操作の待ち時間を計測する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('event-timing');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('event-timing'),
+    getBlogOgCode('event-timing'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/float16array/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/float16array/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '16bit浮動小数点が使える！Float16Array';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('float16array');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('float16array'),
+    getBlogOgCode('float16array'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/font-family-math/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/font-family-math/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'font-family: mathで数式に適切なフォントを適用する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('font-family-math');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('font-family-math'),
+    getBlogOgCode('font-family-math'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/for-the-first-time-in-forever/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/for-the-first-time-in-forever/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '【TSKaigi】初めて登壇しました！';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('for-the-first-time-in-forever');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('for-the-first-time-in-forever'),
+    getBlogOgCode('for-the-first-time-in-forever'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/getorinsert/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/getorinsert/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'getOrInsert';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('getorinsert');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('getorinsert'),
+    getBlogOgCode('getorinsert'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/highlight/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/highlight/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'CSS Custom Highlight APIで任意の範囲のテキストをハイライトする';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('highlight');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('highlight'),
+    getBlogOgCode('highlight'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/input-file-webkitdirectory/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/input-file-webkitdirectory/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'ファイルを受け入れるinput要素でディレクトリを扱うwebkitdirectory属性';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('input-file-webkitdirectory');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('input-file-webkitdirectory'),
+    getBlogOgCode('input-file-webkitdirectory'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/intl-duration-format/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/intl-duration-format/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Intl.DurationFormatで期間をlocaleに基づいて表現する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('intl-duration-format');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('intl-duration-format'),
+    getBlogOgCode('intl-duration-format'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/invoker-commands/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/invoker-commands/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'Invoker Commands APIでJavaScriptなしでボタンから他の要素を操作する';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('invoker-commands');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('invoker-commands'),
+    getBlogOgCode('invoker-commands'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/iterator-concat/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/iterator-concat/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Iterator.concat()';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('iterator-concat');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('iterator-concat'),
+    getBlogOgCode('iterator-concat'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/iterator-methods/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/iterator-methods/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'Iteratorに対してmapやfilterのようなヘルパー関数を作用させる';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('iterator-methods');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('iterator-methods'),
+    getBlogOgCode('iterator-methods'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/js-modules-service-workers/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/js-modules-service-workers/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'JavaScript modules in service workers';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('js-modules-service-workers');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('js-modules-service-workers'),
+    getBlogOgCode('js-modules-service-workers'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/json-modules/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/json-modules/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'withキーワードを使用したJSONモジュールのインポート';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('json-modules');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('json-modules'),
+    getBlogOgCode('json-modules'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/largest-contentful-paint/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/largest-contentful-paint/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'Largest Contentful Paint APIで最大コンテンツの描画時間を計測する';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('largest-contentful-paint');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('largest-contentful-paint'),
+    getBlogOgCode('largest-contentful-paint'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/link-rel-dns-prefetch/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/link-rel-dns-prefetch/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'リソースへのリクエスト前にドメイン名を解決するdns-prefetch';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('link-rel-dns-prefetch');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('link-rel-dns-prefetch'),
+    getBlogOgCode('link-rel-dns-prefetch'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/math-sum-precise/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/math-sum-precise/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Math.sumPrecise()';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('math-sum-precise');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('math-sum-precise'),
+    getBlogOgCode('math-sum-precise'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/navigation/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/navigation/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Navigation API';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('navigation');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('navigation'),
+    getBlogOgCode('navigation'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/npm-trusted-publishing-for-npm-packages/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/npm-trusted-publishing-for-npm-packages/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'OIDCを利用したnpmパッケージの公開が可能になったので、Changeset×GitHub Actionsで試してみる';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('npm-trusted-publishing-for-npm-packages');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('npm-trusted-publishing-for-npm-packages'),
+    getBlogOgCode('npm-trusted-publishing-for-npm-packages'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/open-pseudo/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/open-pseudo/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = ':open疑似クラスで開いている要素をまとめてスタイリングする';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('open-pseudo');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('open-pseudo'),
+    getBlogOgCode('open-pseudo'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/parse-html-unsafe/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/parse-html-unsafe/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'parseHtmlUnsafeでHTMLをDocumentに変換する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('parse-html-unsafe');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('parse-html-unsafe'),
+    getBlogOgCode('parse-html-unsafe'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/popover/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/popover/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'Popover APIを使ってJavaScriptなしでツールチップやドロップダウンメニューを実装する';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('popover');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('popover'),
+    getBlogOgCode('popover'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/print-color-adjust/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/print-color-adjust/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'print-color-adjustで印刷時の色調整を制御する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('print-color-adjust');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('print-color-adjust'),
+    getBlogOgCode('print-color-adjust'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/promise-try/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/promise-try/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '関数の同期・非同期を気にせず処理するPromise.tryとは';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('promise-try');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('promise-try'),
+    getBlogOgCode('promise-try'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/react-children-props/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/react-children-props/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Reactコンポーネントでchildrenに対してpropsを渡す';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('react-children-props');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('react-children-props'),
+    getBlogOgCode('react-children-props'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/react19-usereducer-ts-type-inference/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/react19-usereducer-ts-type-inference/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'React19で変化したuseReducerの型から学ぶTypeScriptの型推論';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('react19-usereducer-ts-type-inference');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('react19-usereducer-ts-type-inference'),
+    getBlogOgCode('react19-usereducer-ts-type-inference'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/readable-byte-streams/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/readable-byte-streams/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Readable Byte Streams';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('readable-byte-streams');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('readable-byte-streams'),
+    getBlogOgCode('readable-byte-streams'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/regexp-escape/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/regexp-escape/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '文字列に潜む正規表現の構文を置き換えるRegExp.escape';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('regexp-escape');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('regexp-escape'),
+    getBlogOgCode('regexp-escape'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/reporting/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/reporting/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Reporting API';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('reporting');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('reporting'),
+    getBlogOgCode('reporting'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/requestclose/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/requestclose/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '<dialog>要素を閉じるように要求するrequestClose';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('requestclose');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('requestclose'),
+    getBlogOgCode('requestclose'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/root-font-units/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/root-font-units/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'rcap, rch, rex, ric単位でルート要素に基づいたサイズを指定する';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('root-font-units');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('root-font-units'),
+    getBlogOgCode('root-font-units'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/sb-mock/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/sb-mock/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'sb.mockでStorybookで利用するモジュールをモックしよう！';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('sb-mock');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('sb-mock'),
+    getBlogOgCode('sb-mock'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/scope/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/scope/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '@scopeでCSSスタイルの適用範囲を制御する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('scope');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('scope'),
+    getBlogOgCode('scope'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/screen-wake-lock/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/screen-wake-lock/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '画面のスリープを防ぐScreen Wake Lock API';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('screen-wake-lock');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('screen-wake-lock'),
+    getBlogOgCode('screen-wake-lock'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/scrollbar-color/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/scrollbar-color/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'scrollbar-colorでスクロールバーの色を変更する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('scrollbar-color');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('scrollbar-color'),
+    getBlogOgCode('scrollbar-color'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/scrollend/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/scrollend/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'scrollendイベントでスクロール終了を検知する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('scrollend');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('scrollend'),
+    getBlogOgCode('scrollend'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/shape-function/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/shape-function/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'shape()';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('shape-function');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('shape-function'),
+    getBlogOgCode('shape-function'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/shared-worker/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/shared-worker/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'SharedWorker';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('shared-worker');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('shared-worker'),
+    getBlogOgCode('shared-worker'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/single-color-gradients/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/single-color-gradients/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'CSS グラデーションの新仕様：単色カラーストップの導入';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('single-color-gradients');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('single-color-gradients'),
+    getBlogOgCode('single-color-gradients'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/spelling-grammar-error/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/spelling-grammar-error/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'スペルミス・文法エラーに対してスタイルを設定する::spelling-errorと::grammar-error';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('spelling-grammar-error');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('spelling-grammar-error'),
+    getBlogOgCode('spelling-grammar-error'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/storybook-framework-hono-vite/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/storybook-framework-hono-vite/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'Hono JSXで@storybook/react-viteと同じ使い心地を得るためのStorybookフレームワーク storybook-framework-hono-vite を作った';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('storybook-framework-hono-vite');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('storybook-framework-hono-vite'),
+    getBlogOgCode('storybook-framework-hono-vite'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/suspense-list/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/suspense-list/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'React SuspenseListでローディング順序を制御する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('suspense-list');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('suspense-list'),
+    getBlogOgCode('suspense-list'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/tanstack-router-introduction/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/tanstack-router-introduction/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Reactの新しいルーティングライブラリ、TanStackRouterを学ぶ';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('tanstack-router-introduction');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('tanstack-router-introduction'),
+    getBlogOgCode('tanstack-router-introduction'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/text-decoration-skip-ink-all/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/text-decoration-skip-ink-all/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'text-decoration-skip-ink: all';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('text-decoration-skip-ink-all');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('text-decoration-skip-ink-all'),
+    getBlogOgCode('text-decoration-skip-ink-all'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/text-indent-keywords/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/text-indent-keywords/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'text-indentのeach-lineとhangingキーワードでインデントを制御する';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('text-indent-keywords');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('text-indent-keywords'),
+    getBlogOgCode('text-indent-keywords'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/toggleevent-source/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/toggleevent-source/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'ToggleEvent.sourceでポップオーバーを開いた要素を特定する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('toggleevent-source');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('toggleevent-source'),
+    getBlogOgCode('toggleevent-source'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/trusted-types/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/trusted-types/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Trusted Types';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('trusted-types');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('trusted-types'),
+    getBlogOgCode('trusted-types'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/typescript-satisfies-narrowing/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/typescript-satisfies-narrowing/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   '特定のケースではsatisfies演算子で型が絞り込まれてしまう？？？';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('typescript-satisfies-narrowing');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('typescript-satisfies-narrowing'),
+    getBlogOgCode('typescript-satisfies-narrowing'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/typescript-satisfies-narrowing/page.mdx
+++ b/apps/main/src/app/blog/(articles)/typescript-satisfies-narrowing/page.mdx
@@ -18,6 +18,7 @@ updatedAt: 2026-01-16
 下の3つの`palette`オブジェクトに注目してください（[TypeScript Playground](https://www.typescriptlang.org/play/?#code/FAFwngDgpgBAwgewDYIE4GcYF4YCJVQAmuMAPngOYFQB2J5uARkgK5S4DcwwAxgjehAwIAQyRQQIKAEZsMAN7AYymAUIAuPAGIAZjoAMh-bgA0SlVSi1NuLYb2HT55czY27RvU4C+MEZj4BEC5efkFhMQkpACZNACUoPlRCAB5EFAwTGEFUAEsaCgA+OUUVVSJ3ByMnMstrbXsDYzMy1yh3I30vM19-GEDBEIGhUXFJKABmEudyjW0qxxaLahoOrqaalTa1xp8-ALChdBEQXPQdXKhMBKTU9LR0LJz8oo4gA)）。
 
 ```ts
+// [!og]
 type Colors = "red" | "green" | "blue";
 
 const palette1 = {

--- a/apps/main/src/app/blog/(articles)/uint8array-base64-hex/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/uint8array-base64-hex/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'Uint8Arrayとbase64、Hex（16進数）の相互変換';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('uint8array-base64-hex');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('uint8array-base64-hex'),
+    getBlogOgCode('uint8array-base64-hex'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/urlpattern/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/urlpattern/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'URLのパターンマッチを簡単にするURLPattern API';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('urlpattern');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('urlpattern'),
+    getBlogOgCode('urlpattern'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/view-transitions/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/view-transitions/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt =
   'Web上のさまざまな表現同士の遷移を簡単にアニメーション化するView Transition API';
@@ -11,10 +14,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('view-transitions');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('view-transitions'),
+    getBlogOgCode('view-transitions'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/wasm-branch-hinting/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/wasm-branch-hinting/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'WebAssemblyのBranch Hintingで分岐予測を助ける';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('wasm-branch-hinting');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('wasm-branch-hinting'),
+    getBlogOgCode('wasm-branch-hinting'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/webrtc-encoded-transform/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/webrtc-encoded-transform/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = '';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('webrtc-encoded-transform');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('webrtc-encoded-transform'),
+    getBlogOgCode('webrtc-encoded-transform'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/webtransport/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/webtransport/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'WebTransportでHTTP/3上の双方向通信を実現する';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('webtransport');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('webtransport'),
+    getBlogOgCode('webtransport'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/app/blog/(articles)/zstd/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/zstd/opengraph-image.tsx
@@ -1,5 +1,8 @@
 import { OgImage } from '@/app/_components/og-image';
-import { getBlogContent } from '@/features/blog/interface/queries';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
 
 export const alt = 'zstd';
 export const size = {
@@ -10,10 +13,14 @@ export const size = {
 export const contentType = 'image/png';
 
 export default async function Image() {
-  const blog = await getBlogContent('zstd');
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('zstd'),
+    getBlogOgCode('zstd'),
+  ]);
 
   return OgImage({
     category: 'Blog',
     title: blog.title,
+    code: ogCode ?? undefined,
   });
 }

--- a/apps/main/src/features/blog/application/og-code.ts
+++ b/apps/main/src/features/blog/application/og-code.ts
@@ -1,0 +1,38 @@
+import { readFile } from 'node:fs/promises';
+
+import { parseAnnotations } from '@repo/code-highlight/parser';
+import { remark } from 'remark';
+import remarkFrontmatter from 'remark-frontmatter';
+
+import { blogPath } from './path';
+
+export type BlogOgCode = {
+  lang: string;
+  code: string;
+};
+
+/**
+ * 記事内で `[!og]` ディレクティブが付いたコードブロックをOGP画像用に抽出する。
+ * マーカー行を含む注釈行はすべて取り除いたコードを返す。見つからなければnull。
+ */
+export const getBlogOgCode = async (
+  slug: string,
+): Promise<BlogOgCode | null> => {
+  const content = await readFile(blogPath(slug), 'utf-8');
+  const tree = remark().use(remarkFrontmatter).parse(content);
+
+  for (const node of tree.children) {
+    if (node.type !== 'code') {
+      continue;
+    }
+    const { code, annotations } = parseAnnotations(node.value);
+    const isOgTarget = annotations.some((lineAnnotations) =>
+      lineAnnotations.some((annotation) => annotation.type === 'og'),
+    );
+    if (isOgTarget) {
+      return { lang: node.lang ?? 'text', code };
+    }
+  }
+
+  return null;
+};

--- a/apps/main/src/features/blog/interface/queries.ts
+++ b/apps/main/src/features/blog/interface/queries.ts
@@ -9,6 +9,7 @@ import {
   getBlogsByTags as _getBlogsByTags,
   getBlogs,
 } from '@/features/blog/application/blogs';
+import { getBlogOgCode as _getBlogOgCode } from '@/features/blog/application/og-code';
 import { getBlogView as _getBlogView } from '@/features/blog/application/view';
 
 export async function getBlogContents() {
@@ -49,6 +50,14 @@ export async function getBlogContent(slug: string) {
     createdAt: metadata.createdAt,
     updatedAt: metadata.updatedAt,
   };
+}
+
+export async function getBlogOgCode(slug: string) {
+  'use cache';
+  cacheLife('max');
+
+  const ogCode = await _getBlogOgCode(slug);
+  return ogCode;
 }
 
 export async function getBlogToc(slug: string) {

--- a/apps/main/src/shared/og/get-google-font.ts
+++ b/apps/main/src/shared/og/get-google-font.ts
@@ -1,0 +1,75 @@
+const cssCache = new Map<string, Promise<string>>();
+const fontCache = new Map<string, Promise<ArrayBuffer>>();
+
+type GoogleFontParams = {
+  family: string;
+  weight: number;
+  text: string;
+};
+
+function buildCssUrl({ family, weight, text }: GoogleFontParams): string {
+  const familyParam = `${family.replaceAll(' ', '+')}:wght@${weight.toString()}`;
+  // 同じグリフ集合でキャッシュが効くよう、文字を重複排除・ソートしてサブセット化する
+  const subset = [...new Set(text)].toSorted().join('');
+  return `https://fonts.googleapis.com/css2?family=${familyParam}&display=swap&text=${encodeURIComponent(subset)}`;
+}
+
+function fetchGoogleFontsCss(url: string): Promise<string> {
+  const cachedCss = cssCache.get(url);
+  if (cachedCss) {
+    return cachedCss;
+  }
+
+  const cssPromise = fetch(url)
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch Google Fonts CSS: ${response.status}`);
+      }
+      return response.text();
+    })
+    .catch((error: unknown) => {
+      cssCache.delete(url);
+      throw error;
+    });
+
+  cssCache.set(url, cssPromise);
+  return cssPromise;
+}
+
+function extractFontUrl(css: string): string {
+  const match =
+    /src:\s*url\(["']?([^"')]+)["']?\)\s*format\('(?:woff2|woff|opentype|truetype)'\)/u.exec(
+      css,
+    );
+
+  if (match?.[1] === undefined) {
+    throw new Error('Failed to parse font URL from Google Fonts CSS');
+  }
+
+  return match[1];
+}
+
+export function getGoogleFont(params: GoogleFontParams): Promise<ArrayBuffer> {
+  const cacheKey = buildCssUrl(params);
+  const cachedFont = fontCache.get(cacheKey);
+  if (cachedFont) {
+    return cachedFont;
+  }
+
+  const fontPromise = fetchGoogleFontsCss(cacheKey)
+    .then(extractFontUrl)
+    .then((fontUrl) => fetch(fontUrl))
+    .then((response) => {
+      if (!response.ok) {
+        throw new Error(`Failed to fetch font file: ${response.status}`);
+      }
+      return response.arrayBuffer();
+    })
+    .catch((error: unknown) => {
+      fontCache.delete(cacheKey);
+      throw error;
+    });
+
+  fontCache.set(cacheKey, fontPromise);
+  return fontPromise;
+}

--- a/apps/main/src/shared/og/get-jellyfish-legs-data-url.ts
+++ b/apps/main/src/shared/og/get-jellyfish-legs-data-url.ts
@@ -1,0 +1,73 @@
+/**
+ * OGP画像用のクラゲの足(細いライン+ドット)SVGをdata URLで返す。
+ * パスデータは app/_components/global-layout/background のものと同じ。
+ * OGは常にライトテーマなので色は固定。
+ */
+
+type Dot = { cx: number; cy: number; r: number };
+
+// 左上の足（多め・大きめ）。viewBox 0 0 240 240。
+const LEG_PATHS_TOP_LEFT = [
+  'M 6 -16 C 36 36, 18 86, 70 116 C 104 135, 92 182, 138 196',
+  'M -16 26 C 40 44, 72 78, 72 124 C 72 158, 104 176, 116 208',
+  'M -8 72 C 28 80, 44 104, 40 140 C 38 162, 52 176, 70 186',
+];
+
+const DOTS_TOP_LEFT: Dot[] = [
+  { cx: 58, cy: 104, r: 2 },
+  { cx: 84, cy: 142, r: 2 },
+  { cx: 112, cy: 180, r: 2 },
+  { cx: 72, cy: 126, r: 1.8 },
+  { cx: 104, cy: 176, r: 1.8 },
+  { cx: 42, cy: 140, r: 1.8 },
+  { cx: 60, cy: 182, r: 1.6 },
+];
+
+// サイトの右下の足をベースに、内側に短い1本を足した3本構成。
+// OGでは下辺用に上下反転して使う。
+const LEG_PATHS_BOTTOM = [
+  'M -10 12 C 52 32, 30 92, 80 126 C 112 148, 98 198, 134 216',
+  'M -6 52 C 32 72, 50 112, 46 152 C 43 186, 62 202, 82 216',
+  'M -12 88 C 24 98, 40 122, 36 152 C 33 176, 46 192, 60 204',
+];
+
+const DOTS_BOTTOM: Dot[] = [
+  { cx: 62, cy: 108, r: 1.8 },
+  { cx: 96, cy: 160, r: 1.8 },
+  { cx: 50, cy: 150, r: 1.6 },
+  { cx: 30, cy: 122, r: 1.6 },
+  { cx: 52, cy: 196, r: 1.6 },
+];
+
+// site側の oklch(0.6 0.09 195 / 0.5) 相当
+const LEG_COLOR = '#38929e';
+const LEG_OPACITY = 0.5;
+
+const buildSvg = (paths: string[], dots: Dot[], flipY: boolean): string => {
+  const transform = flipY ? ' transform="translate(0 240) scale(1 -1)"' : '';
+  const pathElements = paths.map((d) => `<path d="${d}"/>`).join('');
+  const dotElements = dots
+    .map(
+      (dot) =>
+        `<circle cx="${dot.cx.toString()}" cy="${dot.cy.toString()}" r="${dot.r.toString()}"/>`,
+    )
+    .join('');
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 240">` +
+    `<g${transform}>` +
+    `<g fill="none" stroke="${LEG_COLOR}" stroke-opacity="${LEG_OPACITY.toString()}" stroke-width="2" stroke-linecap="round">${pathElements}</g>` +
+    `<g fill="${LEG_COLOR}" fill-opacity="${LEG_OPACITY.toString()}">${dotElements}</g>` +
+    `</g>` +
+    `</svg>`
+  );
+};
+
+export const getJellyfishLegsDataUrl = (
+  variant: 'top-left' | 'bottom-left',
+): string => {
+  const svg =
+    variant === 'top-left'
+      ? buildSvg(LEG_PATHS_TOP_LEFT, DOTS_TOP_LEFT, false)
+      : buildSvg(LEG_PATHS_BOTTOM, DOTS_BOTTOM, true);
+  return `data:image/svg+xml,${encodeURIComponent(svg)}`;
+};

--- a/apps/main/src/shared/og/get-jetbrains-mono-font.ts
+++ b/apps/main/src/shared/og/get-jetbrains-mono-font.ts
@@ -1,0 +1,9 @@
+import { getGoogleFont } from './get-google-font';
+
+export function getJetBrainsMonoFont({
+  text,
+}: {
+  text: string;
+}): Promise<ArrayBuffer> {
+  return getGoogleFont({ family: 'JetBrains Mono', weight: 400, text });
+}

--- a/apps/main/src/shared/og/get-m-plus-2-font.ts
+++ b/apps/main/src/shared/og/get-m-plus-2-font.ts
@@ -1,69 +1,9 @@
-const cssCache = new Map<string, Promise<string>>();
-const fontCache = new Map<string, Promise<ArrayBuffer>>();
-
-function fetchGoogleFontsCss({ text }: { text: string }): Promise<string> {
-  const cacheKey = text;
-  const cachedCss = cssCache.get(cacheKey);
-  if (cachedCss) {
-    return cachedCss;
-  }
-
-  const cssPromise = fetch(
-    `https://fonts.googleapis.com/css2?family=M+PLUS+2:wght@450&display=swap&text=${encodeURIComponent(text)}`,
-  )
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error(`Failed to fetch Google Fonts CSS: ${response.status}`);
-      }
-      return response.text();
-    })
-    .catch((error: unknown) => {
-      cssCache.delete(cacheKey);
-      throw error;
-    });
-
-  cssCache.set(cacheKey, cssPromise);
-  return cssPromise;
-}
-
-function extractFontUrl(css: string): string {
-  const match =
-    /src:\s*url\(["']?([^"')]+)["']?\)\s*format\('(?:woff2|woff|opentype|truetype)'\)/u.exec(
-      css,
-    );
-
-  if (match?.[1] === undefined) {
-    throw new Error('Failed to parse font URL from Google Fonts CSS');
-  }
-
-  return match[1];
-}
+import { getGoogleFont } from './get-google-font';
 
 export function getMPlus2Font({
   text,
 }: {
   text: string;
 }): Promise<ArrayBuffer> {
-  const cacheKey = text;
-  const cachedFont = fontCache.get(cacheKey);
-  if (cachedFont) {
-    return cachedFont;
-  }
-
-  const fontPromise = fetchGoogleFontsCss({ text })
-    .then(extractFontUrl)
-    .then((fontUrl) => fetch(fontUrl))
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error(`Failed to fetch font file: ${response.status}`);
-      }
-      return response.arrayBuffer();
-    })
-    .catch((error: unknown) => {
-      fontCache.delete(cacheKey);
-      throw error;
-    });
-
-  fontCache.set(cacheKey, fontPromise);
-  return fontPromise;
+  return getGoogleFont({ family: 'M PLUS 2', weight: 450, text });
 }

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -9,6 +9,14 @@
       "types": "./src/index.ts",
       "default": "./src/index.ts"
     },
+    "./parser": {
+      "types": "./src/parser.ts",
+      "default": "./src/parser.ts"
+    },
+    "./tokenize": {
+      "types": "./src/tokenize.ts",
+      "default": "./src/tokenize.ts"
+    },
     "./styles.css": "./styles/annotate.css"
   },
   "scripts": {
@@ -17,14 +25,14 @@
     "type-check": "tsgo --noEmit"
   },
   "dependencies": {
-    "@shikijs/rehype": "4.1.0"
+    "@shikijs/rehype": "4.1.0",
+    "shiki": "4.1.0"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@shikijs/types": "4.1.0",
     "@types/hast": "3.0.4",
     "@vitest/coverage-v8": "catalog:",
-    "shiki": "4.1.0",
     "vitest": "catalog:"
   }
 }

--- a/packages/code-highlight/src/parser.test.ts
+++ b/packages/code-highlight/src/parser.test.ts
@@ -90,6 +90,14 @@ describe('parseAnnotations', () => {
 
       expect(result.annotations).toEqual([[{ type: 'highlight' }]]);
     });
+
+    it('// [!og] をOGP用マーカーとして扱い、ディレクティブ行はコードから削除する', () => {
+      const input = ['// [!og]', 'const x = 1;'].join('\n');
+      const result = parseAnnotations(input);
+
+      expect(result.code).toBe('const x = 1;');
+      expect(result.annotations).toEqual([[{ type: 'og' }]]);
+    });
   });
 
   describe('異常系', () => {

--- a/packages/code-highlight/src/parser.ts
+++ b/packages/code-highlight/src/parser.ts
@@ -2,7 +2,8 @@ export type Annotation =
   | { type: 'highlight' }
   | { type: 'add' }
   | { type: 'remove' }
-  | { type: 'callout'; text: string };
+  | { type: 'callout'; text: string }
+  | { type: 'og' };
 
 type ParseResult = {
   code: string;
@@ -24,6 +25,8 @@ const parseDirective = (raw: string): Annotation | null => {
   }
   if (directive === '+') return { type: 'add' };
   if (directive === '-') return { type: 'remove' };
+  // og: OGP画像に使う代表コードブロックの印。表示には影響しない
+  if (directive === 'og') return { type: 'og' };
 
   const callout = /^callout:\s*(.+)$/u.exec(directive);
   if (callout) {

--- a/packages/code-highlight/src/tokenize.ts
+++ b/packages/code-highlight/src/tokenize.ts
@@ -1,0 +1,30 @@
+import { type BundledLanguage, codeToTokens, type ThemedToken } from 'shiki';
+
+export type HighlightedCode = {
+  tokens: ThemedToken[][];
+  fg: string;
+  bg: string;
+};
+
+const FALLBACK_FG = '#a9b2c3';
+const FALLBACK_BG = '#21252b';
+
+/**
+ * コードをrehypeプラグインと同じテーマ(plastic)でトークン化する。
+ * OGP画像のようにHTMLを介さずトークンを直接描画したい場面で使う。
+ */
+export const highlightCode = async (
+  code: string,
+  lang: string,
+): Promise<HighlightedCode> => {
+  const result = await codeToTokens(code, {
+    lang: lang as BundledLanguage,
+    theme: 'plastic',
+  }).catch(() => codeToTokens(code, { lang: 'text', theme: 'plastic' }));
+
+  return {
+    tokens: result.tokens,
+    fg: result.fg ?? FALLBACK_FG,
+    bg: result.bg ?? FALLBACK_BG,
+  };
+};

--- a/packages/code-highlight/src/transformer.ts
+++ b/packages/code-highlight/src/transformer.ts
@@ -73,6 +73,8 @@ export const annotateTransformer = (): ShikiTransformer => ({
           this.addClassToHast(node, 'code-annotate-has-callout');
           calloutsForLine.push(annotation.text);
           break;
+        case 'og':
+          break;
       }
     }
     if (calloutsForLine.length > 0) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -400,6 +400,9 @@ importers:
       '@shikijs/rehype':
         specifier: 4.1.0
         version: 4.1.0
+      shiki:
+        specifier: 4.1.0
+        version: 4.1.0
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
@@ -413,9 +416,6 @@ importers:
       '@vitest/coverage-v8':
         specifier: 'catalog:'
         version: 4.1.8(@vitest/browser@4.1.8)(vitest@4.1.8)
-      shiki:
-        specifier: 4.1.0
-        version: 4.1.0
       vitest:
         specifier: 'catalog:'
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/browser-playwright@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(msw@2.14.6(@types/node@24.12.4)(typescript@6.0.3))(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
@@ -4588,8 +4588,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.0.14:
-    resolution: {integrity: sha512-FY0rNK+mdTozXwNmcJAt5tD9hVOkXEX5ac+Mg77KJvnnsoAh3qIUW64PMnofutjeYz7g1vENMbOcrBmD1v4FlA==}
+  deslop-js@0.0.19:
+    resolution: {integrity: sha512-gLEwJ26XSRNN5r7x/AI8Zi0Fs6uJe/junYM+jQaaVRjfagUUAerPD90fZlwjRnK0Lpb9jRzqaM9BvmHXUHkGxA==}
 
   detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
@@ -5993,8 +5993,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-plugin-react-doctor@0.2.16:
-    resolution: {integrity: sha512-Ul1UxcYfjBnt+HjgNaMnkvMJjyewS6rkSZl3LiD1g/QqSll1jiynYH/ZoNpUaGHp1pDQ/xLvCcXNQvqopN0tHA==}
+  oxlint-plugin-react-doctor@0.4.0:
+    resolution: {integrity: sha512-iC+iV296B41pghbPEmR1oklwjTo8v9LlTVG1LTHed3ZkeuljH3Kq+SKeHB1YXvLuq9MARr+n4WDmN5r7bHtJfg==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxlint-tailwindcss@1.1.0:
@@ -6176,8 +6176,8 @@ packages:
     resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
     engines: {node: ^20.9.0 || >=22}
 
-  react-doctor@0.2.16:
-    resolution: {integrity: sha512-o108QscqM/TlC1QmKgDORf/P53PeZ69nZbRsvy53rXkKvWdKZC1Y0u1JRPmThbTh6v+QpMispBwEnFHhlpZQ7w==}
+  react-doctor@0.4.0:
+    resolution: {integrity: sha512-BWum4WfKZ9Sdv4zTlzRoog4fYEIBEWZXHnq8GaCL42XMLmoldATdix/i3xZSHD3+SqpMrUVGcuzerOL9R9P+bw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -7030,6 +7030,26 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  vscode-jsonrpc@8.2.0:
+    resolution: {integrity: sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==}
+    engines: {node: '>=14.0.0'}
+
+  vscode-languageserver-protocol@3.17.5:
+    resolution: {integrity: sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==}
+
+  vscode-languageserver-textdocument@1.0.12:
+    resolution: {integrity: sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==}
+
+  vscode-languageserver-types@3.17.5:
+    resolution: {integrity: sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==}
+
+  vscode-languageserver@9.0.1:
+    resolution: {integrity: sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==}
+    hasBin: true
+
+  vscode-uri@3.1.0:
+    resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
   walk-up-path@4.0.0:
     resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
@@ -10509,7 +10529,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.0.14:
+  deslop-js@0.0.19:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
@@ -12401,7 +12421,7 @@ snapshots:
       vite-plus: 0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
     optional: true
 
-  oxlint-plugin-react-doctor@0.2.16:
+  oxlint-plugin-react-doctor@0.4.0:
     dependencies:
       '@typescript-eslint/types': 8.60.0
       eslint-scope: 9.1.2
@@ -12611,7 +12631,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-doctor@0.2.16(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)):
+  react-doctor@0.4.0(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@effect/platform-node-shared': 4.0.0-beta.70(effect@4.0.0-beta.70)
@@ -12619,15 +12639,18 @@ snapshots:
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.0.14
+      deslop-js: 0.0.19
       effect: 4.0.0-beta.70
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint-plugin-react-doctor: 0.2.16
+      oxlint-plugin-react-doctor: 0.4.0
       prompts: 2.4.2
       typescript: 6.0.3
+      vscode-languageserver: 9.0.1
+      vscode-languageserver-textdocument: 1.0.12
+      vscode-uri: 3.1.0
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
       - bufferutil
@@ -12690,7 +12713,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.2.16(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0))
+      react-doctor: 0.4.0(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.23(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0))
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.44(react@19.2.7)
     optionalDependencies:
@@ -13675,6 +13698,23 @@ snapshots:
       '@vitest/ui': 4.1.8(vitest@4.1.8)
     transitivePeerDependencies:
       - msw
+
+  vscode-jsonrpc@8.2.0: {}
+
+  vscode-languageserver-protocol@3.17.5:
+    dependencies:
+      vscode-jsonrpc: 8.2.0
+      vscode-languageserver-types: 3.17.5
+
+  vscode-languageserver-textdocument@1.0.12: {}
+
+  vscode-languageserver-types@3.17.5: {}
+
+  vscode-languageserver@9.0.1:
+    dependencies:
+      vscode-languageserver-protocol: 3.17.5
+
+  vscode-uri@3.1.0: {}
 
   walk-up-path@4.0.0: {}
 


### PR DESCRIPTION
## 概要

ブログ記事のOGP画像を「タイトルのみ」のデザインから、記事内の代表コードブロックをエディタ風パネルで表示するデザインに拡張する。

記事のコードブロックに `// [!og]` マーカーを1行書くと、そのコードがOGP画像の右側にシンタックスハイライト付きで表示される。マーカーのない記事は従来のテキストのみのデザインにフォールバックする。

## 動機

技術記事のOGPとしてコードが見えると「技術記事である」ことがタイムライン上で一目で伝わり、差別化になる。コードは縮小時には読ませる情報ではなくテクスチャとして機能させ、タイトルを主役のまま維持するレイアウトにした。

## 詳細

- **`@repo/code-highlight`**
  - 注釈パーサーに `[!og]` ディレクティブを追加。記事レンダリングではマーカー行が除去されるだけで表示に影響しない
  - `tokenize.ts` を新設し、rehypeを介さずShikiトークンを取得する `highlightCode` を公開（テーマは記事本文と同じ `plastic`）。shikiをdependenciesへ移動
- **`features/blog`**
  - `getBlogOgCode(slug)`: MDXから `[!og]` 付きコードブロックを先勝ちで抽出（注釈行はすべて除去）。`'use cache'` + `cacheLife('max')`
- **OGコンポーネント**
  - `OgCodeImage`: 左カラムにタイトル＋ブランド、右に信号機ドット・言語ラベル付きのダークパネルを置く2カラムレイアウト
  - コードのフォントサイズは行数・最長行から自動計算（11〜20px）、タイトルも文字量から自動縮小（42〜28px）
  - サイト背景と同じクラゲの足をカード左下に流す（3本構成）
- **フォント**
  - 取得処理を `getGoogleFont` に汎用化し、コード用に JetBrains Mono を追加。サブセットは文字の重複排除で縮小
- **全記事への配線**
  - 全73記事の `opengraph-image.tsx` を `getBlogOgCode` 対応に機械変換で統一。マーカーなし記事の出力画像は不変
  - 試適用として `typescript-satisfies-narrowing` にマーカーを付与

## 気をつけるポイント

- Satori(yoga)では左カラムに `flexBasis: 0` + `minWidth: 0` がないと、タイトルのmax-content幅で右パネルがカード外へ押し出される（コードにコメントあり）
- クラゲの足のパスデータは `global-layout/Background` からの複製（shared → app の逆方向importを避けるため）。共通化する場合はパスデータをsharedへ切り出す整理が別途必要
- 72ファイルの一括変更はスラッグ＝フォルダ名の検証付きスクリプトで実施。`[!og]` がない限り生成画像は1pxも変わらない

## 影響範囲

- ブログ記事のOGP画像生成のみ。記事本文のレンダリングには影響しない
- ブログ以外のページのOGP画像は不変

## テスト

- lint / type-check / 全テスト green（`[!og]` のパーサーテストを追加）
- スタンドアロンharnessとdev serverの両方で実画像を確認（通常タイトル・長タイトル・タイムライン縮小サイズ）