### PR TITLE
fix: OGフォント取得をuse cache化しprerenderのhanging promiseを解消

### DIFF
--- a/apps/main/src/shared/og/get-google-font.ts
+++ b/apps/main/src/shared/og/get-google-font.ts
@@ -1,5 +1,4 @@
-const cssCache = new Map<string, Promise<string>>();
-const fontCache = new Map<string, Promise<ArrayBuffer>>();
+import { cacheLife } from 'next/cache';
 
 type GoogleFontParams = {
   family: string;
@@ -12,28 +11,6 @@ function buildCssUrl({ family, weight, text }: GoogleFontParams): string {
   // 同じグリフ集合でキャッシュが効くよう、文字を重複排除・ソートしてサブセット化する
   const subset = [...new Set(text)].toSorted().join('');
   return `https://fonts.googleapis.com/css2?family=${familyParam}&display=swap&text=${encodeURIComponent(subset)}`;
-}
-
-function fetchGoogleFontsCss(url: string): Promise<string> {
-  const cachedCss = cssCache.get(url);
-  if (cachedCss) {
-    return cachedCss;
-  }
-
-  const cssPromise = fetch(url)
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error(`Failed to fetch Google Fonts CSS: ${response.status}`);
-      }
-      return response.text();
-    })
-    .catch((error: unknown) => {
-      cssCache.delete(url);
-      throw error;
-    });
-
-  cssCache.set(url, cssPromise);
-  return cssPromise;
 }
 
 function extractFontUrl(css: string): string {
@@ -49,27 +26,24 @@ function extractFontUrl(css: string): string {
   return match[1];
 }
 
-export function getGoogleFont(params: GoogleFontParams): Promise<ArrayBuffer> {
-  const cacheKey = buildCssUrl(params);
-  const cachedFont = fontCache.get(cacheKey);
-  if (cachedFont) {
-    return cachedFont;
+// cacheComponents 下では未キャッシュの fetch を static prerender で行うと、
+// プリレンダー完了時に未解決の promise が HANGING_PROMISE_REJECTION で弾かれる。
+// 'use cache' でフォント取得をキャッシュ境界に閉じ込め、ビルドを決定的にする。
+export async function getGoogleFont(
+  params: GoogleFontParams,
+): Promise<ArrayBuffer> {
+  'use cache';
+  cacheLife('max');
+
+  const cssResponse = await fetch(buildCssUrl(params));
+  if (!cssResponse.ok) {
+    throw new Error(`Failed to fetch Google Fonts CSS: ${cssResponse.status}`);
   }
 
-  const fontPromise = fetchGoogleFontsCss(cacheKey)
-    .then(extractFontUrl)
-    .then((fontUrl) => fetch(fontUrl))
-    .then((response) => {
-      if (!response.ok) {
-        throw new Error(`Failed to fetch font file: ${response.status}`);
-      }
-      return response.arrayBuffer();
-    })
-    .catch((error: unknown) => {
-      fontCache.delete(cacheKey);
-      throw error;
-    });
+  const fontResponse = await fetch(extractFontUrl(await cssResponse.text()));
+  if (!fontResponse.ok) {
+    throw new Error(`Failed to fetch font file: ${fontResponse.status}`);
+  }
 
-  fontCache.set(cacheKey, fontPromise);
-  return fontPromise;
+  return fontResponse.arrayBuffer();
 }


### PR DESCRIPTION
## 問題

OG画像の static prerender 時に、フォント取得の `fetch()`（`get-google-font.ts`）が **未キャッシュ**のまま走っていた。`cacheComponents` 有効下では、プリレンダー完了時に未解決の promise が `HANGING_PROMISE_REJECTION` で弾かれ、ビルドが**間欠的に失敗**していた（落ちる記事OGルートは実行ごとに変化＝flaky。本番 main デプロイも踏んでいた）。

```
Error: During prerendering, fetch() rejects when the prerender is complete...
  at src/shared/og/get-google-font.ts:23  const cssPromise = fetch(url)
  route: '/blog/.../opengraph-image-...'
  digest: 'HANGING_PROMISE_REJECTION'
```

blog データ取得（`getBlogContent` 等）は既に `'use cache'` 済みだったが、フォント取得だけが未キャッシュだった。加えてモジュールレベルの promise キャッシュ（`Map<string, Promise>`）が in-flight な fetch promise を render 境界をまたいで保持しており、これが hanging の直接要因になっていた。

## 修正

`getGoogleFont` を、アプリ内の他データ取得と同じく `'use cache'` + `cacheLife('max')` のキャッシュ境界に閉じ込める。これによりフォント取得が prerender 中の「未キャッシュ fetch」ではなく、ビルド時に解決・キャッシュされる正規のデータ取得になり、hanging promise が発生しない。あわせてモジュールレベルの promise Map を撤去（`'use cache'` がキャッシュ・重複排除を担う）。フォントは静的データのため `max`。

## 検証

- `pnpm check`（lint/format）・`pnpm type-check` グリーン
- ローカルで `next build` は OG 経路まで正常コンパイル（OG経路の未キャッシュ fetch は本ファイルの2箇所のみで、いずれもキャッシュ境界に内包）。フルビルドの最終段（全289ページの static 生成）は実 DB env を要するため、**最終確認はこの PR の Vercel プレビュービルド**（実 env）で行う
- 参考: `get-icon-data-url` / `get-jellyfish-legs-data-url` は同期のデータURL生成でネットワーク fetch なし