### PR TITLE
feat: コントラストチェッカーにAPCA対応を追加

### DIFF
--- a/apps/main/src/app/contrast-checker/_components/apca-result-table/apca-result-table.stories.tsx
+++ b/apps/main/src/app/contrast-checker/_components/apca-result-table/apca-result-table.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { ApcaResultTable } from './apca-result-table';
+
+const meta: Meta<typeof ApcaResultTable> = {
+  title: 'app/contrast-checker/apca-result-table',
+  component: ApcaResultTable,
+};
+
+export default meta;
+type Story = StoryObj<typeof ApcaResultTable>;
+
+export const AllValid: Story = {
+  args: {
+    lc: 100,
+  },
+};
+
+export const PartiallyValid: Story = {
+  args: {
+    lc: 63,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // Lc 63はLc 60/45/30/15を満たし、Lc 90/75を満たさない
+    // モバイル表示とデスクトップ表示の両方がDOMに存在するため2倍になる
+    await expect(canvas.getAllByText('OK')).toHaveLength(8);
+    await expect(canvas.getAllByText('NG')).toHaveLength(4);
+  },
+};
+
+export const AllInvalid: Story = {
+  args: {
+    lc: 10,
+  },
+};
+
+export const NegativeLc: Story = {
+  args: {
+    lc: -80,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // 負のLc値は絶対値で判定されるため、Lc -80はLc 75以下の基準を満たす
+    await expect(canvas.getAllByText('OK')).toHaveLength(10);
+    await expect(canvas.getAllByText('NG')).toHaveLength(2);
+  },
+};

--- a/apps/main/src/app/contrast-checker/_components/apca-result-table/apca-result-table.tsx
+++ b/apps/main/src/app/contrast-checker/_components/apca-result-table/apca-result-table.tsx
@@ -1,0 +1,107 @@
+import { AlertIcon } from '@k8o/arte-odyssey';
+import type { FC } from 'react';
+
+type Props = {
+  lc: number;
+};
+
+const APCA_LEVELS = [
+  {
+    threshold: 90,
+    usage: '本文テキスト（推奨）',
+    example: '長文の本文や14px程度の小さな文字',
+  },
+  {
+    threshold: 75,
+    usage: '本文テキストの最低基準',
+    example: '18px程度の本文',
+  },
+  {
+    threshold: 60,
+    usage: '本文以外のテキストの最低基準',
+    example: '24px程度の大きめのテキストや16pxの太字',
+  },
+  {
+    threshold: 45,
+    usage: '大きなテキストの最低基準',
+    example: '36px以上の見出しや24px程度の太字',
+  },
+  {
+    threshold: 30,
+    usage: 'あらゆるテキストの下限',
+    example: 'プレースホルダーや無効状態の文字を含む',
+  },
+  {
+    threshold: 15,
+    usage: '非テキスト要素の下限',
+    example: 'アイコンや境界線など意味を持つ要素',
+  },
+] as const;
+
+const Status: FC<{ isInvalid: boolean }> = ({ isInvalid }) =>
+  isInvalid ? (
+    <div className="text-fg-error flex items-center justify-center gap-1">
+      <AlertIcon size="sm" status="error" />
+      <span className="font-bold">NG</span>
+    </div>
+  ) : (
+    <div className="text-fg-success flex items-center justify-center gap-1">
+      <AlertIcon size="sm" status="success" />
+      <span className="font-bold">OK</span>
+    </div>
+  );
+
+export const ApcaResultTable: FC<Props> = ({ lc }) => {
+  // APCAのLcは正負で文字と背景の明暗関係を表すため、判定には絶対値を使う
+  const absLc = Math.abs(lc);
+
+  return (
+    <div className="border-border-base bg-bg-base overflow-hidden rounded-xl border">
+      <div className="sm:hidden">
+        {APCA_LEVELS.map((level) => (
+          <div
+            className="border-border-base flex flex-col gap-2 border-b p-4 last:border-b-0"
+            key={level.threshold}
+          >
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm font-bold">Lc {level.threshold}以上</p>
+              <Status isInvalid={absLc < level.threshold} />
+            </div>
+            <p className="text-sm">{level.usage}</p>
+            <p className="text-fg-mute text-xs">{level.example}</p>
+          </div>
+        ))}
+      </div>
+      <table className="hidden w-full sm:table">
+        <thead>
+          <tr className="border-border-base bg-bg-mute md:text-md border-b text-xs font-medium sm:text-sm">
+            <th className="px-3 py-2 sm:px-4 sm:py-3">判定</th>
+            <th className="px-3 py-2 sm:px-4 sm:py-3">基準</th>
+            <th className="px-3 py-2 text-left sm:px-4 sm:py-3">用途</th>
+          </tr>
+        </thead>
+        <tbody>
+          {APCA_LEVELS.map((level) => (
+            <tr
+              className="border-border-base border-b last:border-b-0"
+              key={level.threshold}
+            >
+              <td className="p-2 sm:py-3">
+                <Status isInvalid={absLc < level.threshold} />
+              </td>
+              <td className="px-3 py-2 text-center font-bold whitespace-nowrap sm:px-4 sm:py-3">
+                Lc {level.threshold}以上
+              </td>
+              <td className="px-3 py-2 sm:px-4 sm:py-3">
+                <p className="text-sm md:text-base">{level.usage}</p>
+                <p className="text-fg-mute text-xs md:text-sm">
+                  {level.example}
+                </p>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/apps/main/src/app/contrast-checker/_components/apca-result-table/index.ts
+++ b/apps/main/src/app/contrast-checker/_components/apca-result-table/index.ts
@@ -1,0 +1,1 @@
+export { ApcaResultTable } from './apca-result-table';

--- a/apps/main/src/app/contrast-checker/_components/check-contrast/check-contrast.stories.tsx
+++ b/apps/main/src/app/contrast-checker/_components/check-contrast/check-contrast.stories.tsx
@@ -21,6 +21,9 @@ export const InitialContrast: Story = {
     await expect(
       canvas.getByText('コントラスト比 21.00:1'),
     ).toBeInTheDocument();
+
+    // 初期状態（黒背景に白文字）のAPCA Lc値は-107.9
+    await expect(canvas.getByText('APCA Lc -107.9')).toBeInTheDocument();
   },
 };
 

--- a/apps/main/src/app/contrast-checker/_components/check-contrast/check-contrast.tsx
+++ b/apps/main/src/app/contrast-checker/_components/check-contrast/check-contrast.tsx
@@ -1,9 +1,11 @@
 'use client';
 
-import { Alert } from '@k8o/arte-odyssey';
+import { Alert, Heading } from '@k8o/arte-odyssey';
+import { calcApca } from '@repo/helpers/color/calc-apca';
 import { calcContrast } from '@repo/helpers/color/calc-contrast';
 import { type FC, useState } from 'react';
 
+import { ApcaResultTable } from '../apca-result-table';
 import { ColorPallet } from '../color-pallet';
 import { ResultTable } from '../result-table';
 
@@ -11,6 +13,7 @@ export const CheckContrast: FC = () => {
   const [baseColor, setBaseColor] = useState('#000000');
   const [compareColor, setCompareColor] = useState('#ffffff');
   const contrast = calcContrast(baseColor, compareColor);
+  const apcaLc = calcApca(compareColor, baseColor);
 
   const WCAG_THRESHOLDS = {
     AA_LARGE_TEXT: 3,
@@ -41,9 +44,14 @@ export const CheckContrast: FC = () => {
           setColor={setCompareColor}
         />
       </div>
-      <p className="text-center text-sm font-medium sm:text-base">
-        コントラスト比 {contrast.toFixed(2)}:1
-      </p>
+      <div className="flex flex-col items-center justify-center gap-1 sm:flex-row sm:gap-6">
+        <p className="text-center text-sm font-medium sm:text-base">
+          コントラスト比 {contrast.toFixed(2)}:1
+        </p>
+        <p className="text-center text-sm font-medium sm:text-base">
+          APCA Lc {apcaLc.toFixed(1)}
+        </p>
+      </div>
       {contrast < WCAG_THRESHOLDS.LOW_VISIBILITY_WARNING && (
         <Alert
           message="コントラスト比が非常に低いため、テキストが見えにくい場合があります"
@@ -65,14 +73,21 @@ export const CheckContrast: FC = () => {
           この文字と背景色の組み合わせを確認できます
         </p>
       </section>
-      <ResultTable
-        baseColor={baseColor}
-        compareColor={compareColor}
-        isInvalidAaaLargeText={isInvalidAaaLargeText}
-        isInvalidAaaNormalText={isInvalidAaaNormalText}
-        isInvalidAaLargeText={isInvalidAaLargeText}
-        isInvalidAaNormalText={isInvalidAaNormalText}
-      />
+      <section className="flex flex-col gap-3">
+        <Heading type="h3">WCAG 2.2による判定</Heading>
+        <ResultTable
+          baseColor={baseColor}
+          compareColor={compareColor}
+          isInvalidAaaLargeText={isInvalidAaaLargeText}
+          isInvalidAaaNormalText={isInvalidAaaNormalText}
+          isInvalidAaLargeText={isInvalidAaLargeText}
+          isInvalidAaNormalText={isInvalidAaNormalText}
+        />
+      </section>
+      <section className="flex flex-col gap-3">
+        <Heading type="h3">APCAによる判定</Heading>
+        <ApcaResultTable lc={apcaLc} />
+      </section>
     </div>
   );
 };

--- a/apps/main/src/app/contrast-checker/_components/description/description.tsx
+++ b/apps/main/src/app/contrast-checker/_components/description/description.tsx
@@ -3,27 +3,47 @@ import type { FC } from 'react';
 
 export const Description: FC = () => (
   <div className="bg-bg-mute w-full rounded-xl p-4">
-    <div className="flex flex-col gap-3">
-      <p className="text-lg font-bold md:text-xl">
-        <Anchor href="https://www.w3.org/TR/WCAG22/">WCAG 2.2</Anchor>
-        によるコントラスト比の基準
-      </p>
-      <div className="flex flex-col gap-2">
-        <div className="flex flex-col gap-1">
-          <p className="text-md font-bold md:text-lg">AA基準</p>
-          <p className="md:text-md text-sm">
-            文字のコントラスト比が最低でも4.5:1、大文字の場合は3:1
-          </p>
-        </div>
-        <div className="flex flex-col gap-1">
-          <p className="text-md font-bold md:text-lg">AAA基準</p>
-          <p className="md:text-md text-sm">
-            文字のコントラスト比が最低でも7:1、大文字の場合は4.5:1
-          </p>
-        </div>
-        <p className="text-fg-mute self-end text-xs md:text-sm">
-          大文字とは18pt（24px）以上、太字の場合は14pt（18.66px）以上を指します。
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-3">
+        <p className="text-lg font-bold md:text-xl">
+          <Anchor href="https://www.w3.org/TR/WCAG22/">WCAG 2.2</Anchor>
+          によるコントラスト比の基準
         </p>
+        <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-1">
+            <p className="text-md font-bold md:text-lg">AA基準</p>
+            <p className="md:text-md text-sm">
+              文字のコントラスト比が最低でも4.5:1、大文字の場合は3:1
+            </p>
+          </div>
+          <div className="flex flex-col gap-1">
+            <p className="text-md font-bold md:text-lg">AAA基準</p>
+            <p className="md:text-md text-sm">
+              文字のコントラスト比が最低でも7:1、大文字の場合は4.5:1
+            </p>
+          </div>
+          <p className="text-fg-mute self-end text-xs md:text-sm">
+            大文字とは18pt（24px）以上、太字の場合は14pt（18.66px）以上を指します。
+          </p>
+        </div>
+      </div>
+      <div className="flex flex-col gap-3">
+        <p className="text-lg font-bold md:text-xl">
+          <Anchor href="https://git.apcacontrast.com/">APCA</Anchor>
+          によるコントラストの基準
+        </p>
+        <div className="flex flex-col gap-2">
+          <p className="md:text-md text-sm">
+            APCA（Accessible Perceptual Contrast Algorithm）は、WCAG
+            3で検討されている人間の知覚に基づくコントラスト指標です。
+            コントラストの強さをLc値（0〜±108程度）で表し、正の値は明るい背景に暗い文字、負の値は暗い背景に明るい文字を意味します。
+            判定にはLc値の絶対値を使い、本文テキストはLc
+            75以上、見出しなど大きなテキストはLc 45以上が目安です。
+          </p>
+          <p className="text-fg-mute self-end text-xs md:text-sm">
+            APCAは策定中の指標のため、基準値は今後変わる可能性があります。
+          </p>
+        </div>
       </div>
     </div>
   </div>

--- a/apps/main/src/app/contrast-checker/layout.tsx
+++ b/apps/main/src/app/contrast-checker/layout.tsx
@@ -3,10 +3,12 @@ import type { Metadata } from 'next';
 
 export const metadata = {
   title: 'コントラストチェッカー',
-  description: '2色のコントラスト比を計算し、WCAGの基準で評価します。',
+  description:
+    '2色のコントラスト比とAPCAのLc値を計算し、WCAGの基準で評価します。',
   openGraph: {
     title: 'コントラストチェッカー',
-    description: '2色のコントラスト比を計算し、WCAGの基準で評価します。',
+    description:
+      '2色のコントラスト比とAPCAのLc値を計算し、WCAGの基準で評価します。',
     url: 'https://k8o.me/contrast-checker',
     siteName: 'k8o',
     locale: 'ja',
@@ -15,7 +17,8 @@ export const metadata = {
   twitter: {
     title: 'コントラストチェッカー',
     card: 'summary',
-    description: '2色のコントラスト比を計算し、WCAGの基準で評価します。',
+    description:
+      '2色のコントラスト比とAPCAのLc値を計算し、WCAGの基準で評価します。',
   },
 } satisfies Metadata;
 

--- a/apps/main/src/app/page.tsx
+++ b/apps/main/src/app/page.tsx
@@ -128,7 +128,7 @@ export default function Home() {
               title="もじカウント"
             />
             <AppCard
-              description="2色のコントラスト比を計算し、WCAGの基準で評価します。"
+              description="2色のコントラスト比とAPCAのLc値を計算し、WCAGの基準で評価します。"
               link="/contrast-checker"
               title="コントラストチェッカー"
             />

--- a/apps/main/src/shared/site/page-metadata.ts
+++ b/apps/main/src/shared/site/page-metadata.ts
@@ -22,7 +22,8 @@ export const pageMetadata = {
   },
   contrastChecker: {
     title: 'コントラストチェッカー',
-    description: '2色のコントラスト比を計算し、WCAGの基準で評価します。',
+    description:
+      '2色のコントラスト比とAPCAのLc値を計算し、WCAGの基準で評価します。',
   },
   mojiCount: {
     title: 'もじカウント',

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -21,6 +21,10 @@
       "types": "./src/cn.ts",
       "default": "./src/cn.ts"
     },
+    "./color/calc-apca": {
+      "types": "./src/color/calc-apca.ts",
+      "default": "./src/color/calc-apca.ts"
+    },
     "./color/calc-contrast": {
       "types": "./src/color/calc-contrast.ts",
       "default": "./src/color/calc-contrast.ts"

--- a/packages/helpers/src/color/calc-apca.ts
+++ b/packages/helpers/src/color/calc-apca.ts
@@ -1,0 +1,160 @@
+type Rgb = [number, number, number];
+
+const validHexColorRegex = /^#[0-9A-Fa-f]{6}$/u;
+
+const isValidHexColor = (hex: string): boolean => validHexColorRegex.test(hex);
+
+const convertHexToRgb = (hex: string): Rgb => {
+  if (!isValidHexColor(hex)) {
+    throw new Error(
+      `Invalid hex color format: ${hex}. Expected format: #RRGGBB`,
+    );
+  }
+
+  const r = Number.parseInt(hex.slice(1, 3), 16);
+  const g = Number.parseInt(hex.slice(3, 5), 16);
+  const b = Number.parseInt(hex.slice(5, 7), 16);
+  return [r, g, b];
+};
+
+// APCA-W3 0.0.98G-4g の定数
+// https://github.com/Myndex/apca-w3
+const SA98G = {
+  mainTrc: 2.4,
+  sRco: 0.212_672_9,
+  sGco: 0.715_152_2,
+  sBco: 0.072_175,
+  normBg: 0.56,
+  normText: 0.57,
+  revText: 0.62,
+  revBg: 0.65,
+  blkThrs: 0.022,
+  // APCA仕様の定数はちょうど1.414であり、Math.SQRT2（1.41421356...）ではない
+  // oxlint-disable-next-line oxc/approx-constant
+  blkClmp: 1.414,
+  scaleBoW: 1.14,
+  scaleWoB: 1.14,
+  loBoWOffset: 0.027,
+  loWoBOffset: 0.027,
+  loClip: 0.1,
+  deltaYMin: 0.0005,
+} as const;
+
+const calcScreenLuminance = (rgbColor: Rgb): number => {
+  const [r, g, b] = rgbColor;
+  return (
+    SA98G.sRco * (r / 255) ** SA98G.mainTrc +
+    SA98G.sGco * (g / 255) ** SA98G.mainTrc +
+    SA98G.sBco * (b / 255) ** SA98G.mainTrc
+  );
+};
+
+// 黒に近い輝度を知覚に合わせて持ち上げるソフトクランプ
+const clampBlackLevel = (y: number): number =>
+  y > SA98G.blkThrs ? y : y + (SA98G.blkThrs - y) ** SA98G.blkClmp;
+
+/**
+ * APCA（Accessible Perceptual Contrast Algorithm）のLc値を計算する。
+ * 正の値は明るい背景に暗い文字、負の値は暗い背景に明るい文字を表す。
+ * 基準との比較には絶対値を使う。
+ */
+export const calcApca = (
+  textColor: string,
+  backgroundColor: string,
+): number => {
+  const textY = clampBlackLevel(
+    calcScreenLuminance(convertHexToRgb(textColor)),
+  );
+  const bgY = clampBlackLevel(
+    calcScreenLuminance(convertHexToRgb(backgroundColor)),
+  );
+
+  if (Math.abs(bgY - textY) < SA98G.deltaYMin) {
+    return 0;
+  }
+
+  if (bgY > textY) {
+    // 明るい背景に暗い文字（正のLc）
+    const sapc =
+      (bgY ** SA98G.normBg - textY ** SA98G.normText) * SA98G.scaleBoW;
+    return sapc < SA98G.loClip ? 0 : (sapc - SA98G.loBoWOffset) * 100;
+  }
+
+  // 暗い背景に明るい文字（負のLc）
+  const sapc = (bgY ** SA98G.revBg - textY ** SA98G.revText) * SA98G.scaleWoB;
+  return sapc > -SA98G.loClip ? 0 : (sapc + SA98G.loWoBOffset) * 100;
+};
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  describe('calcApca', () => {
+    describe('正常な入力の場合', () => {
+      // 期待値はapca-w3 0.0.98G-4gのリファレンス値
+      it('明るい背景に暗い文字の場合は正のLc値を返すべき', () => {
+        expect(calcApca('#888888', '#ffffff')).toBeCloseTo(
+          63.056_469_930_209_42,
+          10,
+        );
+        expect(calcApca('#000000', '#aaaaaa')).toBeCloseTo(
+          58.146_262_578_561_33,
+          10,
+        );
+        expect(calcApca('#112233', '#ddeeff')).toBeCloseTo(
+          91.668_308_114_816_31,
+          10,
+        );
+      });
+
+      it('暗い背景に明るい文字の場合は負のLc値を返すべき', () => {
+        expect(calcApca('#ffffff', '#888888')).toBeCloseTo(
+          -68.541_464_366_449_62,
+          10,
+        );
+        expect(calcApca('#aaaaaa', '#000000')).toBeCloseTo(
+          -56.241_133_368_397_42,
+          10,
+        );
+        expect(calcApca('#ddeeff', '#112233')).toBeCloseTo(
+          -93.067_700_494_842_75,
+          10,
+        );
+      });
+
+      it('同じ色の場合は0を返すべき', () => {
+        expect(calcApca('#000000', '#000000')).toBe(0);
+        expect(calcApca('#ffffff', '#ffffff')).toBe(0);
+        expect(calcApca('#888888', '#888888')).toBe(0);
+      });
+    });
+
+    describe('エッジケース', () => {
+      it('コントラストが非常に低い場合は0にクリップされるべき', () => {
+        expect(calcApca('#112233', '#444444')).toBeCloseTo(
+          8.323_261_369_573_93,
+          10,
+        );
+        expect(calcApca('#444444', '#112233')).toBeCloseTo(
+          -7.526_878_460_278_154,
+          10,
+        );
+        // loClip未満はスケーリング前に0へ丸められる
+        expect(calcApca('#fefefe', '#ffffff')).toBe(0);
+      });
+    });
+
+    describe('異常な入力の場合', () => {
+      it('無効なhex形式の場合はエラーを投げるべき', () => {
+        expect(() => calcApca('invalid', '#ffffff')).toThrow(
+          'Invalid hex color format',
+        );
+        expect(() => calcApca('#000000', 'invalid')).toThrow(
+          'Invalid hex color format',
+        );
+        expect(() => calcApca('#000', '#ffffff')).toThrow(
+          'Invalid hex color format',
+        );
+      });
+    });
+  });
+}


### PR DESCRIPTION
## 概要

コントラストチェッカーで、WCAG 2.xのコントラスト比に加えてAPCA（Accessible Perceptual Contrast Algorithm）のLc値を計算・判定できるようにする。

## 変更内容

### @repo/helpers
- `color/calc-apca` を追加。[apca-w3](https://github.com/Myndex/apca-w3) 0.0.98G-4g のアルゴリズム（推定輝度→黒レベルソフトクランプ→極性別べき乗カーブ→低コントラストクリップ）を実装
- in-sourceテストでapca-w3公開のリファレンス値8ペアと小数10桁まで一致することを検証

### apps/main（contrast-checker）
- コントラスト比の横にAPCAのLc値を表示
- Lc 90 / 75 / 60 / 45 / 30 / 15 の6段階判定テーブル（`ApcaResultTable`）を追加。負のLcは絶対値で判定
- 既存のWCAGテーブルと区別するため「WCAG 2.2による判定」「APCAによる判定」の見出しを追加
- 説明文にAPCAの解説（Lc値の読み方・極性・策定中である旨の注記）を追加
- ページ説明文（layout / page-metadata / トップのAppCard）を更新

## レビュー時の補足

- `calc-apca.ts` の定数 `1.414` はOXCに `Math.SQRT2` の近似と誤検知されるため、その行のみ `oxc/approx-constant` を無効化している（APCA仕様上ちょうど1.414）
- 判定しきい値は [APCA easy intro](https://git.apcacontrast.com/documentation/APCAeasyIntro) のGeneral Guidelinesに基づく簡易6段階。厳密なフォントサイズ×ウェイトのルックアップテーブルは採用していない
- APCAは策定中の指標のため、将来基準値が変わる可能性がある（UI上にも注記済み）

## テスト

- `pnpm run test`: 全274件パス（calc-apca 5件、apca-result-tableストーリー4件、check-contrastストーリーのLc値アサーション追加を含む）
- `pnpm run check` / `type-check` / `ls-lint`: パス