### PR TITLE
fix: カラーコード職人のOKLCHスライダーの不具合を修正

### DIFF
--- a/apps/main/src/app/color-converter/_components/color-converter/channel-sliders.tsx
+++ b/apps/main/src/app/color-converter/_components/color-converter/channel-sliders.tsx
@@ -4,6 +4,7 @@ import { NumberField, Slider, Tabs } from '@k8o/arte-odyssey';
 import { toSrgbGamut } from '@repo/helpers/color/gamut';
 import {
   type Color,
+  type Oklch,
   clamp,
   colorToHsl,
   colorToOklch,
@@ -12,12 +13,17 @@ import {
   oklchToColor,
   rgb255ToColor,
 } from '@repo/helpers/color/spaces';
-import { type FC, useId } from 'react';
+import { type FC, useId, useState } from 'react';
 
 type Props = {
   color: Color;
   onColorChange: (color: Color) => void;
 };
+
+// 編集中の OKLCH 値が、自分でガモットマッピングして生成した色と
+// 一致しているか（= 外部から色が変わっていないか）を RGB で判定する。
+const isSameRgb = (a: Color, b: Color): boolean =>
+  a.r === b.r && a.g === b.g && a.b === b.b;
 
 type Channel = {
   label: string;
@@ -83,7 +89,24 @@ const ChannelGroup: FC<{ channels: Channel[] }> = ({ channels }) => (
 export const ChannelSliders: FC<Props> = ({ color, onColorChange }) => {
   const rgb = colorToRgb255(color);
   const hsl = colorToHsl(color);
-  const oklch = colorToOklch(color);
+
+  // OKLCH はガモットマッピングで C/H が縮むため、RGB から逆算すると
+  // L だけ動かしたつもりでも C/H が勝手に変わってしまう。ユーザーが
+  // 入力した OKLCH の意図値を編集中だけ保持し、外部から色が変わった
+  // ときのみ RGB から再計算する。
+  const [oklchEdit, setOklchEdit] = useState<{
+    oklch: Oklch;
+    color: Color;
+  } | null>(null);
+  const oklch =
+    oklchEdit && isSameRgb(oklchEdit.color, color)
+      ? oklchEdit.oklch
+      : colorToOklch(color);
+  const changeOklch = (next: Oklch): void => {
+    const mapped = toSrgbGamut(oklchToColor(next, color.alpha));
+    setOklchEdit({ oklch: next, color: mapped });
+    onColorChange(mapped);
+  };
 
   const alphaChannel: Channel = {
     label: 'A',
@@ -180,7 +203,7 @@ export const ChannelSliders: FC<Props> = ({ color, onColorChange }) => {
       precision: 3,
       value: oklch.l,
       onChange: (l) => {
-        onColorChange(toSrgbGamut(oklchToColor({ ...oklch, l }, color.alpha)));
+        changeOklch({ ...oklch, l });
       },
     },
     {
@@ -191,7 +214,7 @@ export const ChannelSliders: FC<Props> = ({ color, onColorChange }) => {
       precision: 3,
       value: oklch.c,
       onChange: (c) => {
-        onColorChange(toSrgbGamut(oklchToColor({ ...oklch, c }, color.alpha)));
+        changeOklch({ ...oklch, c });
       },
     },
     {
@@ -202,7 +225,7 @@ export const ChannelSliders: FC<Props> = ({ color, onColorChange }) => {
       precision: 1,
       value: oklch.h,
       onChange: (h) => {
-        onColorChange(toSrgbGamut(oklchToColor({ ...oklch, h }, color.alpha)));
+        changeOklch({ ...oklch, h });
       },
     },
     alphaChannel,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@k8o/arte-odyssey':
-      specifier: 10.1.1
-      version: 10.1.1
+      specifier: 10.1.2
+      version: 10.1.2
     '@storybook/addon-a11y':
       specifier: 10.4.2
       version: 10.4.2
@@ -142,7 +142,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -239,7 +239,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
       '@mdx-js/loader':
         specifier: 3.1.1
         version: 3.1.1
@@ -1942,11 +1942,12 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@k8o/arte-odyssey@10.1.1':
-    resolution: {integrity: sha512-7CSStKtaqE1V6XuLWumFmsEOwTWZer9yEM8DwWr4Ec9PdsE0OGWKUF11xR4xwG2bUNOb8z8Okv+QS8878hoifg==}
+  '@k8o/arte-odyssey@10.1.2':
+    resolution: {integrity: sha512-iy9UsjNGV/yUKTz5HsUgKLJFsvG5adFuI5Hktv7gfUBlR+ek9HWEaIhz9o5mXgnvp8FWXZTBwG8V1M94S/G9gA==}
     peerDependencies:
       '@json-render/core': '>=0.19.0'
       '@json-render/react': '>=0.19.0'
+      '@openuidev/lang-core': '>=0.2.5'
       '@openuidev/react-lang': '>=0.2.6'
       '@types/react': '>=19.0.0'
       '@types/react-dom': '>=19.0.0'
@@ -1959,6 +1960,8 @@ packages:
       '@json-render/core':
         optional: true
       '@json-render/react':
+        optional: true
+      '@openuidev/lang-core':
         optional: true
       '@openuidev/react-lang':
         optional: true
@@ -8385,7 +8388,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@k8o/arte-odyssey@10.1.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)':
+  '@k8o/arte-odyssey@10.1.2(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react': 19.2.17
@@ -10019,7 +10022,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 24.12.4
+      '@types/node': 24.13.1
 
   '@typescript-eslint/types@8.60.0': {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,7 +15,7 @@ allowBuilds:
 blockExoticSubdeps: true
 
 catalog:
-  '@k8o/arte-odyssey': 10.1.1
+  '@k8o/arte-odyssey': 10.1.2
   '@storybook/addon-a11y': 10.4.2
   '@storybook/addon-docs': 10.4.2
   '@storybook/addon-mcp': '0.6.0'


### PR DESCRIPTION
## 概要

カラーコード職人（color-converter）の OKLCH スライダーの不具合を 2 点修正する。

## 1. L を編集すると C/H が勝手に動く（`channel-sliders.tsx`）

OKLCH の値を毎レンダー RGB から逆算していたため、L を動かす→ガモットマッピングで C が縮む→逆算した C が変わる、という連鎖で「L しか触っていないのに C/H が動く」状態だった（C が 0 付近まで潰れると H も 0 に飛ぶ）。

ユーザーが入力した OKLCH の意図値を編集中だけ保持し、外部から色が変わったときのみ RGB から再計算するように修正（oklch.com など実用ピッカーと同じ挙動）。canonical は RGB のまま維持。

## 2. C スライダーの塗りがつまみとズレる（`@k8o/arte-odyssey` 10.1.2）

共有 `Slider` コンポーネントの `range = Math.max(max - min, 1)` が、スパン < 1 のスライダー（OKLCH の C は 0〜0.4）で range を 1 に丸め、塗り(fill)とネイティブのつまみが 2.5 倍ズレていた。

本体側で修正済み（[arte-odyssey#533](https://github.com/k35o/arte-odyssey/pull/533) → 10.1.2 公開）。本 PR では catalog を 10.1.2 に更新して取り込む。

## 検証

- dev サーバーで OKLCH タブの C スライダーを確認: 塗り 31.27% = つまみ 31.3%（一致）
- `pnpm -F main type-check` pass / arte-odyssey 側 story テスト 4 passed

## 補足

dev 環境用の `portless.json`（appPort）と `.claude/launch.json` は本 PR には含めていない。