### PR TITLE
feat: 記事に読了時間を表示し、閲覧数計測を堅牢化

### DIFF
--- a/apps/main/src/app/blog/_components/blog-layout/blog-layout.stories.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/blog-layout.stories.tsx
@@ -109,6 +109,6 @@ export const Primary: Story = {
     headingTree,
     recommendedBlogs,
     slug: 'tanstack-router-introduction',
-    viewCount: 74_931,
+    readingTime: 5,
   },
 };

--- a/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -6,17 +6,16 @@ import {
   Separator,
   TagIcon,
   UpdateDateIcon,
-  ViewIcon,
 } from '@k8o/arte-odyssey';
 import { formatDate } from '@repo/helpers/date/format';
-import { commalize } from '@repo/helpers/number/commalize';
 import Link from 'next/link';
-import { type FC, type ReactNode, Suspense } from 'react';
+import type { FC, ReactNode } from 'react';
 
 import { SilentErrorBoundary } from '@/app/_components/error-boundary';
 import { JsonLd } from '@/app/_components/json-ld';
 import {
   getBlogContent,
+  getBlogReadingTime,
   type getBlogsByTags,
   getBlogToc,
 } from '@/features/blog/interface/queries';
@@ -28,7 +27,6 @@ import { Feedback } from './feedback';
 import { Recommend, RecommendContent } from './recommend';
 import { SlideLinkButton } from './slide-link-button';
 import { TableOfContents } from './table-of-contents';
-import { ViewCounter } from './view-counter';
 import { ViewReporter } from './view-reporter';
 import { WritingModeContent } from './writing-mode';
 
@@ -41,16 +39,16 @@ type BlogLayoutContentProps = BlogLayoutProps & {
   blog: Awaited<ReturnType<typeof getBlogContent>>;
   headingTree: Awaited<ReturnType<typeof getBlogToc>>;
   recommendedBlogs?: Awaited<ReturnType<typeof getBlogsByTags>>;
-  viewCount?: number;
+  readingTime: number;
 };
 
 export const BlogLayoutContent: FC<BlogLayoutContentProps> = ({
   blog,
   children,
   headingTree,
+  readingTime,
   recommendedBlogs,
   slug,
-  viewCount,
 }) => {
   const shouldUseRecommendedBlogs = recommendedBlogs !== undefined;
 
@@ -90,25 +88,9 @@ export const BlogLayoutContent: FC<BlogLayoutContentProps> = ({
                     <span>更新: {formatDate(new Date(blog.updatedAt))}</span>
                   </div>
                 </div>
-                <SilentErrorBoundary>
-                  {viewCount === undefined ? (
-                    <Suspense fallback={null}>
-                      <div className="flex items-center gap-1">
-                        <ViewIcon size="sm" />
-                        <span className="sr-only">閲覧数</span>
-                        <span>
-                          <ViewCounter id={blog.id} /> views
-                        </span>
-                      </div>
-                    </Suspense>
-                  ) : (
-                    <div className="flex items-center gap-1">
-                      <ViewIcon size="sm" />
-                      <span className="sr-only">閲覧数</span>
-                      <span>{commalize(viewCount)} views</span>
-                    </div>
-                  )}
-                </SilentErrorBoundary>
+                <div className="flex items-center gap-1">
+                  <span>約{readingTime}分で読めます</span>
+                </div>
               </div>
               {blog.tags.length > 0 && (
                 <div className="mb-4 flex flex-wrap items-center gap-2">
@@ -152,11 +134,17 @@ export const BlogLayoutContent: FC<BlogLayoutContentProps> = ({
 export const BlogLayout: FC<BlogLayoutProps> = async ({ children, slug }) => {
   const blog = await getBlogContent(slug);
   const headingTree = await getBlogToc(slug);
+  const readingTime = await getBlogReadingTime(slug);
 
   return (
     <>
       <JsonLd data={blogPostingJsonLd(blog)} />
-      <BlogLayoutContent blog={blog} headingTree={headingTree} slug={slug}>
+      <BlogLayoutContent
+        blog={blog}
+        headingTree={headingTree}
+        readingTime={readingTime}
+        slug={slug}
+      >
         {children}
       </BlogLayoutContent>
     </>

--- a/apps/main/src/app/blog/_components/blog-layout/view-counter/index.ts
+++ b/apps/main/src/app/blog/_components/blog-layout/view-counter/index.ts
@@ -1,1 +1,0 @@
-export * from './view-counter';

--- a/apps/main/src/app/blog/_components/blog-layout/view-counter/view-counter.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/view-counter/view-counter.tsx
@@ -1,9 +1,0 @@
-import { commalize } from '@repo/helpers/number/commalize';
-import type { FC } from 'react';
-
-import { getBlogView } from '@/features/blog/interface/queries';
-
-export const ViewCounter: FC<{ id: number }> = async ({ id }) => {
-  const views = await getBlogView(id);
-  return <span>{commalize(views)}</span>;
-};

--- a/apps/main/src/app/blog/_components/blog-layout/view-reporter/view-reporter.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/view-reporter/view-reporter.tsx
@@ -2,13 +2,34 @@
 
 import { type FC, useEffect } from 'react';
 
+const reportView = (slug: string): void => {
+  const body = JSON.stringify({ slug });
+
+  // 離脱・タブクローズ時でも送信が保証されやすい sendBeacon を優先する
+  if (
+    typeof navigator !== 'undefined' &&
+    typeof navigator.sendBeacon === 'function'
+  ) {
+    const blob = new Blob([body], { type: 'application/json' });
+    if (navigator.sendBeacon('/api/blog/views', blob)) {
+      return;
+    }
+  }
+
+  // フォールバック: ページ遷移中でも中断されにくいよう keepalive を付ける
+  void fetch('/api/blog/views', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    keepalive: true,
+  }).catch(() => {
+    // 計測の失敗は致命的ではないため握りつぶす
+  });
+};
+
 export const ViewReporter: FC<{ slug: string }> = ({ slug }) => {
   useEffect(() => {
-    void fetch('/api/blog/views', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ slug }),
-    });
+    reportView(slug);
   }, [slug]);
 
   return null;

--- a/apps/main/src/features/blog/application/reading-time.test.ts
+++ b/apps/main/src/features/blog/application/reading-time.test.ts
@@ -1,0 +1,49 @@
+import { estimateReadingTimeMinutes } from './reading-time';
+
+describe('estimateReadingTimeMinutes', () => {
+  describe('正常系', () => {
+    it('日本語の文字数から読了時間を見積もる', () => {
+      // 1000文字 / 500cpm = 2分
+      const result = estimateReadingTimeMinutes('あ'.repeat(1000));
+
+      expect(result).toBe(2);
+    });
+
+    it('英単語数から読了時間を見積もる', () => {
+      // 500語 / 250wpm = 2分
+      const text = Array.from({ length: 500 }, () => 'word').join(' ');
+
+      expect(estimateReadingTimeMinutes(text)).toBe(2);
+    });
+
+    it('日本語と英語を合算して切り上げる', () => {
+      // 250文字/500 + 125語/250 = 0.5 + 0.5 = 1分
+      const words = Array.from({ length: 125 }, () => 'word').join(' ');
+      const text = `${'あ'.repeat(250)} ${words}`;
+
+      expect(estimateReadingTimeMinutes(text)).toBe(1);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('コードブロックは読了時間に含めない', () => {
+      const text = ['```ts', 'const x = 1;'.repeat(500), '```'].join('\n');
+
+      expect(estimateReadingTimeMinutes(text)).toBe(1);
+    });
+
+    it('リンクはテキストのみカウントしURLは除外する', () => {
+      const text = '[リンク](https://example.com/very/long/path/to/article)';
+
+      expect(estimateReadingTimeMinutes(text)).toBe(1);
+    });
+
+    it('短い本文でも最低1分を返す', () => {
+      expect(estimateReadingTimeMinutes('短い')).toBe(1);
+    });
+
+    it('空文字でも1分を返す', () => {
+      expect(estimateReadingTimeMinutes('')).toBe(1);
+    });
+  });
+});

--- a/apps/main/src/features/blog/application/reading-time.ts
+++ b/apps/main/src/features/blog/application/reading-time.ts
@@ -1,0 +1,35 @@
+// 記事本文（マークダウン）から推定読了時間（分）を算出する。
+// 日本語(CJK)は文字数、英数字は単語数で見積もり、合算して切り上げる。
+// コードブロック・URL は読み飛ばされる前提で除外する。
+
+const CJK_CHARS_PER_MINUTE = 500;
+const WORDS_PER_MINUTE = 250;
+
+const CJK_RE = /[぀-ヿ㐀-䶿一-鿿ｦ-ﾟ]/gu;
+
+export const estimateReadingTimeMinutes = (markdown: string): number => {
+  const text = markdown
+    // フェンスドコードブロック
+    .replaceAll(/```[\s\S]*?```/gu, ' ')
+    // インラインコード
+    .replaceAll(/`[^`]*`/gu, ' ')
+    // 画像
+    .replaceAll(/!\[[^\]]*\]\([^)]*\)/gu, ' ')
+    // リンクはテキストのみ残す
+    .replaceAll(/\[([^\]]*)\]\([^)]*\)/gu, '$1')
+    // 裸のURL
+    .replaceAll(/https?:\/\/\S+/gu, ' ');
+
+  const cjkCount = (text.match(CJK_RE) ?? []).length;
+
+  const wordCount = text
+    .replaceAll(CJK_RE, ' ')
+    .split(/\s+/u)
+    .filter((token) => /[a-z0-9]/iu.test(token)).length;
+
+  const minutes = Math.ceil(
+    cjkCount / CJK_CHARS_PER_MINUTE + wordCount / WORDS_PER_MINUTE,
+  );
+
+  return Math.max(1, minutes);
+};

--- a/apps/main/src/features/blog/application/view.test.ts
+++ b/apps/main/src/features/blog/application/view.test.ts
@@ -1,20 +1,19 @@
 import { db } from '@repo/database';
-import { eq } from 'drizzle-orm';
 
-import { getBlogView, incrementBlogView } from './view';
+import { incrementBlogView, incrementBlogViewDaily } from './view';
 
 vi.mock('@repo/database', () => ({
   db: {
-    query: {
-      blogViews: {
-        findFirst: vi.fn(),
-      },
-    },
-    update: vi.fn(),
+    insert: vi.fn(),
     _schema: {
       blogViews: {
         views: 'blogViews.views',
         blogId: 'blogViews.blogId',
+      },
+      blogViewDailies: {
+        views: 'blogViewDailies.views',
+        blogId: 'blogViewDailies.blogId',
+        date: 'blogViewDailies.date',
       },
     },
     _utils: {
@@ -22,86 +21,81 @@ vi.mock('@repo/database', () => ({
     },
   },
 }));
-vi.mock('drizzle-orm');
+
+// db.insert(...).values(...).onConflictDoUpdate(...) のチェーンをモックするヘルパー
+const mockInsertChain = (resolvedValue: unknown) => {
+  const onConflictDoUpdate = vi.fn().mockResolvedValue(resolvedValue);
+  const values = vi.fn().mockReturnValue({ onConflictDoUpdate });
+  vi.mocked(db.insert).mockReturnValue({
+    values,
+  } as unknown as ReturnType<typeof db.insert>);
+  return { values, onConflictDoUpdate };
+};
 
 describe('view service', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  describe('getBlogView', () => {
-    it('ブログの閲覧数を取得できる', async () => {
-      const mockViewData = { views: 123 };
-      const mockFindFirst = vi.fn().mockResolvedValue(mockViewData);
-
-      vi.mocked(db.query.blogViews.findFirst).mockImplementation(mockFindFirst);
-
-      const result = await getBlogView(1);
-
-      expect(result).toBe(123);
-      expect(mockFindFirst).toHaveBeenCalledTimes(1);
-    });
-
-    it('閲覧数データが存在しない場合は0を返す', async () => {
-      const mockFindFirst = vi.fn().mockResolvedValue(null);
-
-      vi.mocked(db.query.blogViews.findFirst).mockImplementation(mockFindFirst);
-
-      const result = await getBlogView(1);
-
-      expect(result).toBe(0);
-    });
-
-    it('viewsプロパティがundefinedの場合は0を返す', async () => {
-      const mockViewData = { views: undefined };
-      const mockFindFirst = vi.fn().mockResolvedValue(mockViewData);
-
-      vi.mocked(db.query.blogViews.findFirst).mockImplementation(mockFindFirst);
-
-      const result = await getBlogView(1);
-
-      expect(result).toBe(0);
-    });
-  });
-
   describe('incrementBlogView', () => {
-    it('ブログの閲覧数をインクリメントできる', async () => {
-      const mockIncrement = vi.fn().mockReturnValue('INCREMENTED_VALUE');
-      const mockUpdate = vi.fn().mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(true),
-        }),
-      });
-      const mockEq = vi.fn().mockReturnValue('WHERE_CONDITION');
-
-      vi.mocked(db._utils.increment).mockImplementation(mockIncrement);
-      vi.mocked(db.update).mockImplementation(mockUpdate);
-      vi.mocked(eq).mockImplementation(mockEq);
+    it('累計ビュー数を upsert でインクリメントできる', async () => {
+      vi.mocked(db._utils.increment).mockReturnValue(
+        'INCREMENTED' as unknown as ReturnType<typeof db._utils.increment>,
+      );
+      const { values, onConflictDoUpdate } = mockInsertChain(true);
 
       const result = await incrementBlogView(1);
 
-      expect(db.update).toHaveBeenCalledWith(db._schema.blogViews);
-      expect(mockIncrement).toHaveBeenCalledWith(db._schema.blogViews.views);
-      expect(mockEq).toHaveBeenCalledWith(db._schema.blogViews.blogId, 1);
+      expect(db.insert).toHaveBeenCalledWith(db._schema.blogViews);
+      expect(values).toHaveBeenCalledWith({ blogId: 1, views: 1 });
+      expect(db._utils.increment).toHaveBeenCalledWith(
+        db._schema.blogViews.views,
+      );
+      expect(onConflictDoUpdate).toHaveBeenCalledWith({
+        target: db._schema.blogViews.blogId,
+        set: { views: 'INCREMENTED' },
+      });
       expect(result).toBe(true);
     });
 
     it('異なるブログIDでも正しく動作する', async () => {
-      const mockIncrement = vi.fn().mockReturnValue('INCREMENTED_VALUE');
-      const mockUpdate = vi.fn().mockReturnValue({
-        set: vi.fn().mockReturnValue({
-          where: vi.fn().mockResolvedValue(true),
-        }),
-      });
-      const mockEq = vi.fn().mockReturnValue('WHERE_CONDITION');
-
-      vi.mocked(db._utils.increment).mockImplementation(mockIncrement);
-      vi.mocked(db.update).mockImplementation(mockUpdate);
-      vi.mocked(eq).mockImplementation(mockEq);
+      vi.mocked(db._utils.increment).mockReturnValue(
+        'INCREMENTED' as unknown as ReturnType<typeof db._utils.increment>,
+      );
+      const { values } = mockInsertChain(true);
 
       await incrementBlogView(999);
 
-      expect(mockEq).toHaveBeenCalledWith(db._schema.blogViews.blogId, 999);
+      expect(values).toHaveBeenCalledWith({ blogId: 999, views: 1 });
+    });
+  });
+
+  describe('incrementBlogViewDaily', () => {
+    it('日次ビュー数を (blogId, date) 単位で upsert できる', async () => {
+      vi.mocked(db._utils.increment).mockReturnValue(
+        'INCREMENTED' as unknown as ReturnType<typeof db._utils.increment>,
+      );
+      const { values, onConflictDoUpdate } = mockInsertChain(true);
+
+      const result = await incrementBlogViewDaily(1, '2026-06-22');
+
+      expect(db.insert).toHaveBeenCalledWith(db._schema.blogViewDailies);
+      expect(values).toHaveBeenCalledWith({
+        blogId: 1,
+        date: '2026-06-22',
+        views: 1,
+      });
+      expect(db._utils.increment).toHaveBeenCalledWith(
+        db._schema.blogViewDailies.views,
+      );
+      expect(onConflictDoUpdate).toHaveBeenCalledWith({
+        target: [
+          db._schema.blogViewDailies.blogId,
+          db._schema.blogViewDailies.date,
+        ],
+        set: { views: 'INCREMENTED' },
+      });
+      expect(result).toBe(true);
     });
   });
 });

--- a/apps/main/src/features/blog/application/view.ts
+++ b/apps/main/src/features/blog/application/view.ts
@@ -1,17 +1,25 @@
 import { db } from '@repo/database';
-import { eq } from 'drizzle-orm';
 
-export const getBlogView = (id: number): Promise<number> =>
-  db.query.blogViews
-    .findFirst({
-      where: (blogViews, { eq: equals }) => equals(blogViews.blogId, id),
-    })
-    .then((res) => res?.views ?? 0);
-
+// 累計ビュー数をインクリメントする。
+// 行が存在しない場合でも insert で自己修復するため、計測漏れが起きない。
 export const incrementBlogView = (id: number) =>
   db
-    .update(db._schema.blogViews)
-    .set({
-      views: db._utils.increment(db._schema.blogViews.views),
-    })
-    .where(eq(db._schema.blogViews.blogId, id));
+    .insert(db._schema.blogViews)
+    .values({ blogId: id, views: 1 })
+    .onConflictDoUpdate({
+      target: db._schema.blogViews.blogId,
+      set: { views: db._utils.increment(db._schema.blogViews.views) },
+    });
+
+// 日次ビュー数をインクリメントする。(blogId, date) 単位で集約する。
+export const incrementBlogViewDaily = (id: number, date: string) =>
+  db
+    .insert(db._schema.blogViewDailies)
+    .values({ blogId: id, date, views: 1 })
+    .onConflictDoUpdate({
+      target: [
+        db._schema.blogViewDailies.blogId,
+        db._schema.blogViewDailies.date,
+      ],
+      set: { views: db._utils.increment(db._schema.blogViewDailies.views) },
+    });

--- a/apps/main/src/features/blog/interface/__mocks__/queries.ts
+++ b/apps/main/src/features/blog/interface/__mocks__/queries.ts
@@ -8,4 +8,4 @@ export const getBlogToc = fn().mockName('getBlogToc');
 
 export const getBlogsByTags = fn().mockName('getBlogsByTags');
 
-export const getBlogView = fn().mockName('getBlogView');
+export const getBlogReadingTime = fn().mockName('getBlogReadingTime');

--- a/apps/main/src/features/blog/interface/commands.test.ts
+++ b/apps/main/src/features/blog/interface/commands.test.ts
@@ -1,0 +1,58 @@
+import {
+  incrementBlogView as _incrementBlogView,
+  incrementBlogViewDaily as _incrementBlogViewDaily,
+} from '../application/view';
+import { incrementBlogView } from './commands';
+
+vi.mock('../application/view', () => ({
+  incrementBlogView: vi.fn(),
+  incrementBlogViewDaily: vi.fn(),
+}));
+
+describe('incrementBlogView (command)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('正常系', () => {
+    it('累計と日次の両方をインクリメントし、日次にはUTC基準の当日日付を渡す', async () => {
+      // JST では翌日(06-24 01:00)になる時刻でも、UTC基準の日付になることを確認
+      vi.setSystemTime(new Date('2026-06-23T16:00:00.000Z'));
+
+      await incrementBlogView(42);
+
+      expect(_incrementBlogView).toHaveBeenCalledWith(42);
+      expect(_incrementBlogViewDaily).toHaveBeenCalledWith(42, '2026-06-23');
+    });
+  });
+
+  describe('異常系', () => {
+    it('日次集計が失敗しても throw せず、エラーをログする（best-effort）', async () => {
+      vi.setSystemTime(new Date('2026-06-23T00:00:00.000Z'));
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+      vi.mocked(_incrementBlogViewDaily).mockRejectedValue(new Error('boom'));
+
+      await expect(incrementBlogView(1)).resolves.toBeUndefined();
+
+      // 累計は影響を受けずに実行される
+      expect(_incrementBlogView).toHaveBeenCalledWith(1);
+      expect(consoleError).toHaveBeenCalledTimes(1);
+
+      consoleError.mockRestore();
+    });
+
+    it('累計のインクリメントが失敗した場合は throw する（累計はsource of truth）', async () => {
+      vi.setSystemTime(new Date('2026-06-23T00:00:00.000Z'));
+      vi.mocked(_incrementBlogView).mockRejectedValue(new Error('db down'));
+
+      await expect(incrementBlogView(1)).rejects.toThrow('db down');
+    });
+  });
+});

--- a/apps/main/src/features/blog/interface/commands.ts
+++ b/apps/main/src/features/blog/interface/commands.ts
@@ -1,6 +1,24 @@
-import { incrementBlogView as _incrementBlogView } from '../application/view';
+import {
+  incrementBlogView as _incrementBlogView,
+  incrementBlogViewDaily as _incrementBlogViewDaily,
+} from '../application/view';
 
-export async function incrementBlogView(id: number) {
-  const result = await _incrementBlogView(id);
-  return result;
+export async function incrementBlogView(id: number): Promise<void> {
+  // UTC 基準の YYYY-MM-DD
+  const date = new Date().toISOString().slice(0, 10);
+
+  await Promise.all([
+    _incrementBlogView(id),
+    // 日次集計は best-effort。累計カウントを巻き込まないよう失敗は握りつぶすが、
+    // 未適用マイグレーション等によるサイレントな欠落を検知できるようログは残す。
+    Promise.resolve(_incrementBlogViewDaily(id, date)).catch(
+      (error: unknown) => {
+        console.error('Failed to increment blog view daily:', {
+          id,
+          date,
+          error,
+        });
+      },
+    ),
+  ]);
 }

--- a/apps/main/src/features/blog/interface/queries.ts
+++ b/apps/main/src/features/blog/interface/queries.ts
@@ -10,7 +10,9 @@ import {
   getBlogs,
 } from '@/features/blog/application/blogs';
 import { getBlogOgCode as _getBlogOgCode } from '@/features/blog/application/og-code';
-import { getBlogView as _getBlogView } from '@/features/blog/application/view';
+import { estimateReadingTimeMinutes } from '@/features/blog/application/reading-time';
+
+import { getMarkdown } from './markdown';
 
 export async function getBlogContents() {
   'use cache';
@@ -79,10 +81,10 @@ export async function getBlogsByTags(slug: string) {
   );
 }
 
-export async function getBlogView(id: number) {
+export async function getBlogReadingTime(slug: string): Promise<number> {
   'use cache';
-  cacheLife('minutes');
+  cacheLife('max');
 
-  const view = await _getBlogView(id);
-  return view;
+  const markdown = await getMarkdown(slug);
+  return estimateReadingTimeMinutes(markdown);
 }

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -114,6 +114,11 @@ erDiagram
     integer blog_id FK
     integer tag_id FK
   }
+  blog_view_dailies {
+    integer blog_id PK,FK
+    text date PK
+    integer views
+  }
   blog_views {
     integer blog_id PK,FK
     integer views
@@ -221,6 +226,7 @@ erDiagram
   article_sources ||--o{ articles : "article_source_id"
   blogs ||--o{ blog_comment : "blog_id"
   blogs ||--o{ blog_tag : "blog_id"
+  blogs ||--o{ blog_view_dailies : "blog_id"
   blogs ||--o{ blog_views : "blog_id"
   blogs ||--o{ talks : "blog_id"
   comments ||--o{ blog_comment : "comment_id"

--- a/packages/database/migrations/0055_workable_xorn.sql
+++ b/packages/database/migrations/0055_workable_xorn.sql
@@ -1,0 +1,9 @@
+CREATE TABLE `blog_view_dailies` (
+	`blog_id` integer NOT NULL,
+	`date` text NOT NULL,
+	`views` integer DEFAULT 0 NOT NULL,
+	PRIMARY KEY(`blog_id`, `date`),
+	FOREIGN KEY (`blog_id`) REFERENCES `blogs`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `blog_view_dailies_date_idx` ON `blog_view_dailies` (`date`);

--- a/packages/database/migrations/meta/0055_snapshot.json
+++ b/packages/database/migrations/meta/0055_snapshot.json
@@ -1,0 +1,1554 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "42c9ca59-0529-42f3-a3b3-9e993d1d2e23",
+  "prevId": "9853affb-b33a-42df-a4f1-ce1967240802",
+  "tables": {
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_attempts": {
+          "name": "summary_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "article_sources",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_view_dailies": {
+      "name": "blog_view_dailies",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "blog_view_dailies_date_idx": {
+          "name": "blog_view_dailies_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_view_dailies_blog_id_blogs_id_fk": {
+          "name": "blog_view_dailies_blog_id_blogs_id_fk",
+          "tableFrom": "blog_view_dailies",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_view_dailies_blog_id_date_pk": {
+          "columns": [
+            "blog_id",
+            "date"
+          ],
+          "name": "blog_view_dailies_blog_id_date_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "feedbacks",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_logs": {
+      "name": "push_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "succeeded": {
+          "name": "succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed": {
+          "name": "failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_logs_dedupe_key_idx": {
+          "name": "push_logs_dedupe_key_idx",
+          "columns": [
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "push_logs_sent_at_idx": {
+          "name": "push_logs_sent_at_idx",
+          "columns": [
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "push_logs_kind_check": {
+          "name": "push_logs_kind_check",
+          "value": "\"push_logs\".\"kind\" IN ('readings_updated', 'baseline_updated')"
+        }
+      }
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_idx": {
+          "name": "push_subscriptions_endpoint_idx",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_tag": {
+      "name": "slide_tag",
+      "columns": {
+        "slide_id": {
+          "name": "slide_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slide_tag_slide_id_idx": {
+          "name": "slide_tag_slide_id_idx",
+          "columns": [
+            "slide_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_tag_id_idx": {
+          "name": "slide_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_unique_idx": {
+          "name": "slide_tag_unique_idx",
+          "columns": [
+            "slide_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "slide_tag_slide_id_slides_id_fk": {
+          "name": "slide_tag_slide_id_slides_id_fk",
+          "tableFrom": "slide_tag",
+          "tableTo": "slides",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slide_tag_tag_id_tags_id_fk": {
+          "name": "slide_tag_tag_id_tags_id_fk",
+          "tableFrom": "slide_tag",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slides": {
+      "name": "slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slides_slug_idx": {
+          "name": "slides_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "tableTo": "talks",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -386,6 +386,13 @@
       "when": 1782106757872,
       "tag": "0054_zippy_nightshade",
       "breakpoints": true
+    },
+    {
+      "idx": 55,
+      "version": "6",
+      "when": 1782141213327,
+      "tag": "0055_workable_xorn",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/blog-view-dailies.ts
+++ b/packages/database/src/schema/blog-view-dailies.ts
@@ -1,0 +1,28 @@
+import {
+  index,
+  integer,
+  primaryKey,
+  sqliteTable,
+  text,
+} from 'drizzle-orm/sqlite-core';
+
+import { blogs } from './blogs';
+
+// ブログの日次ビュー数を集計する時系列テーブル。
+// (blog_id, date) を複合主キーとし、1日1行に集約する。
+// date は UTC 基準の YYYY-MM-DD 文字列。
+export const blogViewDailies = sqliteTable(
+  'blog_view_dailies',
+  {
+    blogId: integer('blog_id')
+      .notNull()
+      .references(() => blogs.id),
+    date: text('date').notNull(),
+    views: integer('views').notNull().default(0),
+  },
+  (table) => [
+    primaryKey({ columns: [table.blogId, table.date] }),
+    // 全ブログ横断の日付レンジ集計（ダッシュボードの推移表示など）向け
+    index('blog_view_dailies_date_idx').on(table.date),
+  ],
+);

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -14,6 +14,7 @@ import {
 import { baselineSnapshots } from './baseline-snapshots';
 import { blogComment, blogCommentRelations } from './blog-comment';
 import { blogTag, blogTagRelations } from './blog-tag';
+import { blogViewDailies } from './blog-view-dailies';
 import { blogViews } from './blog-views';
 import { blogs, blogsRelations } from './blogs';
 import { comments, commentsRelations } from './comments';
@@ -41,6 +42,7 @@ export const schema = {
   pushLogs,
   blogs,
   blogViews,
+  blogViewDailies,
   blogTag,
   blogComment,
   talks,


### PR DESCRIPTION
## 概要

- 記事ページに推定**読了時間**を表示
- 公開ページの閲覧数表示を削除（閲覧数は管理画面で確認）
- 閲覧数計測を sendBeacon ベースに変更し、**日次集計テーブル**を追加

## 変更点

### 読了時間（feat: 記事ページに読了時間を表示）
- 本文マークダウンから推定（日本語=500字/分・英数=250語/分、コードブロック・URLは除外、最低1分・切り上げ）
- 記事メタ情報に「約N分で読めます」を表示
- 未使用になった `ViewCounter` / `getBlogView` を整理

### 計測の堅牢化 + 日次集計（feat: ブログ閲覧数の計測を堅牢化し日次集計テーブルを追加）
- `ViewReporter` を `sendBeacon` + `keepalive` 化（離脱時の取りこぼし防止）
- 累計カウントを upsert 化（行欠損時も自己修復）
- `blog_view_dailies` テーブルを追加（日次のビュー数を集計）

## マイグレーション
- `0055_workable_xorn.sql`（`blog_view_dailies` 追加）。本番反映には `pnpm -F @repo/database migrate` が必要。

## テスト
- type-check / blog feature unit tests（29 passed）/ lint / ls-lint すべてパス
- ⚠️ `blog-layout` の Story が閲覧数→読了時間に変わるため、**VRT ベースラインの更新**が必要