### PR TITLE
feat: add @k8o/create to artifacts

### DIFF
--- a/apps/main/src/features/artifacts/application/artifacts.test.ts
+++ b/apps/main/src/features/artifacts/application/artifacts.test.ts
@@ -4,7 +4,7 @@ describe('getArtifacts', () => {
   it('公開している制作物一覧を返す', () => {
     const projects = getArtifacts();
 
-    expect(projects).toHaveLength(9);
+    expect(projects).toHaveLength(10);
     expect(projects).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/apps/main/src/features/artifacts/application/artifacts.ts
+++ b/apps/main/src/features/artifacts/application/artifacts.ts
@@ -85,4 +85,13 @@ export const getArtifacts = (): Artifact[] => [
     npmPackageName: '@k8o/oxc-config',
     tags: ['oxlint', 'Config', 'Personal'],
   },
+  {
+    name: '@k8o/create',
+    description:
+      'vp create @k8oで、k8oの規約一式が入ったリポジトリの雛形を生成するプロジェクトジェネレーター。',
+    githubUrl: 'https://github.com/k35o/templates',
+    websiteUrl: null,
+    npmPackageName: '@k8o/create',
+    tags: ['Vite+', 'Generator', 'Tool'],
+  },
 ];


### PR DESCRIPTION
Artifacts に `@k8o/create`（[k35o/templates](https://github.com/k35o/templates)）を追加します。

- `vp create @k8o` で k8o 規約一式が入ったリポジトリの雛形を生成するプロジェクトジェネレーター
- npm: `@k8o/create` / tags: `Vite+`, `Generator`, `Tool`
- 件数固定テスト `toHaveLength` を 9 → 10 に更新

`pnpm -F main exec vitest run .../artifacts.test.ts` green。