### PR TITLE
test: github-contribution-graphのStoryデータを固定基準日で決定的に生成

### DIFF
--- a/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.stories.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.stories.tsx
@@ -1,3 +1,4 @@
+import { formatDate } from '@repo/helpers/date/format';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
 import { expect, within } from 'storybook/test';
 
@@ -53,9 +54,9 @@ export const Empty: Story = {
 
 function generateMockContributions(highActivity = false, empty = false) {
   const days: Array<{ date: string; count: number }> = [];
-  const today = new Date();
-  const startDate = new Date(today);
-  startDate.setDate(today.getDate() - 13);
+  // args はモジュール評価時に実行され mockingDate の fake clock が効かないため、
+  // preview.tsx の mockingDate(2023-01-02) に合わせた固定基準日を使う
+  const startDate = new Date(2022, 11, 20);
 
   for (let i = 0; i <= 13; i++) {
     const date = new Date(startDate);
@@ -75,10 +76,7 @@ function generateMockContributions(highActivity = false, empty = false) {
     // VRTのためStoryのデータは決定的に生成する（乱数を使わない）
     const count = (i * 7) % (maxContributions + 1);
 
-    const dateString = date.toISOString().split('T')[0];
-    if (dateString !== undefined) {
-      days.push({ date: dateString, count });
-    }
+    days.push({ date: formatDate(date, 'yyyy-MM-dd'), count });
   }
 
   return days;


### PR DESCRIPTION
## 変更内容

`github-contribution-graph.stories.tsx` のモックデータ生成を、実行時の現在日時（`new Date()`）依存から固定基準日ベースに変更しました。

- 基準日を `new Date(2022, 11, 20)` に固定（14日間ウィンドウの終端が `preview.tsx` の `mockingDate`（2023-01-02）に揃う）
- 日付文字列の生成を `toISOString()`（UTC）から `formatDate(date, 'yyyy-MM-dd')`（ローカル）に変更

## なぜ

このStoryはVRTがflakyでした。原因は2つ:

1. **mock-dateアドオンのfake clockとのレース**: `storybook-addon-mock-date` は decorator（レンダリング時）に `Date` を差し替えますが、`args` 内の `generateMockContributions()` はモジュール評価時に実行されます。fake clockは一度installされるとuninstallされないため、テストの実行順次第で実日付/モック日付のどちらが使われるか変わり、同一コミットでもスクリーンショットが揺れます。
2. **日次ドリフト**: 実日付が使われた場合、X軸ラベル（M/d）が毎日変わるうえ、14日間ウィンドウ内の土日位置がずれて `maxContributions` の割り当て＝棒の高さが変化し、mainのVRTベースラインと確実に差分が出ます。

また、`isWeekend` 判定（ローカルの `getDay()`）と出力文字列（`toISOString()` = UTC）のタイムゾーン不整合も解消しています（JSTでは午前9時前の実行で日付文字列が1日ずれていた）。

## レビュアー向けメモ

- **このPRのVRTは5 Storyすべてで差分が出ます**（X軸ラベルが実日付 → 12/20〜1/2固定に変わるため）。意図した変更なので、マージ時に新ベースラインとして承認してください。以降は安定します。
- 調査中に別の既存問題を発見: Vitest実行時に `storybook-addon-mock-date` 自体が「Could not resolve addon」でスキップされ、`mockingDate` がテスト中効いていません（mainでも再現）。本修正はアドオンに依存しない形なので、その問題とは独立に安定します。アドオン側の修正は別途対応予定です。

## 検証

- `pnpm run type-check`: 成功
- `pnpm run check`: エラー0
- `pnpm -F main run test --project=storybook <対象ファイル>`: 5 Story すべてパス