### PR TITLE
fix: モックDBの dialect を libsql に修正

### DIFF
--- a/packages/database/src/__mocks__/db.ts
+++ b/packages/database/src/__mocks__/db.ts
@@ -1,5 +1,5 @@
 import { type AnyColumn, sql } from 'drizzle-orm';
-import { drizzle } from 'drizzle-orm/neon-serverless';
+import { drizzle } from 'drizzle-orm/libsql';
 
 import { relations, schema } from '../schema';
 


### PR DESCRIPTION
## 概要

`__mocks__/db.ts` が `drizzle-orm/neon-serverless`(PostgreSQL 方言)を使っていたため、Storybook / テストが本番（`libsql` / SQLite）と異なる SQL 方言で動いていた。本番と同じ `drizzle-orm/libsql` の `drizzle.mock()` に揃える（1行修正）。

## 経緯
当初このPRには公開書き込みエンドポイントのレート制限も含めていたが、

- サイトのアクセス量が少なく費用対効果が低い
- 本番は Cloudflare 経由のため、アプリ層での IP 識別が不安定（IP が Cloudflare の IP に潰れると全ユーザーが同一バケットに集約され、正規ユーザーまでブロックされる事故が起きやすい）

との判断で**レート制限は取り下げ**、モック方言修正のみに縮小した。必要になればエッジ（Cloudflare Rate Limiting Rules）側で実施するのが適切。

## 検証
- `pnpm run type-check` 成功
- モックDBを読み込む Storybook テスト（例: admin BlogTable）pass