### PR TITLE
fix: push購読解除のIDOR対策（auth一致を必須化）

### DIFF
--- a/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.tsx
@@ -5,8 +5,6 @@ import { getUserContributions } from '@/features/github/interface/queries';
 
 import { Presenter } from './presenter';
 
-// Presenter のカード構造（ヘッダ / h-48 のチャート / フッタ）に合わせた骨組み。
-// 取得が遅い GitHub API を待つ間にページ全体の描画をブロックしないための fallback。
 const Skeleton = () => (
   <Card>
     <div className="flex flex-col gap-4 p-6">

--- a/apps/main/src/app/notifications/_components/push-subscribe/push-subscribe.tsx
+++ b/apps/main/src/app/notifications/_components/push-subscribe/push-subscribe.tsx
@@ -117,7 +117,10 @@ export const PushSubscribe: FC<Props> = ({ vapidPublicKey }) => {
       if (subscription !== null) {
         // subscribe と対称に、サーバー側の削除成功を確認してから
         // ブラウザ側の購読解除と UI 更新を行う。
-        const result = await unsubscribePushAction(subscription.endpoint);
+        const result = await unsubscribePushAction({
+          endpoint: subscription.endpoint,
+          auth: subscription.toJSON().keys?.['auth'] ?? '',
+        });
         if (!result.success) {
           throw new Error(result.message);
         }

--- a/apps/main/src/features/push-notification/application/push-keys.ts
+++ b/apps/main/src/features/push-notification/application/push-keys.ts
@@ -1,6 +1,4 @@
-// Web Push の購読鍵の形式を検証する。
-// p256dh は非圧縮 P-256 公開鍵（先頭 0x04 + X座標32B + Y座標32B = 計65バイト）、
-// auth は 16〜32 bytes(RFC 8291)。不正な鍵を永続保存しないよう登録時に弾く。
+// p256dh は非圧縮 P-256 公開鍵(0x04 + 64B = 計65B)、auth は 16〜32B (RFC 8291)
 export const isValidPushKeys = (p256dh: string, auth: string): boolean => {
   const p256dhBytes = Buffer.from(p256dh, 'base64url');
   const authBytes = Buffer.from(auth, 'base64url');

--- a/apps/main/src/features/push-notification/application/subscribe.ts
+++ b/apps/main/src/features/push-notification/application/subscribe.ts
@@ -15,6 +15,13 @@ export const subscribePush = async (input: SubscribeInput): Promise<void> => {
   await insertSubscription({ ...input, endpointHost });
 };
 
-export const unsubscribePush = async (endpoint: string): Promise<void> => {
-  await deleteSubscription(endpoint);
+type UnsubscribeInput = {
+  endpoint: string;
+  auth: string;
+};
+
+export const unsubscribePush = async (
+  input: UnsubscribeInput,
+): Promise<void> => {
+  await deleteSubscription(input.endpoint, input.auth);
 };

--- a/apps/main/src/features/push-notification/infrastructure/subscription-repository.ts
+++ b/apps/main/src/features/push-notification/infrastructure/subscription-repository.ts
@@ -18,8 +18,7 @@ export const insertSubscription = async (
     .onConflictDoNothing({ target: db._schema.pushSubscriptions.endpoint });
 };
 
-// endpoint だけでなく auth(共有秘密)の一致も条件にし、endpoint を知るだけの
-// 第三者による購読解除（IDOR / 通知停止DoS）を防ぐ。
+// IDOR対策: endpoint を知るだけでは消せないよう auth(共有秘密)の一致も必須にする。
 export const deleteSubscription = async (
   endpoint: string,
   auth: string,

--- a/apps/main/src/features/push-notification/infrastructure/subscription-repository.ts
+++ b/apps/main/src/features/push-notification/infrastructure/subscription-repository.ts
@@ -1,5 +1,5 @@
 import { db } from '@repo/database';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
 type SubscriptionInput = {
   endpoint: string;
@@ -18,8 +18,18 @@ export const insertSubscription = async (
     .onConflictDoNothing({ target: db._schema.pushSubscriptions.endpoint });
 };
 
-export const deleteSubscription = async (endpoint: string): Promise<void> => {
+// endpoint だけでなく auth(共有秘密)の一致も条件にし、endpoint を知るだけの
+// 第三者による購読解除（IDOR / 通知停止DoS）を防ぐ。
+export const deleteSubscription = async (
+  endpoint: string,
+  auth: string,
+): Promise<void> => {
   await db
     .delete(db._schema.pushSubscriptions)
-    .where(eq(db._schema.pushSubscriptions.endpoint, endpoint));
+    .where(
+      and(
+        eq(db._schema.pushSubscriptions.endpoint, endpoint),
+        eq(db._schema.pushSubscriptions.auth, auth),
+      ),
+    );
 };

--- a/apps/main/src/features/push-notification/interface/actions.ts
+++ b/apps/main/src/features/push-notification/interface/actions.ts
@@ -77,7 +77,6 @@ export const subscribePushAction = async (
 export const unsubscribePushAction = async (
   payload: UnsubscribePayload,
 ): Promise<ActionResult> => {
-  // endpoint だけでなく auth(共有秘密)も検証し、削除時に所有者確認する（IDOR 対策）
   const validated = unsubscribeSchema.safeParse(payload);
   if (!validated.success) {
     return { success: false, message: 'エンドポイントが不正です' };

--- a/apps/main/src/features/push-notification/interface/actions.ts
+++ b/apps/main/src/features/push-notification/interface/actions.ts
@@ -51,7 +51,6 @@ export const subscribePushAction = async (
     };
   }
 
-  // 鍵の形式検証。不正な鍵を永続保存しないよう登録時に弾く。
   if (!isValidPushKeys(validated.data.keys.p256dh, validated.data.keys.auth)) {
     return { success: false, message: '購読鍵の形式が不正です' };
   }

--- a/apps/main/src/features/push-notification/interface/actions.ts
+++ b/apps/main/src/features/push-notification/interface/actions.ts
@@ -21,9 +21,10 @@ const subscriptionSchema = z.object({
   }),
 });
 
-const endpointSchema = z
-  .string()
-  .check(z.minLength(1), z.maxLength(MAX_ENDPOINT_LENGTH));
+const unsubscribeSchema = z.object({
+  endpoint: z.string().check(z.minLength(1), z.maxLength(MAX_ENDPOINT_LENGTH)),
+  auth: z.string().check(z.minLength(1), z.maxLength(MAX_KEY_LENGTH)),
+});
 
 type SubscriptionPayload = {
   endpoint: string;
@@ -31,6 +32,11 @@ type SubscriptionPayload = {
     p256dh: string;
     auth: string;
   };
+};
+
+type UnsubscribePayload = {
+  endpoint: string;
+  auth: string;
 };
 
 type ActionResult = { success: true } | { success: false; message: string };
@@ -69,9 +75,10 @@ export const subscribePushAction = async (
 };
 
 export const unsubscribePushAction = async (
-  endpoint: string,
+  payload: UnsubscribePayload,
 ): Promise<ActionResult> => {
-  const validated = endpointSchema.safeParse(endpoint);
+  // endpoint だけでなく auth(共有秘密)も検証し、削除時に所有者確認する（IDOR 対策）
+  const validated = unsubscribeSchema.safeParse(payload);
   if (!validated.success) {
     return { success: false, message: 'エンドポイントが不正です' };
   }


### PR DESCRIPTION
## 概要

レビュー「任意改善（多層防御）」。push 購読解除が endpoint のみで無条件 DELETE していたため、endpoint を知る第三者が他人の購読を解除できる（通知停止 DoS）IDOR を修正。

> ⚠️ **#1865（テスト追加・Suspense）に stack** しています。同じ `push-notification/interface/actions.ts` を編集するため、#1865 を先にマージしてください。

## 変更
- `deleteSubscription` を `endpoint` だけでなく `auth`(共有秘密) の一致でも絞り込むよう変更（`WHERE endpoint = ? AND auth = ?`）。endpoint を知るだけでは削除できない
- `unsubscribePushAction` / `unsubscribePush` / クライアントを `{ endpoint, auth }` を渡す形に更新（クライアントは `PushSubscription.toJSON().keys.auth` から取得）
- `auth` も zod で長さ検証

## 背景
購読 `insert` 側は既に `onConflictDoNothing` で「endpoint を知る第三者による改ざん」を防いでいたが、`delete` 側が未保護だった。本変更で対称性を持たせた。push endpoint 自体が高エントロピーな秘匿URLのため実害可能性は低いが、多層防御として対応。

## 検証
- `pnpm run type-check` 全7成功 / `pnpm run check` 0 errors
- main features 61 / admin features+shared 38 すべて pass
- `deleteSubscription` の呼び出しは feature 内に閉じており、サーバー起点の gone-endpoint 掃除（admin 側の別経路）には影響なし