### PR TITLE
test: セキュリティ/認可ロジックのテスト追加 + GitHubグラフのSuspense化

### DIFF
--- a/apps/admin/src/shared/auth/verify-cron-request.test.ts
+++ b/apps/admin/src/shared/auth/verify-cron-request.test.ts
@@ -20,7 +20,14 @@ describe('isAuthorizedCronRequest', () => {
   });
 
   describe('異常系', () => {
-    it('CRON_SECRET 未設定なら常に不許可', () => {
+    it('CRON_SECRET が未設定なら常に不許可', () => {
+      vi.stubEnv('CRON_SECRET', undefined);
+      expect(isAuthorizedCronRequest(makeRequest('Bearer anything'))).toBe(
+        false,
+      );
+    });
+
+    it('CRON_SECRET が空文字なら常に不許可', () => {
       vi.stubEnv('CRON_SECRET', '');
       expect(isAuthorizedCronRequest(makeRequest('Bearer anything'))).toBe(
         false,

--- a/apps/admin/src/shared/auth/verify-cron-request.test.ts
+++ b/apps/admin/src/shared/auth/verify-cron-request.test.ts
@@ -1,0 +1,45 @@
+import { isAuthorizedCronRequest } from './verify-cron-request';
+
+const makeRequest = (authHeader?: string): Request =>
+  new Request('https://admin.k8o.localhost/api/crons/sync', {
+    headers: authHeader === undefined ? {} : { Authorization: authHeader },
+  });
+
+describe('isAuthorizedCronRequest', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('正常系', () => {
+    it('正しい Bearer トークンを許可する', () => {
+      vi.stubEnv('CRON_SECRET', 'super-secret');
+      expect(isAuthorizedCronRequest(makeRequest('Bearer super-secret'))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe('異常系', () => {
+    it('CRON_SECRET 未設定なら常に不許可', () => {
+      vi.stubEnv('CRON_SECRET', '');
+      expect(isAuthorizedCronRequest(makeRequest('Bearer anything'))).toBe(
+        false,
+      );
+    });
+
+    it('Authorization ヘッダが無ければ不許可', () => {
+      vi.stubEnv('CRON_SECRET', 'super-secret');
+      expect(isAuthorizedCronRequest(makeRequest())).toBe(false);
+    });
+
+    it('誤ったトークンは不許可', () => {
+      vi.stubEnv('CRON_SECRET', 'super-secret');
+      expect(isAuthorizedCronRequest(makeRequest('Bearer wrong'))).toBe(false);
+    });
+
+    it('Bearer プレフィックスが無いと不許可', () => {
+      vi.stubEnv('CRON_SECRET', 'super-secret');
+      expect(isAuthorizedCronRequest(makeRequest('super-secret'))).toBe(false);
+    });
+  });
+});

--- a/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.tsx
@@ -1,9 +1,30 @@
+import { Card } from '@k8o/arte-odyssey';
+import { Suspense } from 'react';
+
 import { getUserContributions } from '@/features/github/interface/queries';
 
 import { Presenter } from './presenter';
 
-export const GitHubContributionGraph = async () => {
+// Presenter のカード構造（ヘッダ / h-48 のチャート / フッタ）に合わせた骨組み。
+// 取得が遅い GitHub API を待つ間にページ全体の描画をブロックしないための fallback。
+const Skeleton = () => (
+  <Card>
+    <div className="flex flex-col gap-4 p-6">
+      <div className="bg-bg-mute h-5 w-32 animate-pulse rounded" />
+      <div className="bg-bg-mute h-48 animate-pulse rounded" />
+      <div className="bg-bg-mute h-4 w-24 animate-pulse rounded" />
+    </div>
+  </Card>
+);
+
+const GitHubContributionGraphContent = async () => {
   const days = await getUserContributions();
 
   return <Presenter days={days} />;
 };
+
+export const GitHubContributionGraph = () => (
+  <Suspense fallback={<Skeleton />}>
+    <GitHubContributionGraphContent />
+  </Suspense>
+);

--- a/apps/main/src/features/push-notification/application/push-keys.test.ts
+++ b/apps/main/src/features/push-notification/application/push-keys.test.ts
@@ -1,0 +1,45 @@
+import { isValidPushKeys } from './push-keys';
+
+const validP256dh = Buffer.concat([
+  Buffer.from([0x04]),
+  Buffer.alloc(64),
+]).toString('base64url');
+const validAuth = Buffer.alloc(16).toString('base64url');
+
+describe('isValidPushKeys', () => {
+  describe('正常系', () => {
+    it('正しい形式の鍵を許可する', () => {
+      expect(isValidPushKeys(validP256dh, validAuth)).toBe(true);
+    });
+
+    it('auth は最大32バイトまで許可する', () => {
+      const auth32 = Buffer.alloc(32).toString('base64url');
+      expect(isValidPushKeys(validP256dh, auth32)).toBe(true);
+    });
+  });
+
+  describe('異常系', () => {
+    it('p256dh が65バイトでないと不許可', () => {
+      const short = Buffer.alloc(64).toString('base64url');
+      expect(isValidPushKeys(short, validAuth)).toBe(false);
+    });
+
+    it('p256dh の先頭が 0x04 でないと不許可', () => {
+      const bad = Buffer.concat([
+        Buffer.from([0x05]),
+        Buffer.alloc(64),
+      ]).toString('base64url');
+      expect(isValidPushKeys(bad, validAuth)).toBe(false);
+    });
+
+    it('auth が16バイト未満だと不許可', () => {
+      const short = Buffer.alloc(15).toString('base64url');
+      expect(isValidPushKeys(validP256dh, short)).toBe(false);
+    });
+
+    it('auth が32バイト超だと不許可', () => {
+      const long = Buffer.alloc(33).toString('base64url');
+      expect(isValidPushKeys(validP256dh, long)).toBe(false);
+    });
+  });
+});

--- a/apps/main/src/features/push-notification/application/push-keys.ts
+++ b/apps/main/src/features/push-notification/application/push-keys.ts
@@ -1,0 +1,13 @@
+// Web Push の購読鍵の形式を検証する。
+// p256dh は非圧縮 P-256 公開鍵(先頭 0x04 + 65 bytes)、auth は 16〜32 bytes(RFC 8291)。
+// 不正な鍵を永続保存しないよう登録時に弾く。
+export const isValidPushKeys = (p256dh: string, auth: string): boolean => {
+  const p256dhBytes = Buffer.from(p256dh, 'base64url');
+  const authBytes = Buffer.from(auth, 'base64url');
+  return (
+    p256dhBytes.length === 65 &&
+    p256dhBytes[0] === 0x04 &&
+    authBytes.length >= 16 &&
+    authBytes.length <= 32
+  );
+};

--- a/apps/main/src/features/push-notification/application/push-keys.ts
+++ b/apps/main/src/features/push-notification/application/push-keys.ts
@@ -1,6 +1,6 @@
 // Web Push の購読鍵の形式を検証する。
-// p256dh は非圧縮 P-256 公開鍵(先頭 0x04 + 65 bytes)、auth は 16〜32 bytes(RFC 8291)。
-// 不正な鍵を永続保存しないよう登録時に弾く。
+// p256dh は非圧縮 P-256 公開鍵（先頭 0x04 + X座標32B + Y座標32B = 計65バイト）、
+// auth は 16〜32 bytes(RFC 8291)。不正な鍵を永続保存しないよう登録時に弾く。
 export const isValidPushKeys = (p256dh: string, auth: string): boolean => {
   const p256dhBytes = Buffer.from(p256dh, 'base64url');
   const authBytes = Buffer.from(auth, 'base64url');

--- a/apps/main/src/features/push-notification/interface/actions.ts
+++ b/apps/main/src/features/push-notification/interface/actions.ts
@@ -5,6 +5,7 @@ import * as z from 'zod/mini';
 
 import { configureZod } from '@/shared/validation/zod';
 
+import { isValidPushKeys } from '../application/push-keys';
 import { subscribePush, unsubscribePush } from '../application/subscribe';
 
 configureZod();
@@ -50,16 +51,8 @@ export const subscribePushAction = async (
     };
   }
 
-  // 鍵の形式検証: p256dh は非圧縮 P-256 公開鍵(先頭 0x04 + 65 bytes)、
-  // auth は 16 bytes(RFC 8291)。不正な鍵を永続保存しないよう登録時に弾く。
-  const p256dhBytes = Buffer.from(validated.data.keys.p256dh, 'base64url');
-  const authBytes = Buffer.from(validated.data.keys.auth, 'base64url');
-  if (
-    p256dhBytes.length !== 65 ||
-    p256dhBytes[0] !== 0x04 ||
-    authBytes.length < 16 ||
-    authBytes.length > 32
-  ) {
+  // 鍵の形式検証。不正な鍵を永続保存しないよう登録時に弾く。
+  if (!isValidPushKeys(validated.data.keys.p256dh, validated.data.keys.auth)) {
     return { success: false, message: '購読鍵の形式が不正です' };
   }
 


### PR DESCRIPTION
## 概要

レビュー「任意改善」バッチのうち、テスト追加（推奨）と perf 改善。低リスク・追加中心。

## 変更

### テスト追加
- **cron 認可** `isAuthorizedCronRequest` のユニットテスト（正しい Bearer のみ許可 / `CRON_SECRET` 未設定は不許可 / ヘッダ無し・誤トークン・Bearer無しを拒否）
- **push 購読鍵の形式検証** を `push-notification/application/push-keys.ts` の純粋関数 `isValidPushKeys` に切り出してテスト追加（p256dh は 0x04+65bytes、auth は 16〜32bytes）。`interface/actions.ts` はこれを利用するよう簡素化

### perf
- `GitHubContributionGraph` を `Suspense` でラップ。GitHub API の取得待ちでページ全体（Activity セクション）の描画をブロックしていたのを解消し、隣の `RecentBlogs` と同じくストリーミングできるように。fallback は Presenter のカード構造（ヘッダ / h-48 チャート / フッタ）に合わせ CLS を抑制

## 検証
- `pnpm run type-check` 全7成功 / `pnpm run check` 0 errors
- cron テスト 5 / push-keys テスト 6 すべて pass
- github-contribution-graph の Story play テスト 5 pass（Suspense 化後も描画維持）

## 補足（見送り）
- 58KB base64 PNG（OG画像生成）の隔離は、現状すでに専用ファイルで server 専用・実害限定のため見送り（public+fs 化は edge ランタイム互換の検証が必要）