### PR TITLE
fix(ai): Studio のURL復元(?project) と プレビュー sandbox の snapshot 反映

### DIFF
--- a/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
@@ -74,7 +74,6 @@ export const Studio = () => {
     const id = raw === null ? Number.NaN : Number(raw);
     bootProjectIdRef.current = Number.isInteger(id) && id > 0 ? id : null;
   }
-  const urlSyncedRef = useRef(false);
 
   const { messages, sendMessage, status, error, setMessages, stop } = useChat({
     transport: new DefaultChatTransport({ api: '/api/generate' }),
@@ -214,6 +213,7 @@ export const Studio = () => {
     setHistoryOpen(false);
     setView('preview');
     setMobileTab('chat');
+    router.replace('/');
   };
 
   const handleSelectProject = async (id: number): Promise<void> => {
@@ -276,28 +276,30 @@ export const Studio = () => {
     }
   };
 
-  // 初回マウント時、URL に ?project=<id> があればそのプロジェクトを復元する（一度きり）。
-  // 初回レンダーの loader を ref に固定し、effect の依存を安定させる（マウント時のみ実行）。
+  // 初回マウント時、URL に ?project=<id> があればそのプロジェクトを復元する。
+  // 初回レンダーの loader を ref に固定し依存を安定させ、Strict Mode の二重実行でも
+  // bootedRef で1回だけロードする。
   const bootLoadRef = useRef(handleSelectProject);
+  const bootedRef = useRef(false);
   useEffect(() => {
+    if (bootedRef.current) {
+      return;
+    }
+    bootedRef.current = true;
     const bootId = bootProjectIdRef.current;
     if (bootId !== null && bootId !== undefined) {
       void bootLoadRef.current(bootId);
     }
   }, []);
 
-  // 現在のプロジェクトを URL に反映する（初期状態は /、選択中は ?project=<id>）。
-  // 初回は URL からの復元を優先し、ここでは書き換えない。
+  // 選択中プロジェクトを URL(?project=<id>) に反映する。projectId が null のとき
+  // （初期 / boot 中 / 新規）は書き換えない。boot の ?project を握り潰さず、実行回数ではなく
+  // 値で判定するため Strict Mode の二重実行でも安全。新規化での「/」戻しは handleNewProject で行う。
   useEffect(() => {
-    if (!urlSyncedRef.current) {
-      urlSyncedRef.current = true;
+    if (persistence.projectId === null) {
       return;
     }
-    router.replace(
-      persistence.projectId === null
-        ? '/'
-        : `/?project=${persistence.projectId.toString()}`,
-    );
+    router.replace(`/?project=${persistence.projectId.toString()}`);
   }, [persistence.projectId, router]);
 
   return (

--- a/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
@@ -13,6 +13,7 @@ import {
 } from '@k8o/arte-odyssey';
 import { DefaultChatTransport, type UIMessage } from 'ai';
 import { useTheme } from 'next-themes';
+import { useRouter, useSearchParams } from 'next/navigation';
 import {
   type KeyboardEvent,
   useEffect,
@@ -64,6 +65,16 @@ export const Studio = () => {
   const lastPromptRef = useRef('');
   const { resolvedTheme } = useTheme();
   const persistence = useStudioPersistence();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  // URL の ?project=<id> を初回レンダーで一度だけ拾い、リロード/ブックマークから復元する。
+  const bootProjectIdRef = useRef<number | null | undefined>(undefined);
+  if (bootProjectIdRef.current === undefined) {
+    const raw = searchParams.get('project');
+    const id = raw === null ? Number.NaN : Number(raw);
+    bootProjectIdRef.current = Number.isInteger(id) && id > 0 ? id : null;
+  }
+  const urlSyncedRef = useRef(false);
 
   const { messages, sendMessage, status, error, setMessages, stop } = useChat({
     transport: new DefaultChatTransport({ api: '/api/generate' }),
@@ -264,6 +275,30 @@ export const Studio = () => {
       await handleSelectProject(newId);
     }
   };
+
+  // 初回マウント時、URL に ?project=<id> があればそのプロジェクトを復元する（一度きり）。
+  // 初回レンダーの loader を ref に固定し、effect の依存を安定させる（マウント時のみ実行）。
+  const bootLoadRef = useRef(handleSelectProject);
+  useEffect(() => {
+    const bootId = bootProjectIdRef.current;
+    if (bootId !== null && bootId !== undefined) {
+      void bootLoadRef.current(bootId);
+    }
+  }, []);
+
+  // 現在のプロジェクトを URL に反映する（初期状態は /、選択中は ?project=<id>）。
+  // 初回は URL からの復元を優先し、ここでは書き換えない。
+  useEffect(() => {
+    if (!urlSyncedRef.current) {
+      urlSyncedRef.current = true;
+      return;
+    }
+    router.replace(
+      persistence.projectId === null
+        ? '/'
+        : `/?project=${persistence.projectId.toString()}`,
+    );
+  }, [persistence.projectId, router]);
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">

--- a/apps/ai/src/features/preview/infrastructure/sandbox-preview.ts
+++ b/apps/ai/src/features/preview/infrastructure/sandbox-preview.ts
@@ -19,6 +19,13 @@ const PORT = 5173;
 const TIMEOUT_MS = 5 * 60 * 1000;
 const READY_TRIES = 40;
 
+// snapshot 由来の短いタグ。sandbox 名に付けることで、snapshot が変わると名前も変わり、
+// 旧 snapshot で作った sandbox を get で再利用しなくなる（= テンプレ更新が即プレビューに反映）。
+const SNAPSHOT_TAG = SNAPSHOT_ID.replaceAll(/[^a-z0-9]/giu, '')
+  .slice(-12)
+  .toLowerCase();
+const named = (name: string): string => `${name}-${SNAPSHOT_TAG}`;
+
 // デプロイ内は OIDC（VERCEL_OIDC_TOKEN）が自動で効くため creds 不要。ローカルでは
 // VERCEL_TOKEN を明示渡し（team/project は公開ID）。
 const creds = ():
@@ -48,13 +55,16 @@ const getOrCreate = async (name: string): Promise<Sandbox> => {
       'AI_TEMPLATE_SNAPSHOT_ID が未設定です（snapshot を bake してください）',
     );
   }
-  const existing = await Sandbox.get({ name, ...creds() }).catch(() => null);
+  const fullName = named(name);
+  const existing = await Sandbox.get({ name: fullName, ...creds() }).catch(
+    () => null,
+  );
   if (existing !== null) {
     return existing;
   }
   // snapshot ソース指定時は runtime を渡さない（snapshot から継承）。
   return Sandbox.create({
-    name,
+    name: fullName,
     source: { type: 'snapshot', snapshotId: SNAPSHOT_ID },
     ports: [PORT],
     resources: { vcpus: 1 },
@@ -116,7 +126,9 @@ export const writeSandboxPreview = async (
 
 // 名前付きサンドボックスを停止する（非公開化時の後始末。ベストエフォート）。
 export const stopSandboxPreview = async (name: string): Promise<void> => {
-  const sandbox = await Sandbox.get({ name, ...creds() }).catch(() => null);
+  const sandbox = await Sandbox.get({ name: named(name), ...creds() }).catch(
+    () => null,
+  );
   if (sandbox !== null) {
     await sandbox.stop().catch(() => undefined);
   }


### PR DESCRIPTION
## 概要

k8o AI Studio の2点を修正。

## 1. 現在プロジェクトを URL に反映（`feat`）

履歴を切り替えても URL が変わらず、**リロード/ブックマークで復元できなかった**問題を解消。

- 初期状態は `/`、プロジェクト選択中は `/?project=<id>`（`router.replace` で同期）。
- 初回マウント時に `?project=<id>` があればそのプロジェクトを復元。
- URL 同期は `persistence.projectId` の変化に追従するため、選択・新規・生成保存・フォークを一元的にカバー。
- クエリパラメータ方式にしたのは、ルート遷移で Studio が remount して `useChat`/reducer の状態が飛ぶのを避けるため（同一ルートのソフト更新で状態保持）。

## 2. プレビュー sandbox に snapshot タグを付与（`fix`）

テーマ切替で**プレビュー iframe だけ切り替わらない**現象の根本原因対応。

- 旧来は sandbox 名が固定（`studio-preview` / `share-<slug>`）で、`getOrCreate` が**旧 snapshot で作った sandbox を get で再利用し続けていた**。そのため、新 snapshot に焼いたテンプレ更新（テーマ切替の `postMessage` 受け口など）が反映されなかった。
- sandbox 名に snapshot 由来の短いタグを付与し、**snapshot が変われば必ず新しい sandbox を作る**ようにした。`stopSandboxPreview` も同じ命名に合わせる。

## 確認済み

- `pnpm -w run check`（lint/format）✓ 0 errors
- `pnpm -F ai run type-check` ✓
- ai feature tests 35 ✓（snapshot ガードテスト含む）

## 未確認 / 補足

- 2 は本番デプロイ後、旧 `studio-preview` sandbox が失効して新タグの sandbox が立ち上がってから効く。
- テーマ切替が「アプリのガワは切り替わるが iframe は切り替わらない」挙動は、iframe が旧 snapshot で動いているシグネチャ。本 PR で命名を snapshot 連動にしたことで構造的に解消する見込み。