### PR TITLE
refactor: admin UI の重複コンポーネントを共通化（ConfirmDialog/ButtonLink/PublishToggle/LabeledTextField）

### DIFF
--- a/apps/admin/src/app/(authenticated)/_components/button-link/button-link.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/button-link/button-link.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { Button } from '@k8o/arte-odyssey';
+import type { Route } from 'next';
+import Link from 'next/link';
+import type { ComponentProps, FC, ReactNode } from 'react';
+
+type ButtonProps = ComponentProps<typeof Button>;
+
+type ButtonLinkProps = {
+  href: Route;
+  color: NonNullable<ButtonProps['color']>;
+  variant: NonNullable<ButtonProps['variant']>;
+  size: NonNullable<ButtonProps['size']>;
+  children: ReactNode;
+};
+
+// arte-odyssey の Button を next/link として描画する共通パターン。
+// renderItem で Link を差し込むボイラープレートを集約する。
+export const ButtonLink: FC<ButtonLinkProps> = ({
+  href,
+  color,
+  variant,
+  size,
+  children,
+}) => (
+  <Button
+    color={color}
+    renderItem={({ className, children: content }) => (
+      <Link className={className} href={href}>
+        {content}
+      </Link>
+    )}
+    size={size}
+    variant={variant}
+  >
+    {children}
+  </Button>
+);

--- a/apps/admin/src/app/(authenticated)/_components/button-link/index.ts
+++ b/apps/admin/src/app/(authenticated)/_components/button-link/index.ts
@@ -1,0 +1,1 @@
+export { ButtonLink } from './button-link';

--- a/apps/admin/src/app/(authenticated)/_components/confirm-dialog/confirm-dialog.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/confirm-dialog/confirm-dialog.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Button, Dialog, Modal } from '@k8o/arte-odyssey';
+import type { FC, ReactNode } from 'react';
+
+type ConfirmDialogProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  title: string;
+  onConfirm: () => void;
+  isPending: boolean;
+  confirmLabel: string;
+  pendingLabel: string;
+  children: ReactNode;
+};
+
+// 削除・送信・保存などの確認モーダル共通骨格。本文（メッセージやエラー、入力欄）は
+// children で渡す。キャンセル/確定ボタンと pending 表示はここで共通化する。
+export const ConfirmDialog: FC<ConfirmDialogProps> = ({
+  isOpen,
+  onClose,
+  title,
+  onConfirm,
+  isPending,
+  confirmLabel,
+  pendingLabel,
+  children,
+}) => (
+  <Modal isOpen={isOpen} onClose={onClose}>
+    <Dialog.Root>
+      <Dialog.Header onClose={onClose} title={title} />
+      <Dialog.Content>
+        <div className="flex flex-col gap-6">
+          {children}
+          <div className="flex justify-end gap-3">
+            <Button color="gray" onClick={onClose} variant="outline">
+              キャンセル
+            </Button>
+            <Button
+              color="primary"
+              disabled={isPending}
+              onClick={onConfirm}
+              variant="solid"
+            >
+              {isPending ? pendingLabel : confirmLabel}
+            </Button>
+          </div>
+        </div>
+      </Dialog.Content>
+    </Dialog.Root>
+  </Modal>
+);

--- a/apps/admin/src/app/(authenticated)/_components/confirm-dialog/index.ts
+++ b/apps/admin/src/app/(authenticated)/_components/confirm-dialog/index.ts
@@ -1,0 +1,1 @@
+export { ConfirmDialog } from './confirm-dialog';

--- a/apps/admin/src/app/(authenticated)/_components/index.ts
+++ b/apps/admin/src/app/(authenticated)/_components/index.ts
@@ -1,3 +1,4 @@
+export { ConfirmDialog } from './confirm-dialog';
 export { ContentFallback } from './content-fallback';
 export { EmptyState } from './empty-state';
 export { FilterSelect } from './filter-select';

--- a/apps/admin/src/app/(authenticated)/_components/index.ts
+++ b/apps/admin/src/app/(authenticated)/_components/index.ts
@@ -5,6 +5,7 @@ export { EmptyState } from './empty-state';
 export { FilterSelect } from './filter-select';
 export { ListPagination } from './list-pagination';
 export { PageHeader } from './page-header';
+export { PublishToggle } from './publish-toggle';
 export { SearchField } from './search-field';
 export { SectionHeader } from './section-header';
 export { StatCard } from './stat-card';

--- a/apps/admin/src/app/(authenticated)/_components/index.ts
+++ b/apps/admin/src/app/(authenticated)/_components/index.ts
@@ -1,3 +1,4 @@
+export { ButtonLink } from './button-link';
 export { ConfirmDialog } from './confirm-dialog';
 export { ContentFallback } from './content-fallback';
 export { EmptyState } from './empty-state';

--- a/apps/admin/src/app/(authenticated)/_components/index.ts
+++ b/apps/admin/src/app/(authenticated)/_components/index.ts
@@ -3,6 +3,7 @@ export { ConfirmDialog } from './confirm-dialog';
 export { ContentFallback } from './content-fallback';
 export { EmptyState } from './empty-state';
 export { FilterSelect } from './filter-select';
+export { LabeledTextField } from './labeled-text-field';
 export { ListPagination } from './list-pagination';
 export { PageHeader } from './page-header';
 export { PublishToggle } from './publish-toggle';

--- a/apps/admin/src/app/(authenticated)/_components/labeled-text-field/index.ts
+++ b/apps/admin/src/app/(authenticated)/_components/labeled-text-field/index.ts
@@ -1,0 +1,1 @@
+export { LabeledTextField } from './labeled-text-field';

--- a/apps/admin/src/app/(authenticated)/_components/labeled-text-field/labeled-text-field.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/labeled-text-field/labeled-text-field.tsx
@@ -1,0 +1,33 @@
+import { FormControl, TextField } from '@k8o/arte-odyssey';
+import type { FC } from 'react';
+
+type LabeledTextFieldProps = {
+  label: string;
+  name: string;
+  placeholder: string;
+  defaultValue: string;
+  required?: boolean;
+};
+
+// FormControl + TextField の定型（renderInput で aria を引き回す）を集約。
+// 各 admin フォームの単純なテキスト入力で共用する。
+export const LabeledTextField: FC<LabeledTextFieldProps> = ({
+  label,
+  name,
+  placeholder,
+  defaultValue,
+  required = false,
+}) => (
+  <FormControl
+    label={label}
+    required={required}
+    renderInput={({ 'aria-labelledby': _, ...props }) => (
+      <TextField
+        defaultValue={defaultValue}
+        name={name}
+        placeholder={placeholder}
+        {...props}
+      />
+    )}
+  />
+);

--- a/apps/admin/src/app/(authenticated)/_components/publish-toggle/index.ts
+++ b/apps/admin/src/app/(authenticated)/_components/publish-toggle/index.ts
@@ -1,0 +1,1 @@
+export { PublishToggle } from './publish-toggle';

--- a/apps/admin/src/app/(authenticated)/_components/publish-toggle/publish-toggle.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/publish-toggle/publish-toggle.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import { Switch, useToast } from '@k8o/arte-odyssey';
+import { useAsyncAction } from '@repo/react-hooks/use-async-action';
+import { type FC, useState } from 'react';
+
+import type { ActionState } from '@/shared/actions/action-state';
+
+type PublishToggleProps = {
+  initialPublished: boolean;
+  onToggle: (next: boolean) => Promise<ActionState>;
+};
+
+// 公開/下書きの楽観的トグル。失敗時は元の状態へ戻す。blog / slide のテーブル行で共用。
+export const PublishToggle: FC<PublishToggleProps> = ({
+  initialPublished,
+  onToggle,
+}) => {
+  const [published, setPublished] = useState(initialPublished);
+  const { isPending, run } = useAsyncAction();
+  const { onOpen } = useToast();
+
+  const handleToggle = (checked: boolean): void => {
+    const next = checked;
+    setPublished(next);
+    run(() => onToggle(next), {
+      onError: (message) => {
+        setPublished(!next);
+        onOpen('error', message);
+      },
+      onSuccess: () => {
+        onOpen('success', next ? '公開しました' : '下書きに戻しました');
+      },
+    });
+  };
+
+  return (
+    <Switch
+      disabled={isPending}
+      label={published ? '公開' : '下書き'}
+      onChange={handleToggle}
+      value={published}
+    />
+  );
+};

--- a/apps/admin/src/app/(authenticated)/blogs/_components/blog-table/blog-table.tsx
+++ b/apps/admin/src/app/(authenticated)/blogs/_components/blog-table/blog-table.tsx
@@ -1,70 +1,47 @@
 'use client';
 
-import { Badge, Card, Switch, useToast } from '@k8o/arte-odyssey';
-import { useAsyncAction } from '@repo/react-hooks/use-async-action';
-import { type FC, useState } from 'react';
+import { Badge, Card } from '@k8o/arte-odyssey';
+import type { FC } from 'react';
 
-import { EmptyState } from '@/app/(authenticated)/_components';
+import { EmptyState, PublishToggle } from '@/app/(authenticated)/_components';
 import { setBlogPublished } from '@/features/blog/interface/actions';
 import type { BlogRecord } from '@/features/blog/interface/queries';
 
 const BLOG_BASE_URL = 'https://k8o.me/blog';
 
-const BlogRow: FC<{ blog: BlogRecord }> = ({ blog }) => {
-  const [published, setPublished] = useState(blog.published);
-  const { isPending, run } = useAsyncAction();
-  const { onOpen } = useToast();
-
-  const handleToggle = (checked: boolean): void => {
-    const next = checked;
-    setPublished(next);
-    run(() => setBlogPublished(blog.id, next), {
-      onError: (message) => {
-        setPublished(!next);
-        onOpen('error', message);
-      },
-      onSuccess: () => {
-        onOpen('success', next ? '公開しました' : '下書きに戻しました');
-      },
-    });
-  };
-
-  return (
-    <div className="border-border-mute flex items-center gap-3 border-b px-5 py-4 text-sm last:border-b-0">
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <a
-          className="truncate font-medium hover:underline"
-          href={`${BLOG_BASE_URL}/${blog.slug}`}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          {blog.slug}
-        </a>
-        {blog.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {blog.tags.map((tag) => (
-              <Badge key={tag} size="sm" text={tag} tone="neutral" />
-            ))}
-          </div>
-        )}
-      </div>
-      <span className="text-fg-mute hidden w-20 shrink-0 text-right tabular-nums sm:block">
-        {blog.views.toLocaleString()}
-      </span>
-      <span className="text-fg-mute hidden w-16 shrink-0 text-right tabular-nums sm:block">
-        {blog.commentCount}
-      </span>
-      <div className="flex w-24 shrink-0 justify-end">
-        <Switch
-          disabled={isPending}
-          label={published ? '公開' : '下書き'}
-          onChange={handleToggle}
-          value={published}
-        />
-      </div>
+const BlogRow: FC<{ blog: BlogRecord }> = ({ blog }) => (
+  <div className="border-border-mute flex items-center gap-3 border-b px-5 py-4 text-sm last:border-b-0">
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <a
+        className="truncate font-medium hover:underline"
+        href={`${BLOG_BASE_URL}/${blog.slug}`}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {blog.slug}
+      </a>
+      {blog.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {blog.tags.map((tag) => (
+            <Badge key={tag} size="sm" text={tag} tone="neutral" />
+          ))}
+        </div>
+      )}
     </div>
-  );
-};
+    <span className="text-fg-mute hidden w-20 shrink-0 text-right tabular-nums sm:block">
+      {blog.views.toLocaleString()}
+    </span>
+    <span className="text-fg-mute hidden w-16 shrink-0 text-right tabular-nums sm:block">
+      {blog.commentCount}
+    </span>
+    <div className="flex w-24 shrink-0 justify-end">
+      <PublishToggle
+        initialPublished={blog.published}
+        onToggle={(next) => setBlogPublished(blog.id, next)}
+      />
+    </div>
+  </div>
+);
 
 export const BlogTable: FC<{ blogs: BlogRecord[] }> = ({ blogs }) => {
   if (blogs.length === 0) {

--- a/apps/admin/src/app/(authenticated)/comments/_components/comment-actions/comment-actions.tsx
+++ b/apps/admin/src/app/(authenticated)/comments/_components/comment-actions/comment-actions.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { Button, Dialog, Modal, useToast } from '@k8o/arte-odyssey';
+import { Button, useToast } from '@k8o/arte-odyssey';
 import { useAsyncAction } from '@repo/react-hooks/use-async-action';
 import { type FC, useState } from 'react';
 
+import { ConfirmDialog } from '@/app/(authenticated)/_components';
 import { deleteComment } from '@/features/comments/interface/actions';
 
 type Props = {
@@ -39,47 +40,21 @@ export const CommentActions: FC<Props> = ({ id }) => {
       >
         削除
       </Button>
-      <Modal
+      <ConfirmDialog
+        confirmLabel="削除する"
         isOpen={open}
+        isPending={isPending}
         onClose={() => {
           setOpen(false);
         }}
+        onConfirm={handleDelete}
+        pendingLabel="削除中..."
+        title="コメントの削除"
       >
-        <Dialog.Root>
-          <Dialog.Header
-            onClose={() => {
-              setOpen(false);
-            }}
-            title="コメントの削除"
-          />
-          <Dialog.Content>
-            <div className="flex flex-col gap-6">
-              <p className="text-sm">
-                このコメントを削除しますか？この操作は取り消せません。
-              </p>
-              <div className="flex justify-end gap-3">
-                <Button
-                  color="gray"
-                  onClick={() => {
-                    setOpen(false);
-                  }}
-                  variant="outline"
-                >
-                  キャンセル
-                </Button>
-                <Button
-                  color="primary"
-                  disabled={isPending}
-                  onClick={handleDelete}
-                  variant="solid"
-                >
-                  {isPending ? '削除中...' : '削除する'}
-                </Button>
-              </div>
-            </div>
-          </Dialog.Content>
-        </Dialog.Root>
-      </Modal>
+        <p className="text-sm">
+          このコメントを削除しますか？この操作は取り消せません。
+        </p>
+      </ConfirmDialog>
     </>
   );
 };

--- a/apps/admin/src/app/(authenticated)/notifications/_components/push-send-form/push-send-form.tsx
+++ b/apps/admin/src/app/(authenticated)/notifications/_components/push-send-form/push-send-form.tsx
@@ -1,17 +1,10 @@
 'use client';
 
-import {
-  Button,
-  Card,
-  Dialog,
-  Modal,
-  TextField,
-  Textarea,
-  useToast,
-} from '@k8o/arte-odyssey';
+import { Button, Card, TextField, Textarea, useToast } from '@k8o/arte-odyssey';
 import { useAsyncAction } from '@repo/react-hooks/use-async-action';
 import { type ChangeEvent, type FC, useState } from 'react';
 
+import { ConfirmDialog } from '@/app/(authenticated)/_components';
 import {
   type ManualPushActionState,
   sendManualPushAction,
@@ -94,47 +87,21 @@ export const PushSendForm: FC = () => {
           </Button>
         </div>
       </div>
-      <Modal
+      <ConfirmDialog
+        confirmLabel="送信する"
         isOpen={open}
+        isPending={isPending}
         onClose={() => {
           setOpen(false);
         }}
+        onConfirm={handleSend}
+        pendingLabel="送信中..."
+        title="プッシュ通知の送信"
       >
-        <Dialog.Root>
-          <Dialog.Header
-            onClose={() => {
-              setOpen(false);
-            }}
-            title="プッシュ通知の送信"
-          />
-          <Dialog.Content>
-            <div className="flex flex-col gap-6">
-              <p className="text-sm">
-                全購読者へ「{title}」を送信します。よろしいですか？
-              </p>
-              <div className="flex justify-end gap-3">
-                <Button
-                  color="gray"
-                  onClick={() => {
-                    setOpen(false);
-                  }}
-                  variant="outline"
-                >
-                  キャンセル
-                </Button>
-                <Button
-                  color="primary"
-                  disabled={isPending}
-                  onClick={handleSend}
-                  variant="solid"
-                >
-                  {isPending ? '送信中...' : '送信する'}
-                </Button>
-              </div>
-            </div>
-          </Dialog.Content>
-        </Dialog.Root>
-      </Modal>
+        <p className="text-sm">
+          全購読者へ「{title}」を送信します。よろしいですか？
+        </p>
+      </ConfirmDialog>
     </Card>
   );
 };

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/add-article-link/add-article-link.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/add-article-link/add-article-link.tsx
@@ -1,20 +1,16 @@
 'use client';
 
-import { Button } from '@k8o/arte-odyssey';
-import Link from 'next/link';
 import type { FC } from 'react';
 
+import { ButtonLink } from '@/app/(authenticated)/_components';
+
 export const AddArticleLink: FC = () => (
-  <Button
+  <ButtonLink
     color="gray"
-    renderItem={({ className, children }) => (
-      <Link className={className} href="/reading-list/articles/new">
-        {children}
-      </Link>
-    )}
+    href="/reading-list/articles/new"
     size="sm"
     variant="outline"
   >
     記事を追加
-  </Button>
+  </ButtonLink>
 );

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/add-source-link/add-source-link.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/add-source-link/add-source-link.tsx
@@ -1,20 +1,16 @@
 'use client';
 
-import { Button } from '@k8o/arte-odyssey';
-import Link from 'next/link';
 import type { FC } from 'react';
 
+import { ButtonLink } from '@/app/(authenticated)/_components';
+
 export const AddSourceLink: FC = () => (
-  <Button
+  <ButtonLink
     color="primary"
-    renderItem={({ className, children }) => (
-      <Link className={className} href="/reading-list/sources/new">
-        {children}
-      </Link>
-    )}
+    href="/reading-list/sources/new"
     size="sm"
     variant="solid"
   >
     追加
-  </Button>
+  </ButtonLink>
 );

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/article-form/article-form.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/article-form/article-form.tsx
@@ -5,11 +5,11 @@ import {
   Button,
   FormControl,
   Select,
-  TextField,
   Textarea,
 } from '@k8o/arte-odyssey';
 import { type FC, useActionState } from 'react';
 
+import { LabeledTextField } from '@/app/(authenticated)/_components';
 import type { ActionState } from '@/shared/actions/action-state';
 
 type SourceOption = { id: number; title: string };
@@ -59,41 +59,26 @@ export const ArticleForm: FC<ArticleFormProps> = ({
           )}
         />
       )}
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.title ?? ''}
         label="タイトル"
+        name="title"
+        placeholder="記事タイトル"
         required
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            {...props}
-            defaultValue={defaultValues?.title ?? ''}
-            name="title"
-            placeholder="記事タイトル"
-          />
-        )}
       />
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.url ?? ''}
         label="URL"
+        name="url"
+        placeholder="https://example.com/article"
         required
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            {...props}
-            defaultValue={defaultValues?.url ?? ''}
-            name="url"
-            placeholder="https://example.com/article"
-          />
-        )}
       />
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.publishedAt ?? ''}
         label="公開日 (YYYY-MM-DD)"
+        name="publishedAt"
+        placeholder="2025-06-01"
         required
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            {...props}
-            defaultValue={defaultValues?.publishedAt ?? ''}
-            name="publishedAt"
-            placeholder="2025-06-01"
-          />
-        )}
       />
       <FormControl
         label="説明"

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/article-table/article-table.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/article-table/article-table.tsx
@@ -1,12 +1,12 @@
 'use client';
 
-import { Button, Card, Dialog, Modal, useToast } from '@k8o/arte-odyssey';
+import { Button, Card, useToast } from '@k8o/arte-odyssey';
 import { formatDate } from '@repo/helpers/date/format';
 import { useAsyncAction } from '@repo/react-hooks/use-async-action';
 import Link from 'next/link';
 import { type FC, useState } from 'react';
 
-import { EmptyState } from '@/app/(authenticated)/_components';
+import { ConfirmDialog, EmptyState } from '@/app/(authenticated)/_components';
 import {
   deleteArticle,
   refetchArticleMetadata,
@@ -68,48 +68,22 @@ const DeleteButton: FC<{ id: number; title: string }> = ({ id, title }) => {
       >
         削除
       </Button>
-      <Modal
+      <ConfirmDialog
+        confirmLabel="削除する"
         isOpen={open}
+        isPending={isPending}
         onClose={() => {
           setOpen(false);
         }}
+        onConfirm={handleDelete}
+        pendingLabel="削除中..."
+        title="取得済み記事の削除"
       >
-        <Dialog.Root>
-          <Dialog.Header
-            onClose={() => {
-              setOpen(false);
-            }}
-            title="取得済み記事の削除"
-          />
-          <Dialog.Content>
-            <div className="flex flex-col gap-6">
-              <p className="text-sm">「{title}」を削除しますか？</p>
-              {error !== undefined && (
-                <p className="text-fg-error text-sm">{error}</p>
-              )}
-              <div className="flex justify-end gap-3">
-                <Button
-                  color="gray"
-                  onClick={() => {
-                    setOpen(false);
-                  }}
-                  variant="outline"
-                >
-                  キャンセル
-                </Button>
-                <Button
-                  color="primary"
-                  disabled={isPending}
-                  onClick={handleDelete}
-                  variant="solid"
-                >
-                  {isPending ? '削除中...' : '削除する'}
-                </Button>
-              </div>
-            </div>
-          </Dialog.Content>
-        </Dialog.Root>
-      </Modal>
+        <p className="text-sm">「{title}」を削除しますか？</p>
+        {error !== undefined && (
+          <p className="text-fg-error text-sm">{error}</p>
+        )}
+      </ConfirmDialog>
     </>
   );
 };

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/article-table/article-table.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/article-table/article-table.tsx
@@ -3,10 +3,14 @@
 import { Button, Card, useToast } from '@k8o/arte-odyssey';
 import { formatDate } from '@repo/helpers/date/format';
 import { useAsyncAction } from '@repo/react-hooks/use-async-action';
-import Link from 'next/link';
+import type { Route } from 'next';
 import { type FC, useState } from 'react';
 
-import { ConfirmDialog, EmptyState } from '@/app/(authenticated)/_components';
+import {
+  ButtonLink,
+  ConfirmDialog,
+  EmptyState,
+} from '@/app/(authenticated)/_components';
 import {
   deleteArticle,
   refetchArticleMetadata,
@@ -115,21 +119,14 @@ export const ArticleTable: FC<{ articles: Article[] }> = ({ articles }) => {
             {formatDate(new Date(article.publishedAt))}
           </span>
           <div className="flex shrink-0 items-center gap-1">
-            <Button
+            <ButtonLink
               color="gray"
-              renderItem={({ className, children }) => (
-                <Link
-                  className={className}
-                  href={`/reading-list/articles/${String(article.id)}`}
-                >
-                  {children}
-                </Link>
-              )}
+              href={`/reading-list/articles/${String(article.id)}` as Route}
               size="sm"
               variant="skeleton"
             >
               編集
-            </Button>
+            </ButtonLink>
             <RefetchButton id={article.id} />
             <DeleteButton id={article.id} title={article.title} />
           </div>

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/delete-source-button/delete-source-button.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/delete-source-button/delete-source-button.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { Button, Dialog, Modal } from '@k8o/arte-odyssey';
+import { Button } from '@k8o/arte-odyssey';
 import { useAsyncAction } from '@repo/react-hooks/use-async-action';
 import { useState } from 'react';
 
+import { ConfirmDialog } from '@/app/(authenticated)/_components';
 import { deleteSource } from '@/features/reading-list/interface/source-actions';
 
 export const DeleteSourceButton = ({
@@ -32,50 +33,24 @@ export const DeleteSourceButton = ({
       >
         削除
       </Button>
-      <Modal
+      <ConfirmDialog
+        confirmLabel="削除する"
         isOpen={open}
+        isPending={isPending}
         onClose={() => {
           setOpen(false);
         }}
+        onConfirm={handleDelete}
+        pendingLabel="削除中..."
+        title="ソースの削除"
       >
-        <Dialog.Root>
-          <Dialog.Header
-            onClose={() => {
-              setOpen(false);
-            }}
-            title="ソースの削除"
-          />
-          <Dialog.Content>
-            <div className="flex flex-col gap-6">
-              <p className="text-sm">
-                「{title}」を削除しますか？この操作は取り消せません。
-              </p>
-              {error !== undefined && (
-                <p className="text-fg-error text-sm">{error}</p>
-              )}
-              <div className="flex justify-end gap-3">
-                <Button
-                  color="gray"
-                  onClick={() => {
-                    setOpen(false);
-                  }}
-                  variant="outline"
-                >
-                  キャンセル
-                </Button>
-                <Button
-                  color="primary"
-                  disabled={isPending}
-                  onClick={handleDelete}
-                  variant="solid"
-                >
-                  {isPending ? '削除中...' : '削除する'}
-                </Button>
-              </div>
-            </div>
-          </Dialog.Content>
-        </Dialog.Root>
-      </Modal>
+        <p className="text-sm">
+          「{title}」を削除しますか？この操作は取り消せません。
+        </p>
+        {error !== undefined && (
+          <p className="text-fg-error text-sm">{error}</p>
+        )}
+      </ConfirmDialog>
     </>
   );
 };

--- a/apps/admin/src/app/(authenticated)/reading-list/_components/source-form/source-form.tsx
+++ b/apps/admin/src/app/(authenticated)/reading-list/_components/source-form/source-form.tsx
@@ -1,14 +1,9 @@
 'use client';
 
-import {
-  Alert,
-  Button,
-  FormControl,
-  Radio,
-  TextField,
-} from '@k8o/arte-odyssey';
+import { Alert, Button, FormControl, Radio } from '@k8o/arte-odyssey';
 import { useActionState, useState } from 'react';
 
+import { LabeledTextField } from '@/app/(authenticated)/_components';
 import type { ActionState } from '@/shared/actions/action-state';
 
 type SourceFormProps = {
@@ -40,41 +35,26 @@ export const SourceForm = ({ action, defaultValues }: SourceFormProps) => {
       {state.error !== undefined && (
         <Alert message={state.error} tone="error" />
       )}
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.title ?? ''}
         label="タイトル"
+        name="title"
+        placeholder="例: Zenn"
         required
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            defaultValue={defaultValues?.title ?? ''}
-            name="title"
-            placeholder="例: Zenn"
-            {...props}
-          />
-        )}
       />
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.url ?? ''}
         label="フィードURL"
+        name="url"
+        placeholder="例: https://zenn.dev/feed"
         required
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            defaultValue={defaultValues?.url ?? ''}
-            name="url"
-            placeholder="例: https://zenn.dev/feed"
-            {...props}
-          />
-        )}
       />
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.siteUrl ?? ''}
         label="サイトURL"
+        name="siteUrl"
+        placeholder="例: https://zenn.dev"
         required
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            defaultValue={defaultValues?.siteUrl ?? ''}
-            name="siteUrl"
-            placeholder="例: https://zenn.dev"
-            {...props}
-          />
-        )}
       />
       <FormControl
         label="タイプ"

--- a/apps/admin/src/app/(authenticated)/slides/_components/slide-table/slide-table.tsx
+++ b/apps/admin/src/app/(authenticated)/slides/_components/slide-table/slide-table.tsx
@@ -1,64 +1,41 @@
 'use client';
 
-import { Badge, Card, Switch, useToast } from '@k8o/arte-odyssey';
-import { useAsyncAction } from '@repo/react-hooks/use-async-action';
-import { type FC, useState } from 'react';
+import { Badge, Card } from '@k8o/arte-odyssey';
+import type { FC } from 'react';
 
-import { EmptyState } from '@/app/(authenticated)/_components';
+import { EmptyState, PublishToggle } from '@/app/(authenticated)/_components';
 import { setSlidePublished } from '@/features/slides/interface/actions';
 import type { SlideRecord } from '@/features/slides/interface/queries';
 
 const SLIDE_BASE_URL = 'https://k8o.me/slides';
 
-const SlideRow: FC<{ slide: SlideRecord }> = ({ slide }) => {
-  const [published, setPublished] = useState(slide.published);
-  const { isPending, run } = useAsyncAction();
-  const { onOpen } = useToast();
-
-  const handleToggle = (checked: boolean): void => {
-    const next = checked;
-    setPublished(next);
-    run(() => setSlidePublished(slide.id, next), {
-      onError: (message) => {
-        setPublished(!next);
-        onOpen('error', message);
-      },
-      onSuccess: () => {
-        onOpen('success', next ? '公開しました' : '下書きに戻しました');
-      },
-    });
-  };
-
-  return (
-    <div className="border-border-mute flex items-center gap-3 border-b px-5 py-4 text-sm last:border-b-0">
-      <div className="flex min-w-0 flex-1 flex-col gap-1">
-        <a
-          className="truncate font-medium hover:underline"
-          href={`${SLIDE_BASE_URL}/${slide.slug}`}
-          rel="noopener noreferrer"
-          target="_blank"
-        >
-          {slide.slug}
-        </a>
-        {slide.tags.length > 0 && (
-          <div className="flex flex-wrap gap-1">
-            {slide.tags.map((tag) => (
-              <Badge key={tag} size="sm" text={tag} tone="neutral" />
-            ))}
-          </div>
-        )}
-      </div>
-      <div className="flex w-24 shrink-0 justify-end">
-        <Switch
-          disabled={isPending}
-          label={published ? '公開' : '下書き'}
-          onChange={handleToggle}
-          value={published}
-        />
-      </div>
+const SlideRow: FC<{ slide: SlideRecord }> = ({ slide }) => (
+  <div className="border-border-mute flex items-center gap-3 border-b px-5 py-4 text-sm last:border-b-0">
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+      <a
+        className="truncate font-medium hover:underline"
+        href={`${SLIDE_BASE_URL}/${slide.slug}`}
+        rel="noopener noreferrer"
+        target="_blank"
+      >
+        {slide.slug}
+      </a>
+      {slide.tags.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {slide.tags.map((tag) => (
+            <Badge key={tag} size="sm" text={tag} tone="neutral" />
+          ))}
+        </div>
+      )}
     </div>
-  );
-};
+    <div className="flex w-24 shrink-0 justify-end">
+      <PublishToggle
+        initialPublished={slide.published}
+        onToggle={(next) => setSlidePublished(slide.id, next)}
+      />
+    </div>
+  </div>
+);
 
 export const SlideTable: FC<{ slides: SlideRecord[] }> = ({ slides }) => {
   if (slides.length === 0) {

--- a/apps/admin/src/app/(authenticated)/tags/_components/tag-list/tag-list.tsx
+++ b/apps/admin/src/app/(authenticated)/tags/_components/tag-list/tag-list.tsx
@@ -1,18 +1,10 @@
 'use client';
 
-import {
-  Badge,
-  Button,
-  Card,
-  Dialog,
-  Modal,
-  TextField,
-  useToast,
-} from '@k8o/arte-odyssey';
+import { Badge, Button, Card, TextField, useToast } from '@k8o/arte-odyssey';
 import { useAsyncAction } from '@repo/react-hooks/use-async-action';
 import { type ChangeEvent, type FC, useState } from 'react';
 
-import { EmptyState } from '@/app/(authenticated)/_components';
+import { ConfirmDialog, EmptyState } from '@/app/(authenticated)/_components';
 import { deleteTag, renameTag } from '@/features/tags/interface/actions';
 import type { TagWithUsage } from '@/features/tags/interface/queries';
 
@@ -86,76 +78,38 @@ const TagRow: FC<{ tag: TagWithUsage }> = ({ tag }) => {
         削除
       </Button>
 
-      <Modal isOpen={renameOpen} onClose={closeRename}>
-        <Dialog.Root>
-          <Dialog.Header onClose={closeRename} title="タグ名の変更" />
-          <Dialog.Content>
-            <div className="flex flex-col gap-6">
-              <TextField
-                aria-label="新しいタグ名"
-                onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                  setName(e.target.value);
-                }}
-                size={28}
-                value={name}
-              />
-              <div className="flex justify-end gap-3">
-                <Button color="gray" onClick={closeRename} variant="outline">
-                  キャンセル
-                </Button>
-                <Button
-                  color="primary"
-                  disabled={isPending}
-                  onClick={handleRename}
-                  variant="solid"
-                >
-                  {isPending ? '保存中...' : '保存'}
-                </Button>
-              </div>
-            </div>
-          </Dialog.Content>
-        </Dialog.Root>
-      </Modal>
+      <ConfirmDialog
+        confirmLabel="保存"
+        isOpen={renameOpen}
+        isPending={isPending}
+        onClose={closeRename}
+        onConfirm={handleRename}
+        pendingLabel="保存中..."
+        title="タグ名の変更"
+      >
+        <TextField
+          aria-label="新しいタグ名"
+          onChange={(e: ChangeEvent<HTMLInputElement>) => {
+            setName(e.target.value);
+          }}
+          size={28}
+          value={name}
+        />
+      </ConfirmDialog>
 
-      <Modal
+      <ConfirmDialog
+        confirmLabel="削除する"
         isOpen={deleteOpen}
+        isPending={isPending}
         onClose={() => {
           setDeleteOpen(false);
         }}
+        onConfirm={handleDelete}
+        pendingLabel="削除中..."
+        title="タグの削除"
       >
-        <Dialog.Root>
-          <Dialog.Header
-            onClose={() => {
-              setDeleteOpen(false);
-            }}
-            title="タグの削除"
-          />
-          <Dialog.Content>
-            <div className="flex flex-col gap-6">
-              <p className="text-sm">「{tag.name}」を削除しますか？</p>
-              <div className="flex justify-end gap-3">
-                <Button
-                  color="gray"
-                  onClick={() => {
-                    setDeleteOpen(false);
-                  }}
-                  variant="outline"
-                >
-                  キャンセル
-                </Button>
-                <Button
-                  color="primary"
-                  disabled={isPending}
-                  onClick={handleDelete}
-                  variant="solid"
-                >
-                  {isPending ? '削除中...' : '削除する'}
-                </Button>
-              </div>
-            </div>
-          </Dialog.Content>
-        </Dialog.Root>
-      </Modal>
+        <p className="text-sm">「{tag.name}」を削除しますか？</p>
+      </ConfirmDialog>
     </div>
   );
 };

--- a/apps/admin/src/app/(authenticated)/talks/_components/add-talk-link/add-talk-link.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/_components/add-talk-link/add-talk-link.tsx
@@ -1,20 +1,11 @@
 'use client';
 
-import { Button } from '@k8o/arte-odyssey';
-import Link from 'next/link';
 import type { FC } from 'react';
 
+import { ButtonLink } from '@/app/(authenticated)/_components';
+
 export const AddTalkLink: FC = () => (
-  <Button
-    color="primary"
-    renderItem={({ className, children }) => (
-      <Link className={className} href="/talks/new">
-        {children}
-      </Link>
-    )}
-    size="sm"
-    variant="solid"
-  >
+  <ButtonLink color="primary" href="/talks/new" size="sm" variant="solid">
     トークを追加
-  </Button>
+  </ButtonLink>
 );

--- a/apps/admin/src/app/(authenticated)/talks/_components/talk-form/talk-form.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/_components/talk-form/talk-form.tsx
@@ -1,14 +1,9 @@
 'use client';
 
-import {
-  Alert,
-  Button,
-  FormControl,
-  Select,
-  TextField,
-} from '@k8o/arte-odyssey';
+import { Alert, Button, FormControl, Select } from '@k8o/arte-odyssey';
 import { type FC, useActionState } from 'react';
 
+import { LabeledTextField } from '@/app/(authenticated)/_components';
 import type { BlogOption } from '@/features/talks/interface/queries';
 import type { ActionState } from '@/shared/actions/action-state';
 
@@ -43,76 +38,46 @@ export const TalkForm: FC<TalkFormProps> = ({
       {state.error !== undefined && (
         <Alert message={state.error} tone="error" />
       )}
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.title ?? ''}
         label="タイトル"
+        name="title"
+        placeholder="登壇タイトル"
         required
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            {...props}
-            defaultValue={defaultValues?.title ?? ''}
-            name="title"
-            placeholder="登壇タイトル"
-          />
-        )}
       />
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.eventName ?? ''}
         label="イベント名"
+        name="eventName"
+        placeholder="例: Kyoto.js"
         required
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            {...props}
-            defaultValue={defaultValues?.eventName ?? ''}
-            name="eventName"
-            placeholder="例: Kyoto.js"
-          />
-        )}
       />
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.eventDate ?? ''}
         label="開催日 (YYYY-MM-DD)"
+        name="eventDate"
+        placeholder="2025-06-01"
         required
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            {...props}
-            defaultValue={defaultValues?.eventDate ?? ''}
-            name="eventDate"
-            placeholder="2025-06-01"
-          />
-        )}
       />
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.eventLocation ?? ''}
         label="開催地"
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            {...props}
-            defaultValue={defaultValues?.eventLocation ?? ''}
-            name="eventLocation"
-            placeholder="例: 京都 / オンライン"
-          />
-        )}
+        name="eventLocation"
+        placeholder="例: 京都 / オンライン"
       />
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.eventUrl ?? ''}
         label="イベントURL"
+        name="eventUrl"
+        placeholder="https://example.com/event"
         required
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            {...props}
-            defaultValue={defaultValues?.eventUrl ?? ''}
-            name="eventUrl"
-            placeholder="https://example.com/event"
-          />
-        )}
       />
-      <FormControl
+      <LabeledTextField
+        defaultValue={defaultValues?.slideUrl ?? ''}
         label="スライドURL"
+        name="slideUrl"
+        placeholder="https://example.com/slides"
         required
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <TextField
-            {...props}
-            defaultValue={defaultValues?.slideUrl ?? ''}
-            name="slideUrl"
-            placeholder="https://example.com/slides"
-          />
-        )}
       />
       <FormControl
         label="紐づけるブログ"

--- a/apps/admin/src/app/(authenticated)/talks/_components/talk-list/talk-list.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/_components/talk-list/talk-list.tsx
@@ -3,10 +3,14 @@
 import { Badge, Button, Card, useToast } from '@k8o/arte-odyssey';
 import { formatDate } from '@repo/helpers/date/format';
 import { useAsyncAction } from '@repo/react-hooks/use-async-action';
-import Link from 'next/link';
+import type { Route } from 'next';
 import { type FC, useState } from 'react';
 
-import { ConfirmDialog, EmptyState } from '@/app/(authenticated)/_components';
+import {
+  ButtonLink,
+  ConfirmDialog,
+  EmptyState,
+} from '@/app/(authenticated)/_components';
 import { deleteTalk } from '@/features/talks/interface/actions';
 import type { TalkRecord } from '@/features/talks/interface/queries';
 
@@ -39,18 +43,14 @@ const TalkRow: FC<{ talk: TalkRecord }> = ({ talk }) => {
           {talk.title}
         </a>
         <div className="flex shrink-0 items-center gap-1">
-          <Button
+          <ButtonLink
             color="gray"
-            renderItem={({ className, children }) => (
-              <Link className={className} href={`/talks/${String(talk.id)}`}>
-                {children}
-              </Link>
-            )}
+            href={`/talks/${String(talk.id)}` as Route}
             size="sm"
             variant="skeleton"
           >
             編集
-          </Button>
+          </ButtonLink>
           <Button
             color="gray"
             onClick={() => {

--- a/apps/admin/src/app/(authenticated)/talks/_components/talk-list/talk-list.tsx
+++ b/apps/admin/src/app/(authenticated)/talks/_components/talk-list/talk-list.tsx
@@ -1,19 +1,12 @@
 'use client';
 
-import {
-  Badge,
-  Button,
-  Card,
-  Dialog,
-  Modal,
-  useToast,
-} from '@k8o/arte-odyssey';
+import { Badge, Button, Card, useToast } from '@k8o/arte-odyssey';
 import { formatDate } from '@repo/helpers/date/format';
 import { useAsyncAction } from '@repo/react-hooks/use-async-action';
 import Link from 'next/link';
 import { type FC, useState } from 'react';
 
-import { EmptyState } from '@/app/(authenticated)/_components';
+import { ConfirmDialog, EmptyState } from '@/app/(authenticated)/_components';
 import { deleteTalk } from '@/features/talks/interface/actions';
 import type { TalkRecord } from '@/features/talks/interface/queries';
 
@@ -85,45 +78,19 @@ const TalkRow: FC<{ talk: TalkRecord }> = ({ talk }) => {
         </div>
       )}
 
-      <Modal
+      <ConfirmDialog
+        confirmLabel="削除する"
         isOpen={open}
+        isPending={isPending}
         onClose={() => {
           setOpen(false);
         }}
+        onConfirm={handleDelete}
+        pendingLabel="削除中..."
+        title="トークの削除"
       >
-        <Dialog.Root>
-          <Dialog.Header
-            onClose={() => {
-              setOpen(false);
-            }}
-            title="トークの削除"
-          />
-          <Dialog.Content>
-            <div className="flex flex-col gap-6">
-              <p className="text-sm">「{talk.title}」を削除しますか？</p>
-              <div className="flex justify-end gap-3">
-                <Button
-                  color="gray"
-                  onClick={() => {
-                    setOpen(false);
-                  }}
-                  variant="outline"
-                >
-                  キャンセル
-                </Button>
-                <Button
-                  color="primary"
-                  disabled={isPending}
-                  onClick={handleDelete}
-                  variant="solid"
-                >
-                  {isPending ? '削除中...' : '削除する'}
-                </Button>
-              </div>
-            </div>
-          </Dialog.Content>
-        </Dialog.Root>
-      </Modal>
+        <p className="text-sm">「{talk.title}」を削除しますか？</p>
+      </ConfirmDialog>
     </div>
   );
 };


### PR DESCRIPTION
## 概要

[#1861](https://github.com/k35o/k8o/pull/1861) の派生フォローアップ。admin に散在していた UI 重複を共有コンポーネントへ集約する。各コミットは独立して revert 可能。マークアップは各画面で一致を保持しているため **VRT への影響は無い想定**（Story の play テストで描画・操作を確認済み）。

ネットで **-147 行**（414 insertions / 561 deletions, 23 files）。

## 変更（コミット単位）

### ConfirmDialog（削除/送信確認モーダル）
6画面・7モーダルでほぼ同一だった `Modal + Dialog.Root/Header/Content` の確認モーダル骨格を `app/(authenticated)/_components/confirm-dialog` に集約。本文は `children` で渡し、確定ボタンの文言・pending 表示・インラインエラーの差分を吸収。
- comment-actions / delete-source-button / article-table / talk-list / push-send-form / tag-list（rename + delete）

### ButtonLink（Button as next/link）
`Button + renderItem→Link` のボイラープレートを `button-link` に集約。
- add-talk/source/article-link、talk-list / article-table の編集導線
- 動的 href は既存慣習に合わせ `as Route` でキャスト

### PublishToggle（公開トグル）
楽観的更新（失敗時に状態を戻す）を含む公開/下書きトグルのロジックを `publish-toggle` に集約。BlogRow / SlideRow は行レイアウトのみの薄い表示に。

### LabeledTextField（フォームのテキスト入力）
`FormControl + renderInput→TextField` の定型を `labeled-text-field` に集約（source / article / talk フォームの計12箇所）。Select / Textarea / Radio は従来どおり FormControl を直接利用。

## 検証

- `pnpm run type-check`（全7ワークスペース成功）
- `pnpm run check`（lint/format 0 errors）
- Story の play テスト: delete-source-button / article-table（ConfirmDialog・ButtonLink）、blog-table（PublishToggle）、source-form（LabeledTextField）
- `pnpm run knip`（本PRによる新規の未使用検出なし）
- ユニットテスト: helpers 150 / main 55 / admin 33 すべて pass

## design-system 利用について

AGENTS.md の Storybook MCP 確認方針に従い admin-storybook-mcp を参照（`get-documentation` はサーバ側の `storybookId` 必須パラメータがツールスキーマに無く取得不可だったため、**既存の動作する本番コードのコンポーネント利用を 1:1 で踏襲**し、新しい props 推測は行っていない）。各共有コンポーネントは既存の検証済み JSX をそのまま内包するため、描画は不変。

## 見送り
- ListCard（各テーブル/リストの行レイアウト共通化）: 行ごとにカラム・内容が大きく異なり、共通化すると過度な抽象になるため見送り。

## レビュー時の注意
- VRT は main ベースラインとの CI 比較でご確認ください（マークアップ一致のため差分は出ない想定）。