### PR TITLE
chore: artifacts一覧を整理（並び替え・説明/タグ更新・グリッド表示）

### DIFF
--- a/apps/main/src/app/artifacts/_components/artifact-card/artifact-card.tsx
+++ b/apps/main/src/app/artifacts/_components/artifact-card/artifact-card.tsx
@@ -22,7 +22,7 @@ export const ArtifactCard: FC<Artifact> = ({
   <article className="border-border-mute bg-bg-base flex h-full flex-col gap-5 rounded-xl border p-5 shadow-sm transition-colors md:p-6">
     <div className="flex flex-col gap-2">
       <Heading type="h3">{name}</Heading>
-      <p className="text-fg-mute max-w-3xl text-sm leading-relaxed md:text-base">
+      <p className="text-fg-mute text-sm leading-relaxed md:text-base">
         {description}
       </p>
     </div>

--- a/apps/main/src/app/artifacts/page.tsx
+++ b/apps/main/src/app/artifacts/page.tsx
@@ -5,7 +5,7 @@ import { ArtifactCard } from './_components/artifact-card';
 export default function Page() {
   const projects = getArtifacts();
   return (
-    <div className="flex flex-col gap-4">
+    <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
       {projects.map((project) => (
         <ArtifactCard key={project.name} {...project} />
       ))}

--- a/apps/main/src/features/artifacts/application/artifacts.ts
+++ b/apps/main/src/features/artifacts/application/artifacts.ts
@@ -8,74 +8,34 @@ export type Artifact = {
 };
 
 export const getArtifacts = (): Artifact[] => [
+  // デザインシステム
   {
     name: '@k8o/arte-odyssey',
     description:
-      'k8o.meのデザインシステム。コンポーネントやトークンを管理している。',
+      'k8oのデザインシステム。Reactコンポーネントとデザイントークンに加え、LLM駆動でUIを生成するアダプタを備える。',
     githubUrl: 'https://github.com/k35o/arte-odyssey',
     websiteUrl: 'https://arte-odyssey.k8o.me/',
     npmPackageName: '@k8o/arte-odyssey',
-    tags: ['Design System', 'React'],
+    tags: ['Design System', 'React', 'Generative UI'],
   },
-  {
-    name: 'renovate-config',
-    description: 'Renovateの設定を共通化するためのconfigリポジトリ。',
-    githubUrl: 'https://github.com/k35o/renovate-config',
-    websiteUrl: null,
-    npmPackageName: null,
-    tags: ['Renovate', 'Config', 'Personal'],
-  },
-  {
-    name: 'dotfiles',
-    description: '日々の開発環境を整えるためのdotfilesとセットアップ群。',
-    githubUrl: 'https://github.com/k35o/dotfiles',
-    websiteUrl: null,
-    npmPackageName: null,
-    tags: ['Dotfiles', 'Shell', 'Config', 'Personal'],
-  },
-  {
-    name: 'better-css-modules',
-    description: 'CSS Modulesを扱いやすくするための実験的なツール。',
-    githubUrl: 'https://github.com/k35o/better-css-modules',
-    websiteUrl: null,
-    npmPackageName: '@better-css-modules/core',
-    tags: ['CSS Modules', 'webpack', 'Vite', 'Turbopack'],
-  },
-  {
-    name: 'patrol-board',
-    description:
-      'スクリプトを定期実行し、結果をGitHub Issueにダッシュボードとして表示するGitHub Action。',
-    githubUrl: 'https://github.com/k35o/patrol-board',
-    websiteUrl: null,
-    npmPackageName: null,
-    tags: ['GitHub Actions', 'Tool'],
-  },
+  // Storybook 系
   {
     name: 'storybook-addon-mock-date',
     description:
-      'Storybookのストーリーで日付や時刻をモックするためのアドオン。',
+      'Storybookのストーリー単位でDateやタイマーをモックし、時刻に依存するコンポーネントを決定的に表示するアドオン。',
     githubUrl: 'https://github.com/k35o/storybook-addon-mock-date',
     websiteUrl: null,
     npmPackageName: 'storybook-addon-mock-date',
-    tags: ['Storybook', 'Date'],
-  },
-  {
-    name: 'storybook-framework-hono-vite',
-    description:
-      'Hono JSXで書いたコンポーネントを@storybook/react-viteと同じ感覚で扱うためのStorybookフレームワーク。',
-    githubUrl: 'https://github.com/k35o/storybook-framework-hono-vite',
-    websiteUrl: null,
-    npmPackageName: 'storybook-framework-hono-vite',
-    tags: ['Storybook', 'Hono', 'Vite'],
+    tags: ['Storybook', 'Date', 'Mock'],
   },
   {
     name: 'storybook-addon-vrt',
     description:
-      'Storybookのストーリーごとにスクリーンショットを撮り、ビジュアルリグレッションテストを行うアドオン。',
+      'Vitestのブラウザモード上でStorybookのストーリーごとにスクリーンショットを撮り、ビジュアルリグレッションテストを行うツール。',
     githubUrl: 'https://github.com/k35o/storybook-addon-vrt',
     websiteUrl: null,
     npmPackageName: 'storybook-addon-vrt',
-    tags: ['Storybook', 'VRT'],
+    tags: ['Storybook', 'Vitest', 'VRT'],
   },
   {
     name: 'storybook-addon-determinism',
@@ -87,13 +47,15 @@ export const getArtifacts = (): Artifact[] => [
     tags: ['Storybook', 'Determinism', 'VRT'],
   },
   {
-    name: '@k8o/oxc-config',
-    description: 'oxlintの設定を共通化するためのconfigリポジトリ。',
-    githubUrl: 'https://github.com/k35o/oxc-config',
+    name: 'storybook-framework-hono-vite',
+    description:
+      'Hono JSXで書いたコンポーネントを@storybook/react-viteと同じ感覚で扱うためのStorybookフレームワーク。',
+    githubUrl: 'https://github.com/k35o/storybook-framework-hono-vite',
     websiteUrl: null,
-    npmPackageName: '@k8o/oxc-config',
-    tags: ['oxlint', 'Config', 'Personal'],
+    npmPackageName: 'storybook-framework-hono-vite',
+    tags: ['Storybook', 'Hono', 'Vite'],
   },
+  // Vite+ / ビルドツール 系
   {
     name: '@k8o/create',
     description:
@@ -110,6 +72,52 @@ export const getArtifacts = (): Artifact[] => [
     githubUrl: 'https://github.com/k35o/vite-plus-inspector',
     websiteUrl: null,
     npmPackageName: 'vite-plus-inspector',
-    tags: ['Vite+', 'oxlint', 'Tool'],
+    tags: ['Vite+', 'oxlint', 'CLI'],
+  },
+  {
+    name: 'better-css-modules',
+    description:
+      'CSS Modulesから型定義を自動生成し、未使用クラスを検出して開発体験を高めるツールキット。',
+    githubUrl: 'https://github.com/k35o/better-css-modules',
+    websiteUrl: null,
+    npmPackageName: '@better-css-modules/core',
+    tags: ['CSS Modules', 'TypeScript', 'Vite', 'webpack'],
+  },
+  // 共通設定 / Personal
+  {
+    name: '@k8o/oxc-config',
+    description:
+      'oxlintとoxfmtの共有設定パッケージ。TypeScriptやReact、Next.jsなど用途別のプリセットを提供する。',
+    githubUrl: 'https://github.com/k35o/oxc-config',
+    websiteUrl: null,
+    npmPackageName: '@k8o/oxc-config',
+    tags: ['oxlint', 'oxfmt', 'Config'],
+  },
+  {
+    name: 'renovate-config',
+    description: 'Renovateの設定を共通化するためのconfigリポジトリ。',
+    githubUrl: 'https://github.com/k35o/renovate-config',
+    websiteUrl: null,
+    npmPackageName: null,
+    tags: ['Renovate', 'Config', 'Personal'],
+  },
+  {
+    name: 'dotfiles',
+    description:
+      'chezmoiで管理する開発環境の設定一式。zshやmise、ターミナル周りの設定をまとめている。',
+    githubUrl: 'https://github.com/k35o/dotfiles',
+    websiteUrl: null,
+    npmPackageName: null,
+    tags: ['Dotfiles', 'chezmoi', 'Shell', 'Personal'],
+  },
+  // 自動化 / GitHub Actions
+  {
+    name: 'patrol-board',
+    description:
+      'スクリプトを定期実行し、結果をGitHub Issueにダッシュボードとして表示するGitHub Action。',
+    githubUrl: 'https://github.com/k35o/patrol-board',
+    websiteUrl: null,
+    npmPackageName: null,
+    tags: ['GitHub Actions', 'Automation'],
   },
 ];


### PR DESCRIPTION
## 概要

artifacts一覧（`/artifacts`）の整理。2つのまとまりからなる。

1. **データ整理**: 並び順をカテゴリでグループ化し、各リポジトリのREADME・npmレジストリを確認して `description` / `tags` を実態に合わせた
2. **レイアウト**: 一覧を単一カラムからレスポンシブグリッドに変更し、カード幅と説明文の幅の不一致を解消した

## 詳細

### データ整理（`artifacts.ts`）

並び順（コメントでグループの区切りを明示）:

1. デザインシステム … `@k8o/arte-odyssey`
2. Storybook 系 … `storybook-addon-mock-date` / `storybook-addon-vrt` / `storybook-addon-determinism` / `storybook-framework-hono-vite`
3. Vite+ / ビルドツール 系 … `@k8o/create` / `vite-plus-inspector` / `better-css-modules`
4. 共通設定 / Personal … `@k8o/oxc-config` / `renovate-config` / `dotfiles`
5. 自動化 / GitHub Actions … `patrol-board`

説明・タグの実態反映（主なもの）:

- **@k8o/arte-odyssey**: LLM駆動のUI生成アダプタに言及 / `+Generative UI`
- **storybook-addon-mock-date**: タイマーもモックする点を反映 / `+Mock`
- **storybook-addon-vrt**: 「Vitestのブラウザモード上で動く」を明記 / `+Vitest`
- **better-css-modules**: 「実験的なツール」→型定義の自動生成・未使用クラス検出に / タグを `TypeScript/Vite/webpack` に
- **@k8o/oxc-config**: oxlintだけでなく **oxfmt** も含む共有設定である点に修正 / `+oxfmt`
- **vite-plus-inspector**: `Tool`→`CLI`
- **dotfiles**: **chezmoi** 管理であることを明記 / `+chezmoi`
- **patrol-board**: `Tool`→`Automation`

### レイアウト（`page.tsx` / `artifact-card.tsx`）

- 一覧コンテナを `flex flex-col gap-4` → `grid gap-8 md:grid-cols-2 lg:grid-cols-3`（サイト他ページのカード一覧と同じ慣習）
- カードが適切な幅になったため、説明文 `<p>` の `max-w-3xl`（テキスト幅の頭打ち）を撤去

## 気をつけるポイント

- `renovate-config` は npm の同名（unscoped）パッケージが**別人のもの**のため、`npmPackageName: null` のまま据え置き
- `patrol-board` は GitHub Actions Marketplace 未掲載のため、その旨は説明に書かない
- モバイルはグリッドでも1カラム。2〜3カラム化が効くのはタブレット/デスクトップ

## 影響範囲

- `/artifacts` ページ: 表示レイアウト（グリッド）・各カードの並び順 / 説明文 / タグ

## テスト

- `vp check`（format / lint）pass
- `tsc --noEmit`（型チェック）pass
- `artifacts.test.ts`（`arrayContaining` で順序非依存）pass