### PR TITLE
fix(ai): Studio プレビューのローディング表示・考え中バグ修正・生成中のコード実況

### DIFF
--- a/apps/ai/src/app/(authenticated)/_components/studio/preview-loading.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/preview-loading.tsx
@@ -1,0 +1,23 @@
+import type { FC } from 'react';
+
+type PreviewLoadingProps = {
+  message: string;
+};
+
+// プレビューのロード/反映待ちを覆うオーバーレイ。
+// 親（プレビュー枠）を relative にして上に重ね、iframe の読み込み完了で呼び出し側が外す。
+// 背景は bg-surface で塗り、リロード中の空白や前回の描画が透けないようにする。
+export const PreviewLoading: FC<PreviewLoadingProps> = ({ message }) => (
+  <div className="bg-bg-surface absolute inset-0 z-10 flex flex-col items-center justify-center gap-3">
+    <div
+      aria-hidden
+      className="border-border-mute border-t-fg-base size-8 rounded-full border-2 motion-safe:animate-spin"
+    />
+    <p
+      aria-live="polite"
+      className="text-fg-mute text-sm leading-relaxed motion-safe:animate-pulse"
+    >
+      {message}
+    </p>
+  </div>
+);

--- a/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
@@ -140,6 +140,9 @@ export const Studio = () => {
   const lastAssistant = messages.findLast(
     (message) => message.role === 'assistant',
   );
+  // 生成中表示は「会話の最後のメッセージ」だけに付ける。submitted 中はまだ assistant が
+  // 増えていない（最後は user メッセージ）ので、直前ターンの回答が「考え中」に化けない。
+  const lastMessageId = messages.at(-1)?.id;
   const streamingCode =
     lastAssistant === undefined
       ? null
@@ -480,7 +483,7 @@ export const Studio = () => {
                     );
                   }
                   const description = parseGeneration(text).meta?.description;
-                  const working = isBusy && message.id === lastAssistant?.id;
+                  const working = isBusy && message.id === lastMessageId;
                   return (
                     <div className="flex flex-col gap-1.5" key={message.id}>
                       <span className="text-fg-mute text-xs font-bold">AI</span>

--- a/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
@@ -39,6 +39,7 @@ import {
 
 import { CodePanel } from './code-panel';
 import { CopyCodeButton } from './copy-code-button';
+import { PreviewLoading } from './preview-loading';
 import { ProjectHistory } from './project-history';
 import { ShareControl } from './share-control';
 import { useStudioPersistence } from './use-studio-persistence';
@@ -53,6 +54,10 @@ export const Studio = () => {
   );
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
   const [previewNonce, setPreviewNonce] = useState(0);
+  // プレビューへの反映〜iframe 読み込み完了までを覆うローディング。完了は iframe の onLoad で外す。
+  const [previewLoading, setPreviewLoading] = useState(false);
+  // 環境（Sandbox）の用意に失敗したとき。スピナーが回り続けないよう案内に切り替える。
+  const [previewFailed, setPreviewFailed] = useState(false);
   const [view, setView] = useState<PanelView>('preview');
   // 小画面では2ペインを並べられないので、タブで1つずつ表示する。
   const [mobileTab, setMobileTab] = useState<'chat' | 'preview' | 'code'>(
@@ -101,6 +106,8 @@ export const Studio = () => {
           if (parsed.code === null) {
             return;
           }
+          // 反映〜iframe 読み込み完了までローディングを出す（プレビュー表示が遅れても状態が分かるように）。
+          setPreviewLoading(true);
           const res = await applyPreviewCode(parsed.code);
           if (res.ok) {
             setApplyError(null);
@@ -109,6 +116,8 @@ export const Studio = () => {
             setMobileTab('preview');
             return;
           }
+          // 反映に失敗したら iframe は再読込されず onLoad も来ないので、ローディングはここで外す。
+          setPreviewLoading(false);
           // エラーを次ターンの system に流して自動修復を促す（プレビューは前回の正常版のまま＝白画面にしない）。
           if (res.error !== undefined) {
             setApplyError(res.error);
@@ -123,12 +132,18 @@ export const Studio = () => {
 
   const isBusy = status === 'submitted' || status === 'streaming';
 
-  // 起動時にプレビューセッション（ローカルVite）を用意する。
+  // 起動時にプレビューセッション（Sandbox）を用意する。失敗時は無限スピナーにせず案内を出す。
   useEffect(() => {
     void (async () => {
-      const res = await startPreviewSession();
-      if (res !== null) {
-        setPreviewUrl(res.url);
+      try {
+        const res = await startPreviewSession();
+        if (res === null) {
+          setPreviewFailed(true);
+        } else {
+          setPreviewUrl(res.url);
+        }
+      } catch {
+        setPreviewFailed(true);
       }
     })();
   }, []);
@@ -178,6 +193,9 @@ export const Studio = () => {
     }
     setInput('');
     setApplyError(null);
+    // 生成中はコードが組み上がる様子を実況する（完了後に onFinish がプレビューへ戻す）。
+    // モバイルはチャットの「考えています…」を残したいので mobileTab は切り替えない。
+    setView('code');
     lastPromptRef.current = text;
     await sendMessage(
       { text },
@@ -258,11 +276,15 @@ export const Studio = () => {
     );
     setMessages(restored);
     setApplyError(null);
+    setPreviewLoading(true);
     const res = await applyPreviewCode(project.code);
     if (res.ok) {
       setPreviewNonce((nonce) => nonce + 1);
       setView('preview');
       setMobileTab('preview');
+    } else {
+      // 反映失敗時は iframe が再読込されない＝onLoad が来ないので、ここで外す。
+      setPreviewLoading(false);
     }
   };
 
@@ -589,14 +611,29 @@ export const Studio = () => {
           }`}
         >
           <div className="min-h-0 flex-1 overflow-hidden" ref={frameRef}>
-            <div className={view === 'preview' ? 'h-full' : 'hidden'}>
-              {previewUrl !== null && hasResult ? (
-                <ThemedPreviewIframe
-                  key={previewNonce}
-                  theme={resolvedTheme}
-                  title="preview"
-                  url={previewUrl}
-                />
+            <div className={view === 'preview' ? 'relative h-full' : 'hidden'}>
+              {previewFailed ? (
+                <div className="text-fg-mute flex h-full items-center justify-center p-6 text-center text-sm leading-relaxed">
+                  プレビュー環境を準備できませんでした。ページを再読み込みしてください。
+                </div>
+              ) : previewUrl === null ? (
+                // サンドボックスの起動待ち（cold start）。ここが遅いことが多いので明示する。
+                <PreviewLoading message="プレビュー環境を準備しています…" />
+              ) : hasResult ? (
+                <>
+                  <ThemedPreviewIframe
+                    key={previewNonce}
+                    onLoad={() => {
+                      setPreviewLoading(false);
+                    }}
+                    theme={resolvedTheme}
+                    title="preview"
+                    url={previewUrl}
+                  />
+                  {previewLoading ? (
+                    <PreviewLoading message="プレビューを反映しています…" />
+                  ) : null}
+                </>
               ) : (
                 <div className="text-fg-mute flex h-full items-center justify-center p-6 text-center text-sm leading-relaxed">
                   生成すると、ここにライブプレビューが表示されます

--- a/apps/ai/src/app/_components/preview-iframe/preview-iframe.tsx
+++ b/apps/ai/src/app/_components/preview-iframe/preview-iframe.tsx
@@ -8,6 +8,8 @@ type ThemedPreviewIframeProps = {
   url: string;
   theme?: string | undefined;
   title: string;
+  // 読み込み完了の通知（呼び出し側のローディング表示解除に使う）。
+  onLoad?: (() => void) | undefined;
 };
 
 // 生成プレビューの iframe。初期テーマは src(?theme) に載せて初回ペイントから正しい配色にし、
@@ -17,6 +19,7 @@ export const ThemedPreviewIframe: FC<ThemedPreviewIframeProps> = ({
   url,
   theme,
   title,
+  onLoad,
 }) => {
   const ref = useRef<HTMLIFrameElement>(null);
   // url は Sandbox の絶対URL。クエリは URL で安全に組み立て、postMessage の宛先も同オリジンに絞る。
@@ -38,6 +41,7 @@ export const ThemedPreviewIframe: FC<ThemedPreviewIframeProps> = ({
   return (
     <iframe
       className="size-full border-0"
+      onLoad={onLoad}
       ref={ref}
       sandbox="allow-scripts allow-same-origin"
       src={initialSrc}


### PR DESCRIPTION
## 概要

Studio（AI 生成プレビュー）の3点の UX 課題を改善する。

1. プレビューのロードが遅いときに待機状態が分からない → ローディング表示を追加
2. 生成中に直前ターンの回答が「考え中」に化ける → 表示判定のバグ修正
3. 生成完了までプレビューが更新されず進捗が分かりづらい → 生成中はコードを実況し、完成でプレビューへ反映

## 動機

プレビューは Vercel Sandbox 上で配信されるため cold start やコード反映に時間がかかることがあるが、待機中の表示が無く「固まった」ように見えていた。また生成中はプレビューが無反応で、何が起きているか分かりづらかった。

## 詳細

**① ローディング表示**
- `PreviewLoading`（スピナー＋メッセージ）を追加し、プレビュー枠を「環境準備中 / 反映中 / 失敗時の案内 / プレースホルダ」に再構成
- `ThemedPreviewIframe` に `onLoad` を追加し、iframe 読み込み完了で反映中ローディングを外す
- 起動時の `startPreviewSession` を try/catch で包み、失敗時は無限スピナーにせず再読み込みを促す案内を表示

**② 「考え中」バグ修正**
- 生成開始(submitted)直後は最後の要素が user メッセージになるため、「最後の assistant メッセージ」基準だと直前ターンの回答が「考えています…」に化けていた
- 判定を「会話の最後のメッセージ(`messages.at(-1)`)」基準に変更

**③ 生成中のコード実況 → 完成で反映**
- 生成中は右ペインをコードビューへ切り替え、コードが組み上がる様子を実況
- 完了後 `onFinish` がローディング付きでプレビューへ戻す
- モバイルはチャットの考え中表示を残すため `mobileTab` は切り替えない

## 気をつけるポイント

- ③ の「途中の未完成コードもプレビューに逐次反映」は、単一コンポーネントだと構文的に未完成な中間状態が Vite エラーになるため採用せず、「コード実況 → 完成で反映」とした
- `previewFailed` 時はスピナーを止めて案内に切り替えるため、`startPreviewSession` 失敗時に固まらない
- 反映失敗（ビルドエラー）時は iframe が再読込されず `onLoad` が来ないため、その経路では明示的にローディングを解除している

## 影響範囲

- `apps/ai` の Studio（`/`、認証済み）のプレビュー/チャット表示のみ
- `ThemedPreviewIframe` は公開共有ページ（`/s/[slug]`）でも利用するが、追加した `onLoad` は任意 prop で挙動は不変

## テスト

- type-check / lint・format / ls-lint / ai パッケージのユニットテスト(47件) すべてパス
- ブラウザでの実機確認は Sandbox 接続（要 token/認証/DB）依存のため未実施