### PR TITLE
feat(ui-builder): admin にAIチャットでArteOdysseyのUIを構築するツールを追加

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -18,10 +18,13 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
+    "@json-render/core": "0.19.0",
+    "@json-render/react": "0.19.0",
     "@k8o/arte-odyssey": "catalog:",
     "@repo/database": "workspace:*",
     "@repo/helpers": "workspace:*",
     "@tailwindcss/postcss": "catalog:",
+    "ai": "6.0.197",
     "better-auth": "1.6.14",
     "drizzle-orm": "catalog:",
     "next": "catalog:",

--- a/apps/admin/src/app/(authenticated)/_components/admin-sidebar/nav-items.ts
+++ b/apps/admin/src/app/(authenticated)/_components/admin-sidebar/nav-items.ts
@@ -5,6 +5,7 @@ import {
   SendIcon,
   ShieldCheckIcon,
   SlideIcon,
+  SparklesIcon,
   TableIcon,
   TagIcon,
   ViewIcon,
@@ -46,6 +47,12 @@ export const NAV_GROUPS: NavGroup[] = [
   {
     label: '読み物',
     items: [{ href: '/reading-list', label: 'よんでいるもの', icon: RSSIcon }],
+  },
+  {
+    label: 'ツール',
+    items: [
+      { href: '/ui-builder', label: 'AI UIビルダー', icon: SparklesIcon },
+    ],
   },
   {
     label: '運用',

--- a/apps/admin/src/app/(authenticated)/ui-builder/_components/chat-view/chat-view.stories.tsx
+++ b/apps/admin/src/app/(authenticated)/ui-builder/_components/chat-view/chat-view.stories.tsx
@@ -1,0 +1,95 @@
+import type { ChatMessage } from '@json-render/react';
+import type { ArteSpec } from '@k8o/arte-odyssey/json-render';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, fn, within } from 'storybook/test';
+
+import { ChatView } from './chat-view';
+
+const sampleSpec = {
+  root: 'root',
+  elements: {
+    root: {
+      type: 'Stack',
+      props: { direction: 'column', gap: 'sm' },
+      children: ['title', 'submit'],
+    },
+    title: { type: 'Heading', props: { text: 'ログイン', level: 'h3' } },
+    submit: {
+      type: 'Button',
+      props: { label: 'サインイン', color: 'primary' },
+    },
+  },
+} satisfies ArteSpec;
+
+const conversation: ChatMessage[] = [
+  { id: '1', role: 'user', text: 'ログインフォームを作って', spec: null },
+  {
+    id: '2',
+    role: 'assistant',
+    text: 'ログインフォームを作成しました。',
+    spec: sampleSpec,
+  },
+];
+
+const meta: Meta<typeof ChatView> = {
+  title: 'admin/ui-builder/chat-view',
+  component: ChatView,
+  args: {
+    isStreaming: false,
+    error: null,
+    onSend: fn(() => {}),
+    onClear: fn(() => {}),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ChatView>;
+
+export const Empty: Story = {
+  args: {
+    messages: [],
+  },
+  play: async ({ args, canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+
+    // 作成例のボタンが提示され、クリックでそのまま送信される
+    const example = canvas.getByRole('button', {
+      name: '料金プランの比較テーブル',
+    });
+    await userEvent.click(example);
+    await expect(args.onSend).toHaveBeenCalledWith('料金プランの比較テーブル');
+  },
+};
+
+export const Conversation: Story = {
+  args: {
+    messages: conversation,
+  },
+  play: async ({ canvasElement }) => {
+    // 地の文と、spec から生成された UI の両方が描画される
+    await expect(canvasElement.textContent).toContain(
+      'ログインフォームを作成しました',
+    );
+    await expect(canvasElement.textContent).toContain('サインイン');
+  },
+};
+
+export const Streaming: Story = {
+  args: {
+    isStreaming: true,
+    messages: [
+      { id: '1', role: 'user', text: '商品カードを並べて', spec: null },
+      { id: '2', role: 'assistant', text: '', spec: null },
+    ],
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    messages: conversation,
+    error: new Error('生成に失敗しました'),
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.textContent).toContain('生成に失敗しました');
+  },
+};

--- a/apps/admin/src/app/(authenticated)/ui-builder/_components/chat-view/chat-view.tsx
+++ b/apps/admin/src/app/(authenticated)/ui-builder/_components/chat-view/chat-view.tsx
@@ -1,0 +1,194 @@
+'use client';
+
+import type { ChatMessage } from '@json-render/react';
+import {
+  Alert,
+  Button,
+  SendIcon,
+  SparklesIcon,
+  Spinner,
+  Textarea,
+} from '@k8o/arte-odyssey';
+import {
+  type FC,
+  type FormEvent,
+  type KeyboardEvent,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+
+import { UiPreview } from '../ui-preview';
+
+type Props = {
+  messages: ChatMessage[];
+  isStreaming: boolean;
+  error: Error | null;
+  onSend: (text: string) => void;
+  onClear: () => void;
+};
+
+// 空の状態で提示する作成例。クリックでそのまま送信する。
+const EXAMPLE_PROMPTS = [
+  'ログインフォームを作って',
+  'プロフィールカードを3枚横に並べて',
+  '料金プランの比較テーブル',
+  'お問い合わせフォーム',
+] as const;
+
+const Message: FC<{ message: ChatMessage; loading: boolean }> = ({
+  message,
+  loading,
+}) => {
+  if (message.role === 'user') {
+    return (
+      <div className="bg-primary-bg text-primary-fg max-w-[80%] self-end rounded-2xl px-4 py-2 text-sm whitespace-pre-wrap">
+        {message.text}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex w-full flex-col gap-2 self-start">
+      {message.text !== '' && (
+        <p className="text-fg-base text-sm leading-relaxed whitespace-pre-wrap">
+          {message.text}
+        </p>
+      )}
+      {message.spec !== null && (
+        <div className="border-border-mute bg-bg-base rounded-lg border p-4">
+          <p className="text-fg-mute mb-3 text-xs font-bold">プレビュー</p>
+          <UiPreview loading={loading} spec={message.spec} />
+        </div>
+      )}
+      {loading && message.text === '' && message.spec === null && (
+        <Spinner label="生成中" size="sm" />
+      )}
+    </div>
+  );
+};
+
+/**
+ * チャット UI の見た目だけを担う表示専用コンポーネント。
+ * 会話状態は持たず、props で受け取る（ロジックは ui-builder 側の useChatUI）。
+ */
+export const ChatView: FC<Props> = ({
+  messages,
+  isStreaming,
+  error,
+  onSend,
+  onClear,
+}) => {
+  const [input, setInput] = useState('');
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  // 新しいメッセージやストリーミング更新のたびに最下部へスクロールする。
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [messages, isStreaming]);
+
+  const trimmed = input.trim();
+  const canSend = trimmed !== '' && !isStreaming;
+
+  const submit = (): void => {
+    if (!canSend) {
+      return;
+    }
+    onSend(trimmed);
+    setInput('');
+  };
+
+  const handleSubmit = (e: FormEvent<HTMLFormElement>): void => {
+    e.preventDefault();
+    submit();
+  };
+
+  // Cmd/Ctrl + Enter で送信する。
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>): void => {
+    if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  const isEmpty = messages.length === 0;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div
+        className="border-border-subtle bg-bg-mute/30 flex max-h-[60vh] min-h-[40vh] flex-col gap-4 overflow-y-auto rounded-lg border p-4"
+        ref={scrollRef}
+      >
+        {isEmpty ? (
+          <div className="text-fg-mute m-auto flex max-w-md flex-col items-center gap-4 text-center">
+            <SparklesIcon size="lg" />
+            <p className="text-sm leading-relaxed">
+              作りたい画面を言葉で伝えると、ArteOdysseyのコンポーネントでUIを組み立てます。
+            </p>
+            <div className="flex flex-wrap justify-center gap-2">
+              {EXAMPLE_PROMPTS.map((example) => (
+                <Button
+                  color="gray"
+                  disabled={isStreaming}
+                  key={example}
+                  onClick={() => {
+                    onSend(example);
+                  }}
+                  size="sm"
+                  variant="outline"
+                >
+                  {example}
+                </Button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          messages.map((message, index) => (
+            <Message
+              key={message.id}
+              loading={isStreaming && index === messages.length - 1}
+              message={message}
+            />
+          ))
+        )}
+      </div>
+
+      {error !== null && <Alert message={error.message} tone="error" />}
+
+      <form className="flex flex-col gap-2" onSubmit={handleSubmit}>
+        <Textarea
+          autoResize
+          disabled={isStreaming}
+          onChange={(e) => {
+            setInput(e.target.value);
+          }}
+          onKeyDown={handleKeyDown}
+          placeholder="作りたいUIを説明してください（Cmd/Ctrl + Enter で送信）"
+          value={input}
+        />
+        <div className="flex items-center justify-between">
+          <Button
+            color="gray"
+            disabled={isStreaming || isEmpty}
+            onClick={onClear}
+            size="sm"
+            type="button"
+            variant="skeleton"
+          >
+            会話をクリア
+          </Button>
+          <Button
+            color="primary"
+            disabled={!canSend}
+            endIcon={<SendIcon />}
+            size="md"
+            type="submit"
+            variant="solid"
+          >
+            生成
+          </Button>
+        </div>
+      </form>
+    </div>
+  );
+};

--- a/apps/admin/src/app/(authenticated)/ui-builder/_components/chat-view/index.ts
+++ b/apps/admin/src/app/(authenticated)/ui-builder/_components/chat-view/index.ts
@@ -1,0 +1,1 @@
+export { ChatView } from './chat-view';

--- a/apps/admin/src/app/(authenticated)/ui-builder/_components/ui-builder/index.ts
+++ b/apps/admin/src/app/(authenticated)/ui-builder/_components/ui-builder/index.ts
@@ -1,0 +1,1 @@
+export { UiBuilder } from './ui-builder';

--- a/apps/admin/src/app/(authenticated)/ui-builder/_components/ui-builder/ui-builder.tsx
+++ b/apps/admin/src/app/(authenticated)/ui-builder/_components/ui-builder/ui-builder.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { useChatUI } from '@json-render/react';
+import type { FC } from 'react';
+
+import { ChatView } from '../chat-view';
+
+/**
+ * AI UIビルダーのコンテナ。
+ *
+ * `useChatUI`（@json-render/react）が `/api/ui-builder` とやり取りし、各メッセージを
+ * 「地の文（text）」と「json-render Spec」に分解して返す。状態を ChatView に渡すだけ。
+ */
+export const UiBuilder: FC = () => {
+  const { messages, isStreaming, error, send, clear } = useChatUI({
+    api: '/api/ui-builder',
+  });
+
+  return (
+    <ChatView
+      error={error}
+      isStreaming={isStreaming}
+      messages={messages}
+      onClear={clear}
+      onSend={(text) => {
+        void send(text);
+      }}
+    />
+  );
+};

--- a/apps/admin/src/app/(authenticated)/ui-builder/_components/ui-preview/index.ts
+++ b/apps/admin/src/app/(authenticated)/ui-builder/_components/ui-preview/index.ts
@@ -1,0 +1,1 @@
+export { UiPreview } from './ui-preview';

--- a/apps/admin/src/app/(authenticated)/ui-builder/_components/ui-preview/ui-preview.stories.tsx
+++ b/apps/admin/src/app/(authenticated)/ui-builder/_components/ui-preview/ui-preview.stories.tsx
@@ -1,0 +1,116 @@
+import type { Spec } from '@json-render/core';
+import type { ArteSpec } from '@k8o/arte-odyssey/json-render';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect } from 'storybook/test';
+
+import { UiPreview } from './ui-preview';
+
+const meta: Meta<typeof UiPreview> = {
+  title: 'admin/ui-builder/ui-preview',
+  component: UiPreview,
+};
+
+export default meta;
+type Story = StoryObj<typeof UiPreview>;
+
+// 静的な spec（バインディング無し）。型付き ArteSpec で書ける。
+const loginSpec = {
+  root: 'root',
+  elements: {
+    root: {
+      type: 'Stack',
+      props: { direction: 'column', gap: 'md' },
+      children: ['title', 'email', 'password', 'submit'],
+    },
+    title: { type: 'Heading', props: { text: 'ログイン', level: 'h2' } },
+    email: {
+      type: 'TextField',
+      props: { name: 'email', placeholder: 'メールアドレス' },
+    },
+    password: {
+      type: 'PasswordInput',
+      props: { name: 'password', placeholder: 'パスワード' },
+    },
+    submit: {
+      type: 'Button',
+      props: { label: 'ログイン', color: 'primary', fullWidth: true },
+    },
+  },
+} satisfies ArteSpec;
+
+export const Primary: Story = {
+  args: {
+    spec: loginSpec,
+  },
+  play: async ({ canvasElement }) => {
+    await expect(canvasElement.textContent).toContain('ログイン');
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    spec: null,
+  },
+};
+
+// state バインディング・repeat を含む spec（LLM が実際に生成する形）。
+// props に { $item } / { $bindState } のような式オブジェクトが入るため ArteSpec の
+// 静的型には収まらないが、Renderer が実行時に解決して描画できることを確認する。
+const dashboardSpec: Spec = {
+  root: 'dashboard',
+  elements: {
+    dashboard: {
+      type: 'Stack',
+      props: { direction: 'column', gap: 'lg' },
+      children: ['heading', 'grid'],
+    },
+    heading: {
+      type: 'Heading',
+      props: { text: 'ダッシュボード', level: 'h2' },
+    },
+    grid: {
+      type: 'Grid',
+      props: { cols: 2, gap: 'md' },
+      repeat: { statePath: '/stats', key: 'id' },
+      children: ['card'],
+    },
+    card: {
+      type: 'Card',
+      props: { appearance: 'shadow', width: 'full' },
+      children: ['cardBody'],
+    },
+    cardBody: {
+      type: 'Stack',
+      props: { direction: 'column', gap: 'sm' },
+      children: ['label', 'value'],
+    },
+    label: {
+      type: 'Heading',
+      props: { text: { $item: 'label' }, level: 'h3' },
+    },
+    value: {
+      type: 'Heading',
+      props: { text: { $item: 'value' }, level: 'h3' },
+    },
+  },
+  state: {
+    stats: [
+      { id: 'revenue', label: '売上', value: '¥12,480,000' },
+      { id: 'users', label: 'ユーザー数', value: '48,250' },
+      { id: 'conversion', label: 'コンバージョン率', value: '3.8%' },
+      { id: 'bounce', label: '離脱率', value: '42.1%' },
+    ],
+  },
+};
+
+export const DashboardWithBindings: Story = {
+  args: {
+    spec: dashboardSpec,
+  },
+  play: async ({ canvasElement }) => {
+    // repeat が state 配列を展開し、{ $item } バインディングが値に解決される
+    await expect(canvasElement.textContent).toContain('売上');
+    await expect(canvasElement.textContent).toContain('¥12,480,000');
+    await expect(canvasElement.textContent).toContain('離脱率');
+  },
+};

--- a/apps/admin/src/app/(authenticated)/ui-builder/_components/ui-preview/ui-preview.tsx
+++ b/apps/admin/src/app/(authenticated)/ui-builder/_components/ui-preview/ui-preview.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import type { Spec } from '@json-render/core';
+import { JSONUIProvider, Renderer } from '@json-render/react';
+import { registry } from '@k8o/arte-odyssey/json-render/registry';
+import type { FC } from 'react';
+
+type Props = {
+  /** json-render の Spec。null のときは何も描画しない。 */
+  spec: Spec | null;
+  /** 生成ストリーミング中かどうか。Renderer のローディング表示に渡す。 */
+  loading?: boolean;
+};
+
+/**
+ * 生成された json-render Spec を arte-odyssey のコンポーネントで描画する。
+ *
+ * 事前結線済みの `JsonRenderUI` ではなく、低レベルの `JSONUIProvider` + `Renderer`
+ * を自前で結線している。理由は `JsonRenderUI` が `spec.state` を初期 state に
+ * seed しないため、`repeat` や `$item` / `$bindState` を使うデータ駆動 UI が空で
+ * 描画されてしまうから。ここで `initialState={spec.state}` を明示的に渡すことで、
+ * LLM が生成する state 付きの spec も正しく描画される。
+ */
+export const UiPreview: FC<Props> = ({ spec, loading = false }) => (
+  <JSONUIProvider initialState={spec?.state ?? {}} registry={registry}>
+    <Renderer loading={loading} registry={registry} spec={spec} />
+  </JSONUIProvider>
+);

--- a/apps/admin/src/app/(authenticated)/ui-builder/page.tsx
+++ b/apps/admin/src/app/(authenticated)/ui-builder/page.tsx
@@ -1,0 +1,15 @@
+import { PageHeader } from '@/app/(authenticated)/_components';
+
+import { UiBuilder } from './_components/ui-builder';
+
+export default function Page() {
+  return (
+    <div className="flex flex-col gap-10">
+      <PageHeader
+        description="チャットで指示すると、ArteOdysseyのコンポーネントだけでUIを生成します。"
+        title="AI UIビルダー"
+      />
+      <UiBuilder />
+    </div>
+  );
+}

--- a/apps/admin/src/app/api/ui-builder/route.ts
+++ b/apps/admin/src/app/api/ui-builder/route.ts
@@ -1,0 +1,8 @@
+import { handleUiBuilderChat } from '@/features/ui-builder/interface/chat';
+
+// ストリーミング生成のため、実行時間の上限を緩める。
+export const maxDuration = 60;
+
+export function POST(req: Request): Promise<Response> {
+  return handleUiBuilderChat(req);
+}

--- a/apps/admin/src/features/ui-builder/application/prompt.test.ts
+++ b/apps/admin/src/features/ui-builder/application/prompt.test.ts
@@ -1,0 +1,30 @@
+import { buildSystemPrompt } from './prompt';
+
+describe('buildSystemPrompt', () => {
+  describe('正常系', () => {
+    it('空でないシステムプロンプトを生成する', () => {
+      const prompt = buildSystemPrompt();
+
+      expect(prompt.length).toBeGreaterThan(0);
+    });
+
+    it('利用可能な arte-odyssey コンポーネント名を含む', () => {
+      const prompt = buildSystemPrompt();
+
+      expect(prompt).toContain('Stack');
+      expect(prompt).toContain('Button');
+    });
+
+    it('チャット向けの追加ルール（地の文を添える指示）を含む', () => {
+      const prompt = buildSystemPrompt();
+
+      expect(prompt).toContain('地の文');
+    });
+
+    it('arteOdysseyRules（Table のセル数を columns に揃える等）を含む', () => {
+      const prompt = buildSystemPrompt();
+
+      expect(prompt).toContain('columns');
+    });
+  });
+});

--- a/apps/admin/src/features/ui-builder/application/prompt.ts
+++ b/apps/admin/src/features/ui-builder/application/prompt.ts
@@ -1,0 +1,30 @@
+import { arteOdysseyRules, catalog } from '@k8o/arte-odyssey/json-render';
+
+/**
+ * チャットで UI を生成するときの追加ルール。
+ * `catalog.prompt()` 本文（UI を JSONL パッチで出力する指示）に追記される。
+ *
+ * - 地の文（JSON ではない普通の文）と JSONL パッチが混在しても、クライアント側の
+ *   `useChatUI` が `createMixedStreamParser` で振り分けるため、会話としての一言を
+ *   添えてよい。
+ */
+const chatRules = [
+  '最初に1行だけ、何を作ったか・どう変更したかを日本語の地の文（JSON ではない普通の文）で簡潔に述べてから、UI の JSONL パッチを出力すること。',
+  'ユーザーが既存の UI への修正を依頼したら、会話の文脈をもとに UI 全体を作り直してよい。',
+  'ユーザーの依頼が UI の生成と無関係な場合は、UI を出力せず地の文だけで簡潔に応答すること。',
+  // 品質ルール: 単純すぎる・スカスカな出力を避け、実用的で完成度の高い画面にする。
+  'UI は単一要素で終わらせず、Card / Grid / Stack で要素をグルーピングし、見出し・適切な余白・区切りで視覚的な階層を作ること。実画面として成立する完成度を目指す。',
+  'フォームには FormControl やラベル・プレースホルダ・補助テキストを添え、主要な操作には Button を置くなど、実用的な構成にすること。',
+  'ラベルやサンプルデータは日本語で、現実的で具体的な内容にすること（「項目1」のようなダミーは避ける）。一覧やカードは2〜4件など適度な件数を入れる。',
+  'ユーザーの指示が曖昧な場合でも、その用途で一般的に必要な要素を補って、すぐ使える実用的な画面に仕上げること。',
+] as const;
+
+/**
+ * json-render 用のシステムプロンプトを生成する（サーバー安全 / React 非依存）。
+ *
+ * arteOdysseyRules（Table のセル数を columns に揃える・href の形式・Tabs/Accordion の
+ * content はテキストのみ等、LLM が破りやすい横断ルール）に加え、チャット向けの
+ * ルールを注入する。
+ */
+export const buildSystemPrompt = (): string =>
+  catalog.prompt({ customRules: [...arteOdysseyRules, ...chatRules] });

--- a/apps/admin/src/features/ui-builder/infrastructure/generate.ts
+++ b/apps/admin/src/features/ui-builder/infrastructure/generate.ts
@@ -1,0 +1,68 @@
+import { type ModelMessage, streamText } from 'ai';
+
+import { buildSystemPrompt } from '../application/prompt';
+
+// 既定は動作実績のある OpenAI provider の上位モデル（AI Gateway の creator/model 形式）。
+// admin 配下のオーナー専用・低頻度利用なので gpt-4o-mini より品質を優先する。
+// Claude を使いたい場合は AI Gateway にクレジットを追加のうえ
+// UI_BUILDER_MODEL=anthropic/claude-sonnet-4.6 のように env で差し替える。
+const UI_BUILDER_MODEL = process.env['UI_BUILDER_MODEL'] ?? 'openai/gpt-4.1';
+
+// 1 回の生成コストの上限。複雑な UI でも JSONL が途中で切れないよう余裕を持たせつつ、
+// 暴走時の課金は抑える。
+const MAX_OUTPUT_TOKENS = 8000;
+
+// システムプロンプトは決定的なので、モジュール読み込み時に一度だけ生成する。
+const SYSTEM_PROMPT = buildSystemPrompt();
+
+const toMessage = (error: unknown): string =>
+  error instanceof Error ? error.message : String(error);
+
+/**
+ * 会話履歴から UI 生成のストリームを返す。
+ *
+ * レスポンスは「地の文 + JSONL（RFC 6902 JSON Patch）」が混在する素のテキスト
+ * ストリームで、これは `@json-render/react` の `useChatUI` がそのまま解釈できる形式。
+ *
+ * `toTextStreamResponse()` はストリーム途中のエラー（モデル不可・クレジット不足など）を
+ * 本文に出さず握り潰すため、画面が真っ白になってしまう。代わりに `fullStream` を自前で
+ * 流し、error パートを地の文として書き出すことで、失敗理由を会話に表示する。
+ */
+export const streamUiBuilder = (messages: ModelMessage[]): Response => {
+  const result = streamText({
+    model: UI_BUILDER_MODEL,
+    system: SYSTEM_PROMPT,
+    messages,
+    maxOutputTokens: MAX_OUTPUT_TOKENS,
+  });
+
+  const encoder = new TextEncoder();
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const fail = (error: unknown): void => {
+        const message = toMessage(error);
+        // AI Gateway のキー未設定・モデル不可・クレジット不足・レート超過などはここに出る。
+        console.error('AI UIビルダー: 生成に失敗しました:', message);
+        controller.enqueue(encoder.encode(`\n生成に失敗しました: ${message}`));
+      };
+
+      try {
+        for await (const part of result.fullStream) {
+          if (part.type === 'text-delta') {
+            controller.enqueue(encoder.encode(part.text));
+          } else if (part.type === 'error') {
+            fail(part.error);
+          }
+        }
+      } catch (error) {
+        fail(error);
+      } finally {
+        controller.close();
+      }
+    },
+  });
+
+  return new Response(stream, {
+    headers: { 'content-type': 'text/plain; charset=utf-8' },
+  });
+};

--- a/apps/admin/src/features/ui-builder/interface/chat.test.ts
+++ b/apps/admin/src/features/ui-builder/interface/chat.test.ts
@@ -1,0 +1,117 @@
+import { streamUiBuilder } from '../infrastructure/generate';
+import { handleUiBuilderChat } from './chat';
+
+// 認証と AI 呼び出しはモックし、interface の検証・認可ロジックだけを試す。
+const h = vi.hoisted(() => ({
+  authEnabled: false,
+  session: null as unknown,
+}));
+
+vi.mock('@/shared/auth/auth-enabled', () => ({
+  get isAuthEnabled() {
+    return h.authEnabled;
+  },
+}));
+
+vi.mock('@repo/database/auth', () => ({
+  auth: { api: { getSession: vi.fn(() => h.session) } },
+}));
+
+vi.mock('next/headers', () => ({
+  headers: vi.fn(() => new Headers()),
+}));
+
+vi.mock('../infrastructure/generate', () => ({
+  streamUiBuilder: vi.fn(() => new Response('stream', { status: 200 })),
+}));
+
+const post = (body: unknown): Request =>
+  new Request('http://localhost/api/ui-builder', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  });
+
+describe('handleUiBuilderChat', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    h.authEnabled = false;
+    h.session = null;
+  });
+
+  describe('正常系', () => {
+    it('有効なメッセージで streamUiBuilder を呼び、その Response を返す', async () => {
+      const res = await handleUiBuilderChat(
+        post({ messages: [{ role: 'user', content: 'ログインフォーム' }] }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(streamUiBuilder).toHaveBeenCalledWith([
+        { role: 'user', content: 'ログインフォーム' },
+      ]);
+    });
+  });
+
+  describe('認可', () => {
+    it('認証が有効でセッションが無ければ401を返し、生成は呼ばれない', async () => {
+      h.authEnabled = true;
+      h.session = null;
+
+      const res = await handleUiBuilderChat(
+        post({ messages: [{ role: 'user', content: 'x' }] }),
+      );
+
+      expect(res.status).toBe(401);
+      expect(streamUiBuilder).not.toHaveBeenCalled();
+    });
+
+    it('認証が有効でもセッションがあれば生成する', async () => {
+      h.authEnabled = true;
+      h.session = { user: { id: '1' } };
+
+      const res = await handleUiBuilderChat(
+        post({ messages: [{ role: 'user', content: 'x' }] }),
+      );
+
+      expect(res.status).toBe(200);
+      expect(streamUiBuilder).toHaveBeenCalled();
+    });
+  });
+
+  describe('異常系', () => {
+    it('不正なJSONは400を返し、生成は呼ばれない', async () => {
+      const res = await handleUiBuilderChat(post('{ not json'));
+
+      expect(res.status).toBe(400);
+      expect(streamUiBuilder).not.toHaveBeenCalled();
+    });
+
+    it('messages が無ければ400', async () => {
+      const res = await handleUiBuilderChat(post({ foo: 'bar' }));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('空の messages は400', async () => {
+      const res = await handleUiBuilderChat(post({ messages: [] }));
+
+      expect(res.status).toBe(400);
+    });
+
+    it('role が user / assistant 以外なら400', async () => {
+      const res = await handleUiBuilderChat(
+        post({ messages: [{ role: 'system', content: 'x' }] }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+
+    it('content が長すぎると400', async () => {
+      const res = await handleUiBuilderChat(
+        post({ messages: [{ role: 'user', content: 'a'.repeat(8001) }] }),
+      );
+
+      expect(res.status).toBe(400);
+    });
+  });
+});

--- a/apps/admin/src/features/ui-builder/interface/chat.ts
+++ b/apps/admin/src/features/ui-builder/interface/chat.ts
@@ -1,0 +1,96 @@
+import { auth } from '@repo/database/auth';
+import type { ModelMessage } from 'ai';
+import { headers } from 'next/headers';
+
+import { isAuthEnabled } from '@/shared/auth/auth-enabled';
+
+import { streamUiBuilder } from '../infrastructure/generate';
+
+// 32KB。会話履歴を含むが、UI 生成の指示は短文が中心なので十分。
+const MAX_BODY_SIZE = 32 * 1024;
+const MAX_MESSAGES = 40;
+const MAX_CONTENT_CHARS = 8000;
+
+type IncomingMessage = { role: 'user' | 'assistant'; content: string };
+
+// `useChatUI` が送る `{ messages: Array<{ role, content }> }` を検証する。
+// admin は他に JSON ボディの API を持たず zod を使っていないため、軽量な手書き検証にする。
+const parseMessages = (json: unknown): IncomingMessage[] | null => {
+  if (typeof json !== 'object' || json === null || !('messages' in json)) {
+    return null;
+  }
+  const { messages } = json as { messages: unknown };
+  if (!Array.isArray(messages)) {
+    return null;
+  }
+  const result: IncomingMessage[] = [];
+  for (const message of messages) {
+    if (typeof message !== 'object' || message === null) {
+      return null;
+    }
+    const { role, content } = message as { role?: unknown; content?: unknown };
+    if (
+      (role !== 'user' && role !== 'assistant') ||
+      typeof content !== 'string'
+    ) {
+      return null;
+    }
+    result.push({ role, content });
+  }
+  return result;
+};
+
+const errorResponse = (status: number, message: string): Response =>
+  Response.json({ message }, { status });
+
+/**
+ * `useChatUI`（@json-render/react）からの POST を受け、UI 生成のテキストストリームを返す。
+ *
+ * admin の middleware（proxy.ts）は matcher で `/api` を除外しているため、API は
+ * middleware で保護されない。ここで自前にセッションを確認し、未認証なら 401 を返す
+ * （AI 呼び出しを伴うエンドポイントの濫用・課金を防ぐ）。リクエストボディは
+ * `{ messages: Array<{ role, content }> }`、エラー時は `{ message }` の JSON。
+ */
+export const handleUiBuilderChat = async (req: Request): Promise<Response> => {
+  if (isAuthEnabled) {
+    const session = await auth.api.getSession({ headers: await headers() });
+    if (!session) {
+      return errorResponse(401, '認証が必要です');
+    }
+  }
+
+  const contentLength = req.headers.get('content-length');
+  if (contentLength !== null && Number(contentLength) > MAX_BODY_SIZE) {
+    return errorResponse(413, 'リクエストが大きすぎます');
+  }
+
+  const text = await req.text();
+  if (text.length > MAX_BODY_SIZE) {
+    return errorResponse(413, 'リクエストが大きすぎます');
+  }
+
+  let json: unknown;
+  try {
+    json = JSON.parse(text);
+  } catch {
+    return errorResponse(400, '不正なリクエストです');
+  }
+
+  const messages = parseMessages(json);
+  if (messages === null) {
+    return errorResponse(400, '不正なリクエストです');
+  }
+  if (messages.length === 0 || messages.length > MAX_MESSAGES) {
+    return errorResponse(400, 'メッセージ数が不正です');
+  }
+  if (messages.some((message) => message.content.length > MAX_CONTENT_CHARS)) {
+    return errorResponse(400, 'メッセージが長すぎます');
+  }
+
+  const modelMessages: ModelMessage[] = messages.map((message) => ({
+    role: message.role,
+    content: message.content,
+  }));
+
+  return streamUiBuilder(modelMessages);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,9 +140,15 @@ importers:
 
   apps/admin:
     dependencies:
+      '@json-render/core':
+        specifier: 0.19.0
+        version: 0.19.0(zod@4.4.3)
+      '@json-render/react':
+        specifier: 0.19.0
+        version: 0.19.0(react@19.2.7)(zod@4.4.3)
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.2.0(@json-render/core@0.19.0(zod@4.4.3))(@json-render/react@0.19.0(react@19.2.7)(zod@4.4.3))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -152,6 +158,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.3.0
+      ai:
+        specifier: 6.0.197
+        version: 6.0.197(zod@4.4.3)
       better-auth:
         specifier: 1.6.14
         version: 1.6.14(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@libsql/client@0.17.3)(@opentelemetry/api@1.9.1)(kysely@0.28.17))(next@16.2.7(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
@@ -239,7 +248,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.2.0(@json-render/core@0.19.0(zod@4.4.3))(@json-render/react@0.19.0(react@19.2.7)(zod@4.4.3))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)
       '@mdx-js/loader':
         specifier: 3.1.1
         version: 3.1.1
@@ -1941,6 +1950,16 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@json-render/core@0.19.0':
+    resolution: {integrity: sha512-vvcyZ+10EDZKbEyB1J2kXOGfDaiZR2LurZGSqi2r5STHyKr+Te85DWaBxTwRGgM7U1LtIvNx85BzzjElRKoAIg==}
+    peerDependencies:
+      zod: ^4.0.0
+
+  '@json-render/react@0.19.0':
+    resolution: {integrity: sha512-kTW6b6cSNRrlEfCUf/69SLoLn+CufC968ruge9tnQlp9pDTGG/SK8pgM541FdgwMFA4zm3s5mpM3G8rdODKc/A==}
+    peerDependencies:
+      react: ^19.2.3
 
   '@k8o/arte-odyssey@10.2.0':
     resolution: {integrity: sha512-4zZL/9h2IxEYuXBm6OfA5GSh3E3poeu6KbH8CgUafMzMd11YjqMUzMCUfGpFS2jQYAlpT9HmzS76csJ0tCOO/A==}
@@ -4775,8 +4794,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.0.19:
-    resolution: {integrity: sha512-gLEwJ26XSRNN5r7x/AI8Zi0Fs6uJe/junYM+jQaaVRjfagUUAerPD90fZlwjRnK0Lpb9jRzqaM9BvmHXUHkGxA==}
+  deslop-js@0.0.21:
+    resolution: {integrity: sha512-1fYusMl4tDaQ/xdHFtLfDe8kFrEeU0Vu0Pfiy2k/Gd4HSqYlQj1Z7iRqldNneRyuCzNMhwNBvhaL07Urbh5VOA==}
 
   detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
@@ -6190,8 +6209,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-plugin-react-doctor@0.4.0:
-    resolution: {integrity: sha512-iC+iV296B41pghbPEmR1oklwjTo8v9LlTVG1LTHed3ZkeuljH3Kq+SKeHB1YXvLuq9MARr+n4WDmN5r7bHtJfg==}
+  oxlint-plugin-react-doctor@0.4.2:
+    resolution: {integrity: sha512-pH5TCM+FqvbiK7I6PVdUD6AY0013okJ4DCee4eQbce2FjU2X+TXw+gkBxw7GT8S3I6jqvFLGkabekmISKcSJnw==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
   oxlint-tailwindcss@1.2.0:
@@ -6373,8 +6392,8 @@ packages:
     resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
     engines: {node: ^20.9.0 || >=22}
 
-  react-doctor@0.4.0:
-    resolution: {integrity: sha512-BWum4WfKZ9Sdv4zTlzRoog4fYEIBEWZXHnq8GaCL42XMLmoldATdix/i3xZSHD3+SqpMrUVGcuzerOL9R9P+bw==}
+  react-doctor@0.4.2:
+    resolution: {integrity: sha512-h4wykdqF93jBd4RD4AlKjyaukfizqcrwAMdZGLM0UsCw7ipOqJXFPvfPRK+GbHVh8KKoYWq1nU7K1M3uGTY/Ag==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -8388,7 +8407,18 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@k8o/arte-odyssey@10.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)':
+  '@json-render/core@0.19.0(zod@4.4.3)':
+    dependencies:
+      zod: 4.4.3
+
+  '@json-render/react@0.19.0(react@19.2.7)(zod@4.4.3)':
+    dependencies:
+      '@json-render/core': 0.19.0(zod@4.4.3)
+      react: 19.2.7
+    transitivePeerDependencies:
+      - zod
+
+  '@k8o/arte-odyssey@10.2.0(@json-render/core@0.19.0(zod@4.4.3))(@json-render/react@0.19.0(react@19.2.7)(zod@4.4.3))(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.0)(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
       '@floating-ui/react': 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@types/react': 19.2.17
@@ -8403,6 +8433,8 @@ snapshots:
       tailwindcss: 4.3.0
       typescript: 6.0.3
     optionalDependencies:
+      '@json-render/core': 0.19.0(zod@4.4.3)
+      '@json-render/react': 0.19.0(react@19.2.7)(zod@4.4.3)
       zod: 4.4.3
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
@@ -10720,7 +10752,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.0.19:
+  deslop-js@0.0.21:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
@@ -12624,7 +12656,7 @@ snapshots:
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
       vite-plus: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
 
-  oxlint-plugin-react-doctor@0.4.0:
+  oxlint-plugin-react-doctor@0.4.2:
     dependencies:
       '@typescript-eslint/types': 8.60.0
       eslint-scope: 9.1.2
@@ -12810,7 +12842,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-doctor@0.4.0(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)):
+  react-doctor@0.4.2(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@effect/platform-node-shared': 4.0.0-beta.70(effect@4.0.0-beta.70)
@@ -12818,13 +12850,13 @@ snapshots:
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.0.19
+      deslop-js: 0.0.21
       effect: 4.0.0-beta.70
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint-plugin-react-doctor: 0.4.0
+      oxlint-plugin-react-doctor: 0.4.2
       prompts: 2.4.2
       typescript: 6.0.3
       vscode-languageserver: 9.0.1
@@ -12892,7 +12924,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.4.0(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0))
+      react-doctor: 0.4.2(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.1)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0))
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.44(react@19.2.7)
     optionalDependencies:


### PR DESCRIPTION
## 概要

`@k8o/arte-odyssey` の **json-render 連携** を使い、チャットで指示すると ArteOdyssey のコンポーネントだけで UI を生成・プレビューするツールを **`apps/admin`（認証必須・オーナーのみ）** に追加します。

公開サイト（`apps/main`）ではなく **Better Auth 配下の admin** に置くことで、AI 呼び出しを伴うエンドポイントの濫用・課金を構造的に防ぎます（$5 の AI Gateway 予算を守る意図）。

- フレームワーク: **json-render**（slots で自由に入れ子・約50コンポーネント対応）
- 対話: **マルチターン反復**（`useChatUI` で会話を保持）
- 配置: `/(authenticated)/ui-builder`（サイドバー「ツール > AI UIビルダー」）

## コスト/濫用対策

- **認証必須**: admin 配下なので本番はログイン済みオーナーのみ。
- **API 自前ガード**: admin の middleware（`proxy.ts`）は matcher で `/api` を除外するため、`/api/ui-builder` は middleware で保護されない。ルートハンドラ内で `auth.api.getSession` を確認し、未認証は **401**（`isAuthEnabled` 時のみ。preview は認証OFF）。
- **出力トークン上限**: `streamText` に `maxOutputTokens` を設定し、1 回の生成コストを固定。
- 入力検証（件数・長さ・サイズ上限）も実施。

## 構成

- **features/ui-builder**
  - `application/prompt.ts`: `catalog.prompt({ customRules: [...arteOdysseyRules, ...] })`
  - `infrastructure/generate.ts`: `streamText`（AI Gateway, `UI_BUILDER_MODEL` で差し替え可・既定 `openai/gpt-4o-mini`, `maxOutputTokens`）→ 「地の文 + JSONL(RFC6902)」混在テキストストリーム
  - `interface/chat.ts`: セッション確認＋入力検証（admin は zod 未使用のため軽量な手書き検証）
- **app/(authenticated)/ui-builder**: `useChatUI({ api: '/api/ui-builder' })` のコンテナ + 表示専用 chat-view + ui-preview
- サイドバー `nav-items.ts` に「ツール > AI UIビルダー」

## 重要: `JsonRenderUI` が `spec.state` を seed しない件

事前結線済みの `JsonRenderUI` は `spec.state` を `JSONUIProvider` の `initialState` に渡さず、`Renderer` も読みません。そのため `repeat` / `$item` / `$bindState` を使う**データ駆動 UI が空描画**になります（LLM は多用）。→ `ui-preview` では低レベルの `JSONUIProvider initialState={spec.state}` + `Renderer registry={registry}` を自前結線して解決（Storybook play で実描画を確認）。

> 上流提案: `JsonRenderUI` が `spec.state` を `initialState` に渡すよう直せば、この自前結線は不要になります。

## 試し方

- **Vercel プレビュー**: このPRのプレビューデプロイ（admin）は OIDC 経由で AI Gateway が効くため、ローカルのキー設定なしで動かせます（preview は認証OFF）。
- **ローカル**: `pnpm dev` ＋ `AI_GATEWAY_API_KEY`。`LOCAL_AUTH_BYPASS=true` でログイン省略可。`UI_BUILDER_MODEL=anthropic/claude-...` で Claude モデルにも切替可。

## 検証

- type-check（admin/main）/ lint(0 errors) / ls-lint: ✅
- admin feature Vitest（認可・検証）: ✅ 12/12
- admin Storybook play（ui-preview 3 + chat-view 4、state/repeat の実描画含む）: ✅ 7/7
- 生成品質: 本番システムプロンプトに Claude をモデル役として与え、6種の代表 UI が妥当な json-render（bindings/repeat/state/actions 含む）になることをオフライン確認済み