### PR TITLE
feat: artifactsにvite-plus-inspectorを追加

### DIFF
--- a/apps/main/src/features/artifacts/application/artifacts.test.ts
+++ b/apps/main/src/features/artifacts/application/artifacts.test.ts
@@ -4,17 +4,17 @@ describe('getArtifacts', () => {
   it('公開している制作物一覧を返す', () => {
     const projects = getArtifacts();
 
-    expect(projects).toHaveLength(10);
+    expect(projects).toHaveLength(11);
     expect(projects).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          name: 'ArteOdyssey',
+          name: '@k8o/arte-odyssey',
           githubUrl: 'https://github.com/k35o/arte-odyssey',
           websiteUrl: 'https://arte-odyssey.k8o.me/',
-          npmPackageName: null,
+          npmPackageName: '@k8o/arte-odyssey',
         }),
         expect.objectContaining({
-          name: 'oxc-config',
+          name: '@k8o/oxc-config',
           githubUrl: 'https://github.com/k35o/oxc-config',
           websiteUrl: null,
           npmPackageName: '@k8o/oxc-config',

--- a/apps/main/src/features/artifacts/application/artifacts.ts
+++ b/apps/main/src/features/artifacts/application/artifacts.ts
@@ -9,12 +9,12 @@ export type Artifact = {
 
 export const getArtifacts = (): Artifact[] => [
   {
-    name: 'ArteOdyssey',
+    name: '@k8o/arte-odyssey',
     description:
       'k8o.meのデザインシステム。コンポーネントやトークンを管理している。',
     githubUrl: 'https://github.com/k35o/arte-odyssey',
     websiteUrl: 'https://arte-odyssey.k8o.me/',
-    npmPackageName: null,
+    npmPackageName: '@k8o/arte-odyssey',
     tags: ['Design System', 'React'],
   },
   {
@@ -78,7 +78,7 @@ export const getArtifacts = (): Artifact[] => [
     tags: ['Storybook', 'VRT'],
   },
   {
-    name: 'oxc-config',
+    name: '@k8o/oxc-config',
     description: 'oxlintの設定を共通化するためのconfigリポジトリ。',
     githubUrl: 'https://github.com/k35o/oxc-config',
     websiteUrl: null,
@@ -93,5 +93,14 @@ export const getArtifacts = (): Artifact[] => [
     websiteUrl: null,
     npmPackageName: '@k8o/create',
     tags: ['Vite+', 'Generator', 'Tool'],
+  },
+  {
+    name: 'vite-plus-inspector',
+    description:
+      'vite-plusの設定をブラウザで可視化するinspector。oxlintのルールの重大度や適用状況を確認できる。',
+    githubUrl: 'https://github.com/k35o/vite-plus-inspector',
+    websiteUrl: null,
+    npmPackageName: 'vite-plus-inspector',
+    tags: ['Vite+', 'oxlint', 'Tool'],
   },
 ];


### PR DESCRIPTION
## 概要

artifacts（公開制作物）一覧に `vite-plus-inspector` を追加し、@k8o所有パッケージの表示名を@k8oスコープ表記に整理した。

## 詳細

- `vite-plus-inspector` をartifacts一覧に追加（npmパッケージ名: `vite-plus-inspector`）
- @k8o所有のartifactの表示名を@k8oスコープ表記に統一
  - `ArteOdyssey` → `@k8o/arte-odyssey`
  - `oxc-config` → `@k8o/oxc-config`
- `@k8o/arte-odyssey` はnpm公開済みのため `npmPackageName` を設定し、npmリンクを表示するように
- 上記に合わせて `artifacts.test.ts` の期待値（件数・name・npmPackageName）を更新

## 気をつけるポイント

- 他スコープ／unscopedのパッケージ（`@better-css-modules/core`、storybook-addon系、`vite-plus-inspector`）は実際のnpm名のまま維持しており、@k8o表記には変更していない