### PR TITLE
fix(ci): 初回デプロイで ignore-build が永久に skip する問題を修正

### DIFF
--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -55,6 +55,13 @@ if [ "$BASE_SHA" = "origin/main" ]; then
   fi
 fi
 
+# 前回成功デプロイが無い（新規プロジェクトの初回など）と BASE が origin/main = HEAD 自身に
+# 解決し、差分が常に空になって永久に skip してしまう。判定不能なので安全側に倒してビルドする。
+if [ "$(git rev-parse --verify "$BASE_SHA" 2>/dev/null)" = "$(git rev-parse --verify HEAD 2>/dev/null)" ]; then
+  log "Proceeding: BASE_SHA resolves to HEAD (no previous deploy / first build)"
+  exit 1
+fi
+
 # 変更ファイルが取得できなければ安全側に倒してビルド
 if ! CHANGED_FILES=$(git diff --name-only "$BASE_SHA" HEAD 2>&1); then
   log "Proceeding: failed to get changed files ($CHANGED_FILES)"


### PR DESCRIPTION
## 問題
新規 Vercel プロジェクトの**初回 production デプロイがビルドされない**（CANCELED され続ける）。

`scripts/ignore-build.sh` は main の production 判定で「**前回成功デプロイのSHA**」を差分 BASE に使う設計だが、初回は成功デプロイが無く `VERCEL_GIT_PREVIOUS_SHA` が空 → BASE が `origin/main` = **デプロイ対象の HEAD 自身**に解決 → `git diff` が常に空 → affected なし → **skip**。「成功デプロイが無い→常に skip→成功デプロイができない」の chicken-and-egg。

## 修正
fetch 後・差分計算前に「**BASE が HEAD と同一に解決したら判定不能として安全側でビルド**」を追加。

- 既存デプロイ済みの app（k8o / k8o-admin。BASE=前回SHA≠HEAD）は**この分岐に入らず無影響**
- 一般的な「初回デプロイ」バグの修正

## 検証
- `bash -n` 構文OK
- BASE=HEAD → exit 1(build) / BASE=別SHA → 通常ロジック を確認

きっかけ: 新規 `ai` プロジェクトの初回 production デプロイが CANCELED され続けた（API で3回試行、すべて skip）。マージ後の production デプロイで自走ビルドされる想定。