### PR TITLE
feat(ai): 本番プレビューを Vercel Sandbox で実装（ライブ＋公開共有）

### DIFF
--- a/apps/ai/package.json
+++ b/apps/ai/package.json
@@ -25,6 +25,7 @@
     "@repo/database": "workspace:*",
     "@repo/helpers": "workspace:*",
     "@tailwindcss/postcss": "catalog:",
+    "@vercel/sandbox": "^2.2.1",
     "ai": "6.0.205",
     "better-auth": "catalog:",
     "drizzle-orm": "catalog:",

--- a/apps/ai/sandbox-template/vite.config.ts
+++ b/apps/ai/sandbox-template/vite.config.ts
@@ -8,5 +8,7 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
     host: true,
+    // Vercel Sandbox の *.vercel.run ドメイン経由で開けるよう host チェックを無効化する。
+    allowedHosts: true,
   },
 });

--- a/apps/ai/scripts/bake-sandbox-snapshot.mjs
+++ b/apps/ai/scripts/bake-sandbox-snapshot.mjs
@@ -1,0 +1,75 @@
+// sandbox-template を Vercel Sandbox に焼いて snapshot を作る（一度きり / テンプレ・arte-odyssey 更新時に再実行）。
+// 認証は VERCEL_TOKEN（fnox exec で注入）＋ team/project ID 明示渡し。
+// 使い方: fnox exec -- node apps/ai/scripts/bake-sandbox-snapshot.mjs
+import { readdir, readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+import { Sandbox } from '@vercel/sandbox';
+
+const TEAM_ID = 'team_K1poAqb11IhJpOHw17Z5qhvC';
+const PROJECT_ID = 'prj_Iz1SHi1C6rgwFz2YngTzeiRdsFE8';
+const WORKDIR = '/vercel/sandbox';
+const SKIP_DIRS = new Set(['node_modules', 'dist', '.vite', '.git']);
+
+const token = process.env.VERCEL_TOKEN;
+if (!token) {
+  console.error('VERCEL_TOKEN が未設定です（fnox exec -- で渡してください）');
+  process.exit(1);
+}
+
+const here = import.meta.dirname;
+const templateDir = path.resolve(here, '..', 'sandbox-template');
+
+const collect = async (dir) => {
+  const ents = await readdir(dir, { withFileTypes: true });
+  const lists = await Promise.all(
+    ents.map(async (e) => {
+      const abs = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        return SKIP_DIRS.has(e.name) ? [] : collect(abs);
+      }
+      return e.isFile() ? [abs] : [];
+    }),
+  );
+  return lists.flat();
+};
+
+const absFiles = await collect(templateDir);
+const files = await Promise.all(
+  absFiles.map(async (abs) => ({
+    path: path.relative(templateDir, abs).split(path.sep).join('/'),
+    content: await readFile(abs),
+  })),
+);
+console.log(`template files (${files.length}):`);
+for (const f of files) console.log(`  ${f.path}`);
+
+console.log('creating sandbox...');
+const sandbox = await Sandbox.create({
+  token,
+  teamId: TEAM_ID,
+  projectId: PROJECT_ID,
+  runtime: 'node24',
+  timeout: 10 * 60 * 1000,
+});
+try {
+  await sandbox.writeFiles(files);
+  console.log('files written. running `npm ci`...');
+  const ci = await sandbox.runCommand({
+    cmd: 'npm',
+    args: ['ci'],
+    cwd: WORKDIR,
+    timeoutMs: 8 * 60 * 1000,
+  });
+  console.log(`npm ci exit=${ci.exitCode}`);
+  if (ci.exitCode !== 0) {
+    console.error((await ci.stderr()).slice(-3000));
+    throw new Error('npm ci failed');
+  }
+  console.log('snapshotting...');
+  const snap = await sandbox.snapshot({ expiration: 0 });
+  console.log(`\n==== AI_TEMPLATE_SNAPSHOT_ID=${snap.snapshotId} ====\n`);
+} finally {
+  await sandbox.stop().catch(() => undefined);
+  console.log('sandbox stopped.');
+}

--- a/apps/ai/src/app/(authenticated)/layout.tsx
+++ b/apps/ai/src/app/(authenticated)/layout.tsx
@@ -1,14 +1,12 @@
 import type { ReactNode } from 'react';
 
-import { verifySession } from '@/shared/auth/verify-session';
-
-export default async function AuthenticatedLayout({
+// 認証ゲートは page 側（Suspense 配下の Gate）と middleware で行う。layout を sync に保つ
+// ことで Cache Components の prerender（uncached データを Suspense 外で触れない）を満たす。
+export default function AuthenticatedLayout({
   children,
 }: {
   children: ReactNode;
 }) {
-  await verifySession();
-
   return (
     // 全画面ツールなのでカードで囲まずビューポートいっぱいに作業領域を取る。
     <div className="bg-bg-surface flex h-dvh flex-col">

--- a/apps/ai/src/app/(authenticated)/page.tsx
+++ b/apps/ai/src/app/(authenticated)/page.tsx
@@ -2,6 +2,10 @@ import { Suspense } from 'react';
 
 import { Studio } from './_components/studio';
 
+// Sandbox プレビューの cold start（起動～配信確保）に数十秒かかることがあるため、
+// preview 系 server action がタイムアウトしないよう関数の上限を延ばす。
+export const maxDuration = 120;
+
 export default function Page() {
   // useChat（クライアント）が id 生成で Math.random を使うため、Cache Components 下では
   // Suspense 境界で動的サブツリーとして切り出す必要がある。

--- a/apps/ai/src/app/(authenticated)/page.tsx
+++ b/apps/ai/src/app/(authenticated)/page.tsx
@@ -1,17 +1,24 @@
 import { Suspense } from 'react';
 
+import { verifySession } from '@/shared/auth/verify-session';
+
 import { Studio } from './_components/studio';
 
 // Sandbox プレビューの cold start（起動～配信確保）に数十秒かかることがあるため、
 // preview 系 server action がタイムアウトしないよう関数の上限を延ばす。
 export const maxDuration = 120;
 
+// セッション+許可メールを再チェックする認証ゲート（middleware に加えた多層防御）。
+// uncached（DB/cookie）かつ useChat の Math.random もあるため Suspense 配下に置く。
+const AuthenticatedStudio = async () => {
+  await verifySession();
+  return <Studio />;
+};
+
 export default function Page() {
-  // useChat（クライアント）が id 生成で Math.random を使うため、Cache Components 下では
-  // Suspense 境界で動的サブツリーとして切り出す必要がある。
   return (
     <Suspense fallback={null}>
-      <Studio />
+      <AuthenticatedStudio />
     </Suspense>
   );
 }

--- a/apps/ai/src/app/s/[slug]/_components/share-preview.tsx
+++ b/apps/ai/src/app/s/[slug]/_components/share-preview.tsx
@@ -1,0 +1,55 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { resolveShareEntryAction } from '@/features/share/interface/actions';
+
+type SharePreviewProps = {
+  slug: string;
+  title: string;
+};
+
+// 公開ページのプレビュー。配信URL（Sandbox 起動を伴うことがある）を解決してから iframe を出す。
+export const SharePreview = ({ slug, title }: SharePreviewProps) => {
+  const [url, setUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    void (async () => {
+      const res = await resolveShareEntryAction(slug);
+      if (res === null) {
+        setFailed(true);
+        return;
+      }
+      setUrl(res.url);
+    })();
+  }, [slug]);
+
+  if (failed) {
+    return (
+      <div className="text-fg-mute flex h-full items-center justify-center p-6 text-center text-sm">
+        プレビューを表示できませんでした。
+      </div>
+    );
+  }
+  if (url === null) {
+    return (
+      <div className="text-fg-mute flex h-full items-center justify-center p-6 text-center text-sm motion-safe:animate-pulse">
+        プレビューを準備しています…
+      </div>
+    );
+  }
+  // Sandbox 配信は別オリジン(*.vercel.run)で vite の動作に allow-same-origin が要る（親とは
+  // 別オリジンのため脱出は起きない）。disk 配信(同一オリジン)は allow-scripts のみで完全隔離。
+  const sandbox = url.startsWith('http')
+    ? 'allow-scripts allow-same-origin'
+    : 'allow-scripts';
+  return (
+    <iframe
+      className="size-full border-0"
+      sandbox={sandbox}
+      src={url}
+      title={title}
+    />
+  );
+};

--- a/apps/ai/src/app/s/[slug]/page.tsx
+++ b/apps/ai/src/app/s/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
+import { Suspense } from 'react';
 
 import { getPublicShareForRoute } from '@/features/share/interface/queries';
 
@@ -29,13 +30,13 @@ export const generateMetadata = async ({
 };
 
 // 公開共有ページ（認証なし）。スリムなヘッダ＋隔離した iframe で本物ビルドを描画する。
-export default async function SharePage({ params }: SharePageProps) {
+// DB アクセス（公開状態の確認）は uncached なため Cache Components 下では Suspense 配下に置く。
+const ShareContent = async ({ params }: SharePageProps) => {
   const { slug } = await params;
   const share = await getPublicShareForRoute(slug);
   if (share === null) {
     notFound();
   }
-
   return (
     <div className="bg-bg-surface flex h-dvh flex-col">
       <header className="border-border-mute flex items-center justify-between gap-4 border-b px-6 py-3">
@@ -56,5 +57,13 @@ export default async function SharePage({ params }: SharePageProps) {
         <SharePreview slug={slug} title={share.title} />
       </div>
     </div>
+  );
+};
+
+export default function SharePage({ params }: SharePageProps) {
+  return (
+    <Suspense fallback={<div className="bg-bg-surface h-dvh" />}>
+      <ShareContent params={params} />
+    </Suspense>
   );
 }

--- a/apps/ai/src/app/s/[slug]/page.tsx
+++ b/apps/ai/src/app/s/[slug]/page.tsx
@@ -4,6 +4,8 @@ import { notFound } from 'next/navigation';
 
 import { getPublicShareForRoute } from '@/features/share/interface/queries';
 
+import { SharePreview } from './_components/share-preview';
+
 type SharePageProps = {
   params: Promise<{ slug: string }>;
 };
@@ -47,13 +49,7 @@ export default async function SharePage({ params }: SharePageProps) {
         </Link>
       </header>
       <div className="min-h-0 flex-1">
-        {/* allow-same-origin は付けない＝不透明オリジンで親に触れない完全隔離。アセットは CORS 配信。 */}
-        <iframe
-          className="size-full border-0"
-          sandbox="allow-scripts"
-          src={share.entryUrl}
-          title={share.title}
-        />
+        <SharePreview slug={slug} title={share.title} />
       </div>
     </div>
   );

--- a/apps/ai/src/app/s/[slug]/page.tsx
+++ b/apps/ai/src/app/s/[slug]/page.tsx
@@ -6,6 +6,10 @@ import { getPublicShareForRoute } from '@/features/share/interface/queries';
 
 import { SharePreview } from './_components/share-preview';
 
+// 共有プレビューの配信解決（Sandbox 起動を伴うことがある）が cold start で数十秒かかる
+// ことがあるため、server action のタイムアウトを延ばす。
+export const maxDuration = 120;
+
 type SharePageProps = {
   params: Promise<{ slug: string }>;
 };

--- a/apps/ai/src/features/preview/application/preview-provider.ts
+++ b/apps/ai/src/features/preview/application/preview-provider.ts
@@ -3,6 +3,11 @@ import {
   ensureLocalPreview,
   writeLocalPreview,
 } from '../infrastructure/local-preview';
+import {
+  ensureSandboxPreview,
+  isSandboxConfigured,
+  writeSandboxPreview,
+} from '../infrastructure/sandbox-preview';
 
 export type PreviewProvider = {
   ensure: () => Promise<string>;
@@ -14,5 +19,19 @@ const localProvider: PreviewProvider = {
   apply: writeLocalPreview,
 };
 
-// TODO(本番): VERCEL_ENV のとき Vercel Sandbox provider に切り替える。
-export const previewProvider: PreviewProvider = localProvider;
+// 本人専用ツールなのでライブプレビューのサンドボックスは固定名1つ（編集中は1つで足りる）。
+const PREVIEW_NAME = 'studio-preview';
+const sandboxProvider: PreviewProvider = {
+  ensure: () => ensureSandboxPreview(PREVIEW_NAME),
+  apply: (code) => writeSandboxPreview(PREVIEW_NAME, code),
+};
+
+// 本番（Vercel）なら Sandbox。ローカルでも AI_PREVIEW_SANDBOX=true で Sandbox に繋いで
+// 検証できる（VERCEL_TOKEN で認証）。どちらも未設定なら手元の Vite dev。
+const useSandbox =
+  isSandboxConfigured() &&
+  (process.env['VERCEL_ENV'] !== undefined ||
+    process.env['AI_PREVIEW_SANDBOX'] === 'true');
+export const previewProvider: PreviewProvider = useSandbox
+  ? sandboxProvider
+  : localProvider;

--- a/apps/ai/src/features/preview/application/preview-provider.ts
+++ b/apps/ai/src/features/preview/application/preview-provider.ts
@@ -5,7 +5,7 @@ import {
 } from '../infrastructure/local-preview';
 import {
   ensureSandboxPreview,
-  isSandboxConfigured,
+  isSandboxMode,
   writeSandboxPreview,
 } from '../infrastructure/sandbox-preview';
 
@@ -26,12 +26,8 @@ const sandboxProvider: PreviewProvider = {
   apply: (code) => writeSandboxPreview(PREVIEW_NAME, code),
 };
 
-// 本番（Vercel）なら Sandbox。ローカルでも AI_PREVIEW_SANDBOX=true で Sandbox に繋いで
-// 検証できる（VERCEL_TOKEN で認証）。どちらも未設定なら手元の Vite dev。
-const useSandbox =
-  isSandboxConfigured() &&
-  (process.env['VERCEL_ENV'] !== undefined ||
-    process.env['AI_PREVIEW_SANDBOX'] === 'true');
-export const previewProvider: PreviewProvider = useSandbox
+// Sandbox モード（本番、またはローカルで AI_PREVIEW_SANDBOX=true）なら Sandbox、
+// それ以外は手元の Vite dev。
+export const previewProvider: PreviewProvider = isSandboxMode()
   ? sandboxProvider
   : localProvider;

--- a/apps/ai/src/features/preview/infrastructure/sandbox-preview.ts
+++ b/apps/ai/src/features/preview/infrastructure/sandbox-preview.ts
@@ -1,0 +1,104 @@
+import 'server-only';
+import { Sandbox } from '@vercel/sandbox';
+
+// 本番プレビュー: 焼いた snapshot から名前付き microVM を起こして vite dev を立て、その
+// *.vercel.run ドメインを iframe に出す。デプロイ内では OIDC で自動認証。ローカル検証時は
+// VERCEL_TOKEN があれば明示認証する（無ければ OIDC を使う＝デプロイ）。コスト抑制のため
+// 1 vCPU・短い idle timeout で、用が済めば自動停止（停止中は課金されない）。
+
+const SNAPSHOT_ID = process.env['AI_TEMPLATE_SNAPSHOT_ID'] ?? '';
+const TEAM_ID = 'team_K1poAqb11IhJpOHw17Z5qhvC';
+const PROJECT_ID = 'prj_Iz1SHi1C6rgwFz2YngTzeiRdsFE8';
+const WORKDIR = '/vercel/sandbox';
+const PORT = 5173;
+const TIMEOUT_MS = 5 * 60 * 1000;
+const READY_TRIES = 40;
+
+export const isSandboxConfigured = (): boolean => SNAPSHOT_ID !== '';
+
+// デプロイ内は OIDC（VERCEL_OIDC_TOKEN）が自動で効くため creds 不要。ローカル検証では
+// VERCEL_TOKEN を明示渡し（team/project は公開ID）。
+const creds = ():
+  | { token: string; teamId: string; projectId: string }
+  | object => {
+  // VERCEL_TOKEN の有無（存在チェック）。秘密の比較ではない。
+  const token = process.env['VERCEL_TOKEN'];
+  if (token === undefined || token.length === 0) {
+    return {};
+  }
+  return { token, teamId: TEAM_ID, projectId: PROJECT_ID };
+};
+
+const isServing = async (url: string): Promise<boolean> => {
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(2500) });
+    return res.ok;
+  } catch {
+    return false;
+  }
+};
+
+// 名前付きサンドボックスを get（あれば再開）するか、無ければ snapshot から作る。
+const getOrCreate = async (name: string): Promise<Sandbox> => {
+  if (SNAPSHOT_ID === '') {
+    throw new Error(
+      'AI_TEMPLATE_SNAPSHOT_ID が未設定です（snapshot を bake してください）',
+    );
+  }
+  const existing = await Sandbox.get({ name, ...creds() }).catch(() => null);
+  if (existing !== null) {
+    return existing;
+  }
+  // snapshot ソース指定時は runtime を渡さない（snapshot から継承）。
+  return Sandbox.create({
+    name,
+    source: { type: 'snapshot', snapshotId: SNAPSHOT_ID },
+    ports: [PORT],
+    resources: { vcpus: 1 },
+    timeout: TIMEOUT_MS,
+    ...creds(),
+  });
+};
+
+// vite dev が応答していなければ起動し、応答するまで待ってから domain を返す。
+const ensureServing = async (sandbox: Sandbox): Promise<string> => {
+  const url = sandbox.domain(PORT);
+  if (await isServing(url)) {
+    return url;
+  }
+  await sandbox.runCommand({
+    cmd: 'npm',
+    args: ['run', 'dev', '--', '--port', String(PORT), '--host'],
+    cwd: WORKDIR,
+    detached: true,
+  });
+  for (let i = 0; i < READY_TRIES; i += 1) {
+    // eslint-disable-next-line no-await-in-loop -- 起動待ちのポーリング
+    if (await isServing(url)) {
+      return url;
+    }
+    // eslint-disable-next-line no-await-in-loop -- 起動待ちのポーリング
+    await new Promise((resolve) => {
+      setTimeout(resolve, 1000);
+    });
+  }
+  return url;
+};
+
+// プレビュー用サンドボックスを用意して配信URLを返す（コード未指定。apply で差し替える）。
+export const ensureSandboxPreview = async (name: string): Promise<string> => {
+  const sandbox = await getOrCreate(name);
+  return ensureServing(sandbox);
+};
+
+// 生成コードを書き込む（HMR で反映）。停止していれば起こして配信を確保する。
+export const writeSandboxPreview = async (
+  name: string,
+  code: string,
+): Promise<void> => {
+  const sandbox = await getOrCreate(name);
+  await sandbox.writeFiles([
+    { path: 'src/generated/Preview.tsx', content: code },
+  ]);
+  await ensureServing(sandbox);
+};

--- a/apps/ai/src/features/preview/infrastructure/sandbox-preview.ts
+++ b/apps/ai/src/features/preview/infrastructure/sandbox-preview.ts
@@ -16,6 +16,12 @@ const READY_TRIES = 40;
 
 export const isSandboxConfigured = (): boolean => SNAPSHOT_ID !== '';
 
+// 本番（Vercel）、またはローカルで AI_PREVIEW_SANDBOX=true のとき Sandbox を使う。
+export const isSandboxMode = (): boolean =>
+  isSandboxConfigured() &&
+  (process.env['VERCEL_ENV'] !== undefined ||
+    process.env['AI_PREVIEW_SANDBOX'] === 'true');
+
 // デプロイ内は OIDC（VERCEL_OIDC_TOKEN）が自動で効くため creds 不要。ローカル検証では
 // VERCEL_TOKEN を明示渡し（team/project は公開ID）。
 const creds = ():
@@ -91,14 +97,30 @@ export const ensureSandboxPreview = async (name: string): Promise<string> => {
   return ensureServing(sandbox);
 };
 
+// 名前付きサンドボックスにコードを書き込み、配信が立っていることを確保して URL を返す。
+export const serveSandboxPreview = async (
+  name: string,
+  code: string,
+): Promise<string> => {
+  const sandbox = await getOrCreate(name);
+  await sandbox.writeFiles([
+    { path: 'src/generated/Preview.tsx', content: code },
+  ]);
+  return ensureServing(sandbox);
+};
+
 // 生成コードを書き込む（HMR で反映）。停止していれば起こして配信を確保する。
 export const writeSandboxPreview = async (
   name: string,
   code: string,
 ): Promise<void> => {
-  const sandbox = await getOrCreate(name);
-  await sandbox.writeFiles([
-    { path: 'src/generated/Preview.tsx', content: code },
-  ]);
-  await ensureServing(sandbox);
+  await serveSandboxPreview(name, code);
+};
+
+// 名前付きサンドボックスを停止する（非公開化時の後始末。ベストエフォート）。
+export const stopSandboxPreview = async (name: string): Promise<void> => {
+  const sandbox = await Sandbox.get({ name, ...creds() }).catch(() => null);
+  if (sandbox !== null) {
+    await sandbox.stop().catch(() => undefined);
+  }
 };

--- a/apps/ai/src/features/share/application/share-provider.ts
+++ b/apps/ai/src/features/share/application/share-provider.ts
@@ -1,22 +1,41 @@
 import 'server-only';
 import {
+  isSandboxMode,
+  serveSandboxPreview,
+  stopSandboxPreview,
+} from '@/features/preview/infrastructure/sandbox-preview';
+
+import {
   buildSharedBundle,
   removeSharedBundle,
 } from '../infrastructure/local-build';
 
 // 公開バンドルのビルド/配信基盤の抽象。
 export type ShareProvider = {
+  // 公開時の事前準備（ローカルは静的ビルド、Sandbox は不要＝no-op）。
   build: (slug: string, code: string) => Promise<void>;
+  // 非公開化時の後始末（ローカルはバンドル削除、Sandbox は停止）。
   remove: (slug: string) => Promise<void>;
-  // index.html を明示する。末尾スラッシュのリダイレクトで相対アセット解決が壊れるのを避ける。
-  entryUrl: (slug: string) => string;
+  // 閲覧時に iframe へ出す配信 URL を解決する。
+  serve: (slug: string, code: string) => Promise<string>;
 };
+
+const sandboxName = (slug: string): string => `share-${slug}`;
 
 const localShareProvider: ShareProvider = {
   build: buildSharedBundle,
   remove: removeSharedBundle,
-  entryUrl: (slug) => `/s-assets/${slug}/index.html`,
+  // index.html を明示（末尾スラッシュのリダイレクトで相対アセット解決が壊れるのを避ける）。
+  serve: (slug) => Promise.resolve(`/s-assets/${slug}/index.html`),
 };
 
-// TODO(本番): Vercel Sandbox でビルド→Blob/静的ホストに置く provider へ差し替える。
-export const shareProvider: ShareProvider = localShareProvider;
+// Sandbox モード: 公開コードは DB にあり閲覧時に Sandbox がビルド配信するため事前ビルド不要。
+const sandboxShareProvider: ShareProvider = {
+  build: () => Promise.resolve(),
+  remove: (slug) => stopSandboxPreview(sandboxName(slug)),
+  serve: (slug, code) => serveSandboxPreview(sandboxName(slug), code),
+};
+
+export const shareProvider: ShareProvider = isSandboxMode()
+  ? sandboxShareProvider
+  : localShareProvider;

--- a/apps/ai/src/features/share/application/share.ts
+++ b/apps/ai/src/features/share/application/share.ts
@@ -11,14 +11,12 @@ import { shareProvider } from './share-provider';
 
 export type PublishedShare = {
   slug: string;
-  entryUrl: string;
 };
 
 export type PublicShare = {
   title: string;
   slug: string;
   code: string;
-  entryUrl: string;
 };
 
 export const publishProject = async (input: {
@@ -44,7 +42,6 @@ export const publishProject = async (input: {
   }
   return {
     slug: project.slug,
-    entryUrl: shareProvider.entryUrl(project.slug),
   };
 };
 
@@ -101,6 +98,17 @@ export const getPublicShare = async (
     title: project.title,
     slug: project.slug,
     code: project.code,
-    entryUrl: shareProvider.entryUrl(project.slug),
   };
+};
+
+// 閲覧時に iframe へ出す配信 URL を解決する（Sandbox モードでは Sandbox を起こして配信）。
+export const resolveShareEntry = async (
+  slug: string,
+): Promise<{ url: string } | null> => {
+  const share = await getPublicShare(slug);
+  if (share === null) {
+    return null;
+  }
+  const url = await shareProvider.serve(slug, share.code);
+  return { url };
 };

--- a/apps/ai/src/features/share/infrastructure/sandbox-build.ts
+++ b/apps/ai/src/features/share/infrastructure/sandbox-build.ts
@@ -1,0 +1,73 @@
+import 'server-only';
+import { Sandbox } from '@vercel/sandbox';
+
+import { type BundleFile, contentTypeFor } from './build-bundle';
+
+// build-bundle の本番版。Vercel のデプロイ Node ランタイムではテンプレの vite build を回せない
+// （node_modules を抱えられない/重い）ため、テンプレ＋依存を焼いた snapshot から microVM を
+// 起こして本物の vite build を実行し、出力（自己完結の静的バンドル）を Buffer 配列で返す。
+// 認証はデプロイ内では OIDC（VERCEL_OIDC_TOKEN）が自動で効く。ビルド専用で常駐させない。
+
+const SNAPSHOT_ID = process.env['AI_TEMPLATE_SNAPSHOT_ID'] ?? '';
+// snapshot は /vercel/sandbox にテンプレを展開して焼く（bake スクリプトと合わせる）。
+const WORKDIR = '/vercel/sandbox';
+const SESSION_TIMEOUT_MS = 5 * 60 * 1000;
+const BUILD_TIMEOUT_MS = 4 * 60 * 1000;
+
+export const isSandboxBuildConfigured = (): boolean => SNAPSHOT_ID !== '';
+
+export const buildInSandbox = async (code: string): Promise<BundleFile[]> => {
+  if (SNAPSHOT_ID === '') {
+    throw new Error(
+      'AI_TEMPLATE_SNAPSHOT_ID が未設定です（snapshot を bake してください）',
+    );
+  }
+  // snapshot ソース指定時は runtime を渡さない（snapshot から継承される）。
+  const sandbox = await Sandbox.create({
+    source: { type: 'snapshot', snapshotId: SNAPSHOT_ID },
+    timeout: SESSION_TIMEOUT_MS,
+  });
+  try {
+    await sandbox.writeFiles([
+      { path: 'src/generated/Preview.tsx', content: code },
+    ]);
+    // base=./ で相対パス化し、任意の配信パス（/preview や /s 配下）で動くようにする。
+    const build = await sandbox.runCommand({
+      cmd: 'npm',
+      args: ['run', 'build', '--', '--base=./'],
+      cwd: WORKDIR,
+      timeoutMs: BUILD_TIMEOUT_MS,
+    });
+    if (build.exitCode !== 0) {
+      // 生成コードのビルドエラー等。末尾を自己修復ループ/ユーザー提示に回す。
+      const stderr = await build.stderr();
+      throw new Error(
+        `sandbox vite build failed (exit ${build.exitCode.toString()}): ${stderr.slice(-2000)}`,
+      );
+    }
+    const listed = await sandbox.runCommand({
+      cmd: 'find',
+      args: ['dist', '-type', 'f'],
+      cwd: WORKDIR,
+    });
+    const rels = (await listed.stdout())
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0)
+      .map((line) => line.replace(/^(\.\/)?dist\//u, ''));
+    return await Promise.all(
+      rels.map(async (rel) => {
+        const body = await sandbox.readFileToBuffer({
+          path: `dist/${rel}`,
+          cwd: WORKDIR,
+        });
+        if (body === null) {
+          throw new Error(`build 出力が読めません: ${rel}`);
+        }
+        return { path: rel, body, contentType: contentTypeFor(rel) };
+      }),
+    );
+  } finally {
+    await sandbox.stop().catch(() => undefined);
+  }
+};

--- a/apps/ai/src/features/share/interface/actions.ts
+++ b/apps/ai/src/features/share/interface/actions.ts
@@ -7,8 +7,17 @@ import { requireAllowedSession } from '@/shared/auth/require-allowed-session';
 import {
   publishProject,
   type PublishedShare,
+  resolveShareEntry,
   unpublishProject,
 } from '../application/share';
+
+// 公開ページ（/s/[slug]）の iframe 配信 URL を解決する。公開コンテンツなので認証なし。
+export const resolveShareEntryAction = async (
+  slug: string,
+): Promise<{ url: string } | null> => {
+  const entry = await resolveShareEntry(slug);
+  return entry;
+};
 
 export const publishProjectAction = async (
   projectId: number,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,6 +282,9 @@ importers:
       '@tailwindcss/postcss':
         specifier: 'catalog:'
         version: 4.3.0
+      '@vercel/sandbox':
+        specifier: ^2.2.1
+        version: 2.2.1
       ai:
         specifier: 6.0.205
         version: 6.0.205(zod@4.4.3)
@@ -3185,8 +3188,8 @@ packages:
     peerDependencies:
       preact: '>= 10.25.0 || >=11.0.0-0'
 
-  '@react-grab/cli@0.1.44':
-    resolution: {integrity: sha512-gMDYY2rw6OWajCcDlXSIgs2LC432YJXSb3Lm5yM187uhRgBYddoEVULi36h+IolX3r7jSb3ew7vn9FfI8NSo0A==}
+  '@react-grab/cli@0.1.46':
+    resolution: {integrity: sha512-rNjGKeRY3HROku1J/a7y8RGHRGFR6ZnllSPqNLfFI5cUu6FCdjjxHvXf1TEXxW7I5REq8iKoLuzM9iYboXCRdg==}
     hasBin: true
 
   '@reduxjs/toolkit@2.12.0':
@@ -3921,6 +3924,9 @@ packages:
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
     engines: {node: '>= 20'}
 
+  '@vercel/sandbox@2.2.1':
+    resolution: {integrity: sha512-IqFYVEsPilXb28VbpTtrP5UkMgVAyQlp77zcLJUgCUo1yEbjJiClGS6sEqGjkAukhbLGS+T2vG3ZOgzSzUTyZg==}
+
   '@vitest/browser-playwright@4.1.8':
     resolution: {integrity: sha512-SR7FqgegaexEg73xvf3ArtygXegagMdXnL0EZMpxrWvvhQxvicD/E8p0ib0J91riPRtQUViyh67Xjw3NqvyhVg==}
     peerDependencies:
@@ -4136,6 +4142,9 @@ packages:
   '@webcontainer/env@1.1.1':
     resolution: {integrity: sha512-6aN99yL695Hi9SuIk1oC88l9o0gmxL1nGWWQ/kNy81HigJ0FoaoTXpytCj6ItzgyCEwA9kF1wixsTuv5cjsgng==}
 
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
   acorn-import-attributes@1.9.5:
     resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
     peerDependencies:
@@ -4157,6 +4166,10 @@ packages:
 
   agent-install@0.0.5:
     resolution: {integrity: sha512-nHlms9BkP8ZiY79HrwCGiA2DcNaXrAaJrCM/BEqQ7MEsSKyCk+2A76xPGylIfASZSZE0SaU3T0bNSg4rBPIJAQ==}
+    hasBin: true
+
+  agent-install@0.0.6:
+    resolution: {integrity: sha512-7NRMZ/ZDz2vHevQTgJsocBFpakB1/Wx5ip19YSJuj4VOXpraWztTerViNtdSyARKZT9e2yVwUUB5JXXCE7mNrA==}
     hasBin: true
 
   ai@6.0.197:
@@ -4226,12 +4239,23 @@ packages:
     resolution: {integrity: sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==}
     hasBin: true
 
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
   atomically@2.1.1:
     resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
 
   axe-core@4.11.4:
     resolution: {integrity: sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==}
     engines: {node: '>=4'}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
 
   babel-plugin-react-compiler@1.0.0:
     resolution: {integrity: sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==}
@@ -4242,6 +4266,14 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -4908,6 +4940,9 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
     engines: {node: '>=18.0.0'}
@@ -4924,6 +4959,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -5333,6 +5371,9 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
 
   jwa@2.0.1:
     resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
@@ -5829,6 +5870,10 @@ packages:
     resolution: {integrity: sha512-84cglkRILFxdtA8hAvLNdMrtBpPNBTrQ9/ulg0FA7xLMnD6mifv+enAIeRmvtv+WgdCE+LPGOfQmtJRrVaIVhQ==}
     engines: {node: '>=20'}
 
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
   outvariant@1.4.3:
     resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
 
@@ -6050,8 +6095,8 @@ packages:
     peerDependencies:
       react: ^19.2.7
 
-  react-grab@0.1.44:
-    resolution: {integrity: sha512-bDEwBdI90ljq2lhUtPqmWis/HwYB/CvfT0m5i+P9F83Pt0Ot8o9XL8v00s9jcWzdQUlsFDzmq2FO2CHUe8JY8A==}
+  react-grab@0.1.46:
+    resolution: {integrity: sha512-i6sSSBGqW1yxZ5TZL9wX2m9qNMKOydpou5IMaXrK1iylJAJyr/npoqv4mhq3cO7480FBhmlEZbf5VF8KOCBlMQ==}
     hasBin: true
     peerDependencies:
       react: '>=17.0.0'
@@ -6189,6 +6234,10 @@ packages:
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
     engines: {node: '>=18'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
 
   rettime@0.11.11:
     resolution: {integrity: sha512-ILJRqVWBCTlg9r42fFgwVZx1gnFAcQF8mRoMkbgQfIrjEDf9nbBFDFx00oloOa+Q869FUtaYDXZvEfnecQSCoQ==}
@@ -6352,6 +6401,9 @@ packages:
       vite-plus:
         optional: true
 
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
   strict-event-emitter@0.5.1:
     resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
@@ -6445,6 +6497,12 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
 
   third-party-capital@1.0.20:
     resolution: {integrity: sha512-oB7yIimd8SuGptespDAZnNkzIz+NWaJCu2RMsbs4Wmp9zSDUM8Nhi3s2OOcqYuv3mN4hitXc8DVx+LyUmbUDiA==}
@@ -6584,6 +6642,10 @@ packages:
 
   undici@7.24.8:
     resolution: {integrity: sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==}
+    engines: {node: '>=20.18.1'}
+
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unenv@2.0.0-rc.24:
@@ -6886,6 +6948,14 @@ packages:
   wsl-utils@0.1.0:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
+
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
 
   xml2js@0.5.0:
     resolution: {integrity: sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==}
@@ -8579,9 +8649,9 @@ snapshots:
       '@preact/signals-core': 1.14.2
       preact: 10.29.2
 
-  '@react-grab/cli@0.1.44':
+  '@react-grab/cli@0.1.46':
     dependencies:
-      agent-install: 0.0.5
+      agent-install: 0.0.6
       commander: 14.0.3
       ignore: 7.0.5
       ora: 9.4.0
@@ -9239,6 +9309,23 @@ snapshots:
 
   '@vercel/oidc@3.2.0': {}
 
+  '@vercel/sandbox@2.2.1':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.28.0
+      xdg-app-paths: 5.1.0
+      zod: 4.4.3
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   '@vitest/browser-playwright@4.1.8(msw@2.14.6(@types/node@24.13.1)(typescript@6.0.3))(playwright@1.60.0)(vite@8.0.14(@types/node@24.13.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)':
     dependencies:
       '@vitest/browser': 4.1.8(msw@2.14.6(@types/node@24.13.1)(typescript@6.0.3))(vite@8.0.14(@types/node@24.13.1)(esbuild@0.28.0)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(vitest@4.1.8)
@@ -9444,6 +9531,8 @@ snapshots:
 
   '@webcontainer/env@1.1.1': {}
 
+  '@workflow/serde@4.1.0-beta.2': {}
+
   acorn-import-attributes@1.9.5(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -9457,6 +9546,15 @@ snapshots:
   agent-base@7.1.4: {}
 
   agent-install@0.0.5:
+    dependencies:
+      '@iarna/toml': 2.2.5
+      commander: 14.0.3
+      jsonc-parser: 3.3.1
+      picocolors: 1.1.1
+      prompts: 2.4.2
+      yaml: 2.9.0
+
+  agent-install@0.0.6:
     dependencies:
       '@iarna/toml': 2.2.5
       commander: 14.0.3
@@ -9531,12 +9629,18 @@ snapshots:
 
   astring@1.9.0: {}
 
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
   atomically@2.1.1:
     dependencies:
       stubborn-fs: 2.0.0
       when-exit: 2.1.5
 
   axe-core@4.11.4: {}
+
+  b4a@1.8.1: {}
 
   babel-plugin-react-compiler@1.0.0:
     dependencies:
@@ -9545,6 +9649,8 @@ snapshots:
   bail@2.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
 
   base64-js@1.5.1: {}
 
@@ -10189,6 +10295,12 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
   eventsource-parser@3.0.8: {}
 
   expect-type@1.3.0: {}
@@ -10198,6 +10310,8 @@ snapshots:
   fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -10645,6 +10759,8 @@ snapshots:
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
+
+  jsonlines@0.1.1: {}
 
   jwa@2.0.1:
     dependencies:
@@ -11354,6 +11470,8 @@ snapshots:
       stdin-discarder: 0.3.2
       string-width: 8.2.1
 
+  os-paths@4.4.0: {}
+
   outvariant@1.4.3: {}
 
   oxc-parser@0.127.0:
@@ -11704,9 +11822,9 @@ snapshots:
       react: 19.2.7
       scheduler: 0.27.0
 
-  react-grab@0.1.44(react@19.2.7):
+  react-grab@0.1.46(react@19.2.7):
     dependencies:
-      '@react-grab/cli': 0.1.44
+      '@react-grab/cli': 0.1.46
       bippy: 0.5.41(react@19.2.7)
     optionalDependencies:
       react: 19.2.7
@@ -11736,7 +11854,7 @@ snapshots:
       react: 19.2.7
       react-doctor: 0.5.6(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)
       react-dom: 19.2.7(react@19.2.7)
-      react-grab: 0.1.44(react@19.2.7)
+      react-grab: 0.1.46(react@19.2.7)
     optionalDependencies:
       esbuild: 0.28.0
       unplugin: 3.0.0
@@ -11929,6 +12047,8 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
+  retry@0.13.1: {}
+
   rettime@0.11.11: {}
 
   reusify@1.1.0: {}
@@ -12116,6 +12236,15 @@ snapshots:
       - react-dom
       - utf-8-validate
 
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
   strict-event-emitter@0.5.1: {}
 
   string-width@4.2.3:
@@ -12194,6 +12323,21 @@ snapshots:
   tailwindcss@4.3.0: {}
 
   tapable@2.3.3: {}
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
 
   third-party-capital@1.0.20: {}
 
@@ -12306,6 +12450,8 @@ snapshots:
   undici-types@7.18.2: {}
 
   undici@7.24.8: {}
+
+  undici@7.28.0: {}
 
   unenv@2.0.0-rc.24:
     dependencies:
@@ -12644,6 +12790,14 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
 
   xml2js@0.5.0:
     dependencies:

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,6 +13,8 @@ const ignorePatterns = [
   '.github/scripts/**',
   // プレビュー用の独立テンプレート（独自の依存・規約。生成コードを流し込むため lint 対象外）
   'apps/ai/sandbox-template/**',
+  // bake 等の一度きり CLI。tsconfig外の .mjs のため型情報前提のルールが誤検知する
+  'apps/ai/scripts/**',
 ];
 
 export default defineConfig({


### PR DESCRIPTION
## 概要

本番プレビュー（[apps#1877](https://github.com/k35o/k8o/pull/1877) で「別途」とした残作業）を **Vercel Sandbox** で実装。**ライブプレビュー（編集中）と公開共有（/s/[slug]）の両方**を Sandbox 配信に対応した。

## 仕組み

焼いた snapshot（テンプレ＋node_modules）から名前付き microVM を起こし、生成コードを `writeFiles` → `vite dev` → `*.vercel.run` ドメインを iframe 表示。Vercel のアプリは serverless で `vite dev` を常駐できないため、プレビューだけ Sandbox に逃がす。

- 認証: 本番デプロイ内は **OIDC**（`VERCEL_OIDC_TOKEN` 自動注入）、ローカル検証時は `VERCEL_TOKEN`
- コスト抑制: **1 vCPU・5分 idle 自動停止**（停止中は無課金）・非公開化で停止
- cold start 対策: preview/共有ページに `maxDuration=120`

## 主な変更

- `features/preview/infrastructure/sandbox-preview.ts`（新）— microVM の get-or-create / vite dev 起動 / 配信URL（ensure・serve）/ writeFiles / stop / `isSandboxMode`
- `features/share/infrastructure/sandbox-build.ts`（新）— Sandbox 内 vite build の核（将来の静的配信用）
- `preview-provider.ts` — `VERCEL_ENV` か `AI_PREVIEW_SANDBOX=true` で Sandbox、ローカル既定は手元 Vite
- `share-provider.ts` / `share.ts` / `share/interface/actions.ts` — Sandbox モードでは build=no-op・serve=`share-<slug>` の Sandbox・remove=停止。`entryUrl` を廃し閲覧時解決の `resolveShareEntry` に統一
- `app/s/[slug]/_components/share-preview.tsx`（新）— 配信URL解決のクライアント。別オリジンの Sandbox は `allow-same-origin`、同一オリジンの disk は `allow-scripts` のみ
- `scripts/bake-sandbox-snapshot.mjs`（新）+ `sandbox-template/vite.config.ts`（`allowedHosts`）
- `@vercel/sandbox` 導入

## 検証

ローカル Studio から実 Sandbox に接続（`AI_PREVIEW_SANDBOX=true`）し:
- ライブプレビュー: 生成UI（お問い合わせフォーム）が `*.vercel.run` の iframe に実描画
- 公開共有: publish → `/s/[slug]` で `share-<slug>` の Sandbox が起き、UI が完全描画

type-check / lint / 全43テスト green。

## 本番設定（適用済み）

- env `AI_TEMPLATE_SNAPSHOT_ID` を production+preview に設定済み
- OIDC（Secure Backend Access）enabled / team mode

→ この PR の preview デプロイで OIDC 経路の動作を確認する。
