### PR TITLE
perf(ai): Studio の切り替えを高速化（再レンダー抑制・往復削減・HMR反映）

### DIFF
--- a/apps/ai/sandbox-template/src/main.tsx
+++ b/apps/ai/sandbox-template/src/main.tsx
@@ -1,9 +1,19 @@
+/// <reference types="vite/client" />
 import { ArteOdysseyProvider, ToastProvider } from '@k8o/arte-odyssey';
 import { Component, StrictMode, type ReactNode } from 'react';
 import { createRoot } from 'react-dom/client';
 
 import './index.css';
 import Preview from './generated/Preview';
+
+// HMR で Preview が差し替わったら親(Studio)へ通知する。Studio はこれを受けてローディングを
+// 解除し、iframe の強制リロード（白フラッシュ＋全読込）を省く。websocket が張れず HMR が
+// 効かない環境では通知が来ないため、Studio 側はタイムアウトでリロードにフォールバックする。
+if (import.meta.hot) {
+  import.meta.hot.on('vite:afterUpdate', () => {
+    window.parent.postMessage({ type: 'k8o-preview-updated' }, '*');
+  });
+}
 
 // 初期テーマは index.html の head スクリプトが初回ペイント前に反映する。
 // 以降の切替は親からの postMessage で受け、iframe を再読込せず反映する（白フラッシュ回避）。

--- a/apps/ai/sandbox-template/vite.config.ts
+++ b/apps/ai/sandbox-template/vite.config.ts
@@ -10,5 +10,11 @@ export default defineConfig({
     host: true,
     // Vercel Sandbox の *.vercel.run ドメイン経由で開けるよう host チェックを無効化する。
     allowedHosts: true,
+    // プレビューは常に *.vercel.run（HTTPS:443 が 5173 へ proxy）で開く。HMR の websocket も
+    // 同じ 443 経由で張れるよう clientPort を固定する（既定だと 5173 へ繋ぎに行き失敗し、
+    // コード差し替えが HMR で反映されない）。このテンプレは Sandbox 内でしか dev しないため固定で良い。
+    hmr: {
+      clientPort: 443,
+    },
   },
 });

--- a/apps/ai/src/app/(authenticated)/_components/studio/chat-message.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/chat-message.tsx
@@ -1,0 +1,45 @@
+'use client';
+
+import type { UIMessage } from 'ai';
+import { memo } from 'react';
+
+import {
+  messageText,
+  parseGeneration,
+} from '@/features/generation/application/parse-generation';
+
+type ChatMessageProps = {
+  message: UIMessage;
+};
+
+// 確定済み（生成中以外）のメッセージ1件を描画する。過去メッセージは内容が不変なので
+// memo で囲み、ストリーミング中に履歴全体を毎トークン再パース／再レンダーしないようにする。
+const ChatMessageComponent = ({ message }: ChatMessageProps) => {
+  const text = messageText(message);
+  if (message.role === 'user') {
+    return (
+      <div className="flex justify-end">
+        <p className="bg-primary-bg-subtle text-fg-base max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed">
+          {text}
+        </p>
+      </div>
+    );
+  }
+  const description = parseGeneration(text).meta?.description;
+  return (
+    <div className="flex flex-col gap-1.5">
+      <span className="text-fg-mute text-xs font-bold">AI</span>
+      <p className="text-fg-base text-sm leading-relaxed">
+        {description ?? 'コードを更新しました'}
+      </p>
+    </div>
+  );
+};
+
+// id と本文が同じなら再レンダーしない（過去メッセージは parseGeneration を一度きりにする）。
+export const ChatMessage = memo(
+  ChatMessageComponent,
+  (prev, next) =>
+    prev.message.id === next.message.id &&
+    messageText(prev.message) === messageText(next.message),
+);

--- a/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
@@ -16,6 +16,7 @@ import { useTheme } from 'next-themes';
 import { useRouter, useSearchParams } from 'next/navigation';
 import {
   type KeyboardEvent,
+  useCallback,
   useEffect,
   useReducer,
   useRef,
@@ -48,6 +49,10 @@ import { useStudioPersistence } from './use-studio-persistence';
 
 type PanelView = 'preview' | 'code';
 
+// HMR でプレビューが差し替わるのを待つ猶予。これを過ぎても iframe から反映通知が来なければ
+// 強制リロードへフォールバックする（websocket が張れず HMR が効かない環境向けの保険）。
+const PREVIEW_HMR_FALLBACK_MS = 2000;
+
 export const Studio = () => {
   const [input, setInput] = useState('');
   const [state, dispatch] = useReducer(
@@ -71,6 +76,29 @@ export const Studio = () => {
   const frameRef = useRef<HTMLDivElement>(null);
   // 直近の指示。onFinish（一度きりのクロージャ）から版に保存して会話復元に使う。
   const lastPromptRef = useRef('');
+  // HMR 反映待ちのフォールバック用タイマー。反映通知が来れば張り替えず解除する。
+  const reloadFallbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const clearReloadFallback = useCallback((): void => {
+    if (reloadFallbackRef.current !== null) {
+      clearTimeout(reloadFallbackRef.current);
+      reloadFallbackRef.current = null;
+    }
+  }, []);
+  // コード反映後の表示更新。まず HMR の差分反映（iframe からの updated 通知）を待ち、猶予内に
+  // 来なければ iframe を貼り替えて強制リロードする。前者なら白フラッシュなしで即時に切り替わる。
+  const reflectPreview = useCallback((): void => {
+    setPreviewLoading(true);
+    clearReloadFallback();
+    reloadFallbackRef.current = setTimeout(() => {
+      reloadFallbackRef.current = null;
+      setPreviewNonce((nonce) => nonce + 1);
+    }, PREVIEW_HMR_FALLBACK_MS);
+  }, [clearReloadFallback]);
+  // iframe（プレビュー）から HMR 反映通知が来たとき。安定参照にして iframe 側の購読を毎レンダー張り替えない。
+  const handlePreviewUpdated = useCallback((): void => {
+    clearReloadFallback();
+    setPreviewLoading(false);
+  }, [clearReloadFallback]);
   const { resolvedTheme } = useTheme();
   const persistence = useStudioPersistence();
   const router = useRouter();
@@ -113,12 +141,13 @@ export const Studio = () => {
           const res = await applyPreviewCode(parsed.code);
           if (res.ok) {
             setApplyError(null);
-            setPreviewNonce((nonce) => nonce + 1);
+            reflectPreview();
             setView('preview');
             setMobileTab('preview');
             return;
           }
-          // 反映に失敗したら iframe は再読込されず onLoad も来ないので、ローディングはここで外す。
+          // 反映に失敗したら HMR もリロードも起きないので、ローディングはここで外す。
+          clearReloadFallback();
           setPreviewLoading(false);
           // エラーを次ターンの system に流して自動修復を促す（プレビューは前回の正常版のまま＝白画面にしない）。
           if (res.error !== undefined) {
@@ -149,6 +178,16 @@ export const Studio = () => {
       }
     })();
   }, []);
+
+  // アンマウント時に HMR フォールバックのタイマーを始末する。
+  useEffect(
+    () => () => {
+      if (reloadFallbackRef.current !== null) {
+        clearTimeout(reloadFallbackRef.current);
+      }
+    },
+    [],
+  );
 
   // 末尾追従は「メッセージ追加」「生成状態の変化」の節目だけにする。messages 全体を依存に
   // すると生成中は毎トークン smooth スクロールが連打されてもたつくため、件数と status で間引く。
@@ -197,6 +236,8 @@ export const Studio = () => {
     }
     setInput('');
     setApplyError(null);
+    // 直前の反映待ちタイマーが生成中にリロードを起こさないよう始末する。
+    clearReloadFallback();
     // 生成中はコードが組み上がる様子を実況する（完了後に onFinish がプレビューへ戻す）。
     // モバイルはチャットの「考えています…」を残したいので mobileTab は切り替えない。
     setView('code');
@@ -230,6 +271,9 @@ export const Studio = () => {
   const handleNewProject = (): void => {
     // 生成中なら中断してから切り替える（生成中表示が新プロジェクトに残るのを防ぐ）。
     void stop();
+    // 直前の反映待ちタイマーが新プロジェクトでリロードを起こさないよう始末する。
+    clearReloadFallback();
+    setPreviewLoading(false);
     persistence.reset();
     dispatch({ type: 'reset' });
     setMessages([]);
@@ -284,9 +328,8 @@ export const Studio = () => {
     setMessages(restored);
     setApplyError(null);
     if (applied.ok) {
-      // 反映済み。iframe を貼り替え、onLoad までローディングを出す。
-      setPreviewLoading(true);
-      setPreviewNonce((nonce) => nonce + 1);
+      // 反映済み。HMR の差分反映を待ち、来なければリロードへフォールバックする。
+      reflectPreview();
       setView('preview');
       setMobileTab('preview');
     }
@@ -622,8 +665,10 @@ export const Studio = () => {
                   <ThemedPreviewIframe
                     key={previewNonce}
                     onLoad={() => {
+                      clearReloadFallback();
                       setPreviewLoading(false);
                     }}
+                    onUpdated={handlePreviewUpdated}
                     theme={resolvedTheme}
                     title="preview"
                     url={previewUrl}

--- a/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
@@ -36,6 +36,7 @@ import {
   applyPreviewCode,
   startPreviewSession,
 } from '@/features/preview/interface/actions';
+import { loadProjectAndApplyAction } from '@/features/projects/interface/actions';
 
 import { ChatMessage } from './chat-message';
 import { CodePanel } from './code-panel';
@@ -243,10 +244,13 @@ export const Studio = () => {
     // 生成中なら中断してから切り替える（生成中表示が切替先に漏れるのを防ぐ）。
     void stop();
     setHistoryOpen(false);
-    const project = await persistence.load(id);
-    if (project === null) {
+    // 読込（DB）と反映（Sandbox）を1サーバー往復にまとめ、往復・認証を半減する。
+    const result = await loadProjectAndApplyAction(id);
+    if (result === null) {
       return;
     }
+    const { project, applied } = result;
+    persistence.markLoaded(project);
     dispatch({
       type: 'load-project',
       code: project.code,
@@ -279,16 +283,14 @@ export const Studio = () => {
     );
     setMessages(restored);
     setApplyError(null);
-    setPreviewLoading(true);
-    const res = await applyPreviewCode(project.code);
-    if (res.ok) {
+    if (applied.ok) {
+      // 反映済み。iframe を貼り替え、onLoad までローディングを出す。
+      setPreviewLoading(true);
       setPreviewNonce((nonce) => nonce + 1);
       setView('preview');
       setMobileTab('preview');
-    } else {
-      // 反映失敗時は iframe が再読込されない＝onLoad が来ないので、ここで外す。
-      setPreviewLoading(false);
     }
+    // 反映失敗（保存済みコードでは稀）時はプレビューを前版のまま据え置く。
   };
 
   const handleFork = async (): Promise<void> => {

--- a/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
@@ -37,6 +37,7 @@ import {
   startPreviewSession,
 } from '@/features/preview/interface/actions';
 
+import { ChatMessage } from './chat-message';
 import { CodePanel } from './code-panel';
 import { CopyCodeButton } from './copy-code-button';
 import { PreviewLoading } from './preview-loading';
@@ -148,9 +149,11 @@ export const Studio = () => {
     })();
   }, []);
 
+  // 末尾追従は「メッセージ追加」「生成状態の変化」の節目だけにする。messages 全体を依存に
+  // すると生成中は毎トークン smooth スクロールが連打されてもたつくため、件数と status で間引く。
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
-  }, [messages]);
+  }, [messages.length, status]);
 
   const lastAssistant = messages.findLast(
     (message) => message.role === 'assistant',
@@ -494,32 +497,25 @@ export const Studio = () => {
             ) : (
               <div className="flex flex-col gap-5">
                 {messages.map((message) => {
-                  const text = messageText(message);
-                  if (message.role === 'user') {
+                  // 生成中の最後の assistant だけは実況（毎トークン変化）を出す。これ以外の
+                  // 確定メッセージは memo 済みの ChatMessage に委ね、履歴の再パースを避ける。
+                  const working =
+                    isBusy &&
+                    message.id === lastMessageId &&
+                    message.role === 'assistant';
+                  if (working) {
                     return (
-                      <div className="flex justify-end" key={message.id}>
-                        <p className="bg-primary-bg-subtle text-fg-base max-w-[85%] rounded-2xl px-4 py-2.5 text-sm leading-relaxed">
-                          {text}
+                      <div className="flex flex-col gap-1.5" key={message.id}>
+                        <span className="text-fg-mute text-xs font-bold">
+                          AI
+                        </span>
+                        <p className="text-fg-mute text-sm leading-relaxed motion-safe:animate-pulse">
+                          {generatingStatus}
                         </p>
                       </div>
                     );
                   }
-                  const description = parseGeneration(text).meta?.description;
-                  const working = isBusy && message.id === lastMessageId;
-                  return (
-                    <div className="flex flex-col gap-1.5" key={message.id}>
-                      <span className="text-fg-mute text-xs font-bold">AI</span>
-                      {working ? (
-                        <p className="text-fg-mute text-sm leading-relaxed motion-safe:animate-pulse">
-                          {generatingStatus}
-                        </p>
-                      ) : (
-                        <p className="text-fg-base text-sm leading-relaxed">
-                          {description ?? 'コードを更新しました'}
-                        </p>
-                      )}
-                    </div>
-                  );
+                  return <ChatMessage key={message.id} message={message} />;
                 })}
                 {status === 'submitted' ? (
                   <div className="flex flex-col gap-1.5">

--- a/apps/ai/src/app/(authenticated)/_components/studio/use-studio-persistence.ts
+++ b/apps/ai/src/app/(authenticated)/_components/studio/use-studio-persistence.ts
@@ -10,7 +10,6 @@ import type {
 import {
   forkProjectAction,
   listProjectsAction,
-  loadProjectAction,
   saveGenerationAction,
 } from '@/features/projects/interface/actions';
 
@@ -24,7 +23,8 @@ export type StudioPersistence = {
     meta: GenerationMeta;
     prompt: string;
   }) => Promise<void>;
-  load: (projectId: number) => Promise<LoadedProject | null>;
+  // 既に読み込み済みのプロジェクトを現在の選択として確定する（再フェッチしない）。
+  markLoaded: (project: LoadedProject) => void;
   fork: (sourceProjectId: number) => Promise<number | null>;
   reset: () => void;
   refresh: () => Promise<void>;
@@ -76,14 +76,9 @@ export const useStudioPersistence = (): StudioPersistence => {
     [refresh, setCurrent],
   );
 
-  const load = useCallback(
-    async (id: number): Promise<LoadedProject | null> => {
-      const project = await loadProjectAction(id);
-      if (project === null) {
-        return null;
-      }
+  const markLoaded = useCallback(
+    (project: LoadedProject): void => {
       setCurrent(project.id, project.versionId, project.title);
-      return project;
     },
     [setCurrent],
   );
@@ -110,7 +105,7 @@ export const useStudioPersistence = (): StudioPersistence => {
     projectTitle,
     currentVersionId,
     save,
-    load,
+    markLoaded,
     fork,
     reset,
     refresh,

--- a/apps/ai/src/app/_components/preview-iframe/preview-iframe.tsx
+++ b/apps/ai/src/app/_components/preview-iframe/preview-iframe.tsx
@@ -10,6 +10,8 @@ type ThemedPreviewIframeProps = {
   title: string;
   // 読み込み完了の通知（呼び出し側のローディング表示解除に使う）。
   onLoad?: (() => void) | undefined;
+  // HMR でプレビューが差し替わったときの通知（iframe を再読込せずローディングを解除するため）。
+  onUpdated?: (() => void) | undefined;
 };
 
 // 生成プレビューの iframe。初期テーマは src(?theme) に載せて初回ペイントから正しい配色にし、
@@ -20,6 +22,7 @@ export const ThemedPreviewIframe: FC<ThemedPreviewIframeProps> = ({
   theme,
   title,
   onLoad,
+  onUpdated,
 }) => {
   const ref = useRef<HTMLIFrameElement>(null);
   // url は Sandbox の絶対URL。クエリは URL で安全に組み立て、postMessage の宛先も同オリジンに絞る。
@@ -37,6 +40,31 @@ export const ThemedPreviewIframe: FC<ThemedPreviewIframeProps> = ({
       origin,
     );
   }, [theme, origin]);
+
+  // プレビュー(Sandbox)からの「HMR で差し替わった」通知を受ける。送信元オリジンを検証する。
+  useEffect(() => {
+    if (onUpdated === undefined) {
+      return undefined;
+    }
+    const handler = (event: MessageEvent<unknown>): void => {
+      if (event.origin !== origin) {
+        return;
+      }
+      const { data } = event;
+      if (
+        typeof data === 'object' &&
+        data !== null &&
+        'type' in data &&
+        data.type === 'k8o-preview-updated'
+      ) {
+        onUpdated();
+      }
+    };
+    window.addEventListener('message', handler);
+    return () => {
+      window.removeEventListener('message', handler);
+    };
+  }, [onUpdated, origin]);
 
   return (
     <iframe

--- a/apps/ai/src/features/preview/application/apply-preview.ts
+++ b/apps/ai/src/features/preview/application/apply-preview.ts
@@ -1,0 +1,22 @@
+import 'server-only';
+import { findUnknownArteImports } from '@/features/generation/infrastructure/design-system-context';
+
+import { previewProvider } from './preview-provider';
+
+export type ApplyPreviewResult = { ok: true } | { ok: false; error?: string };
+
+// 生成／読込コードをプレビュー（Sandbox）へ反映する中核。auth は呼び出し側で済ませる前提。
+// 存在しない import を書き込むと Vite が壊れ白画面のまま復帰しないため、書込前に弾く。
+export const applyStudioPreviewCode = async (
+  code: string,
+): Promise<ApplyPreviewResult> => {
+  const unknown = findUnknownArteImports(code);
+  if (unknown.length > 0) {
+    return {
+      ok: false,
+      error: `'@k8o/arte-odyssey' に存在しない import: ${unknown.join(', ')}。これらは実在しないため使用できません。`,
+    };
+  }
+  await previewProvider.apply(code);
+  return { ok: true };
+};

--- a/apps/ai/src/features/preview/application/sandbox-runtime.ts
+++ b/apps/ai/src/features/preview/application/sandbox-runtime.ts
@@ -1,7 +1,12 @@
 import 'server-only';
-// 名前付き Sandbox の配信/停止を preview feature の application 境界として公開する。
-// 他 feature（share）は preview/infrastructure を直読みせず、ここを経由して利用する。
+// 名前付き Sandbox の配信/停止と、studio プレビューへのコード反映を preview feature の
+// application 境界として公開する。他 feature（share / projects）は preview/infrastructure を
+// 直読みせず、ここを経由して利用する。
 export {
   serveSandboxPreview,
   stopSandboxPreview,
 } from '../infrastructure/sandbox-preview';
+export {
+  applyStudioPreviewCode,
+  type ApplyPreviewResult,
+} from './apply-preview';

--- a/apps/ai/src/features/preview/infrastructure/sandbox-preview.ts
+++ b/apps/ai/src/features/preview/infrastructure/sandbox-preview.ts
@@ -50,7 +50,20 @@ const isServing = async (url: string): Promise<boolean> => {
   }
 };
 
+// warm インスタンス内で Sandbox ハンドルと「配信確認済み」時刻を fullName 単位でキャッシュし、
+// apply のたびに走る Sandbox.get / isServing の往復を省く（studio / share で別キー）。
+// 停止・失効時は操作失敗で破棄して取り直すため、staleness は writeFiles の retry が吸収する。
+const handleCache = new Map<string, Sandbox>();
+const servingConfirmedAt = new Map<string, number>();
+const SERVING_TTL_MS = 30 * 1000;
+
+const dropCache = (fullName: string): void => {
+  handleCache.delete(fullName);
+  servingConfirmedAt.delete(fullName);
+};
+
 // 名前付きサンドボックスを get（あれば再開）するか、無ければ snapshot から作る。
+// ハンドルはキャッシュして、連続 apply での Sandbox.get 往復を避ける。
 const getOrCreate = async (name: string): Promise<Sandbox> => {
   if (SNAPSHOT_ID === '') {
     throw new Error(
@@ -58,27 +71,42 @@ const getOrCreate = async (name: string): Promise<Sandbox> => {
     );
   }
   const fullName = named(name);
+  const cached = handleCache.get(fullName);
+  if (cached !== undefined) {
+    return cached;
+  }
   const existing = await Sandbox.get({ name: fullName, ...creds() }).catch(
     () => null,
   );
-  if (existing !== null) {
-    return existing;
-  }
   // snapshot ソース指定時は runtime を渡さない（snapshot から継承）。
-  return Sandbox.create({
-    name: fullName,
-    source: { type: 'snapshot', snapshotId: SNAPSHOT_ID },
-    ports: [PORT],
-    resources: { vcpus: 1 },
-    timeout: TIMEOUT_MS,
-    ...creds(),
-  });
+  const sandbox =
+    existing ??
+    (await Sandbox.create({
+      name: fullName,
+      source: { type: 'snapshot', snapshotId: SNAPSHOT_ID },
+      ports: [PORT],
+      resources: { vcpus: 1 },
+      timeout: TIMEOUT_MS,
+      ...creds(),
+    }));
+  handleCache.set(fullName, sandbox);
+  return sandbox;
 };
 
 // vite dev が応答していなければ起動し、応答するまで待ってから domain を返す。
-const ensureServing = async (sandbox: Sandbox): Promise<string> => {
+// trustCache=true かつ直近で配信確認済みなら、apply ごとの確認 fetch を省く。
+const ensureServing = async (
+  sandbox: Sandbox,
+  fullName: string,
+  trustCache: boolean,
+): Promise<string> => {
   const url = sandbox.domain(PORT);
+  const confirmedAt = servingConfirmedAt.get(fullName) ?? 0;
+  if (trustCache && Date.now() - confirmedAt < SERVING_TTL_MS) {
+    return url;
+  }
   if (await isServing(url)) {
+    servingConfirmedAt.set(fullName, Date.now());
     return url;
   }
   await sandbox.runCommand({
@@ -90,6 +118,7 @@ const ensureServing = async (sandbox: Sandbox): Promise<string> => {
   for (let i = 0; i < READY_TRIES; i += 1) {
     // eslint-disable-next-line no-await-in-loop -- 起動待ちのポーリング
     if (await isServing(url)) {
+      servingConfirmedAt.set(fullName, Date.now());
       return url;
     }
     // eslint-disable-next-line no-await-in-loop -- 起動待ちのポーリング
@@ -101,9 +130,10 @@ const ensureServing = async (sandbox: Sandbox): Promise<string> => {
 };
 
 // プレビュー用サンドボックスを用意して配信URLを返す（コード未指定。apply で差し替える）。
+// cold start の確認なのでキャッシュは信頼しない。
 export const ensureSandboxPreview = async (name: string): Promise<string> => {
   const sandbox = await getOrCreate(name);
-  return ensureServing(sandbox);
+  return ensureServing(sandbox, named(name), false);
 };
 
 // 名前付きサンドボックスにコードを書き込み、配信が立っていることを確保して URL を返す。
@@ -111,11 +141,18 @@ export const serveSandboxPreview = async (
   name: string,
   code: string,
 ): Promise<string> => {
-  const sandbox = await getOrCreate(name);
-  await sandbox.writeFiles([
-    { path: 'src/generated/Preview.tsx', content: code },
-  ]);
-  return ensureServing(sandbox);
+  const fullName = named(name);
+  const files = [{ path: 'src/generated/Preview.tsx', content: code }];
+  let sandbox = await getOrCreate(name);
+  try {
+    await sandbox.writeFiles(files);
+  } catch {
+    // キャッシュした handle が失効していた場合は取り直して一度だけ再試行する。
+    dropCache(fullName);
+    sandbox = await getOrCreate(name);
+    await sandbox.writeFiles(files);
+  }
+  return ensureServing(sandbox, fullName, true);
 };
 
 // 生成コードを書き込む（HMR で反映）。停止していれば起こして配信を確保する。
@@ -128,10 +165,12 @@ export const writeSandboxPreview = async (
 
 // 名前付きサンドボックスを停止する（非公開化時の後始末。ベストエフォート）。
 export const stopSandboxPreview = async (name: string): Promise<void> => {
-  const sandbox = await Sandbox.get({ name: named(name), ...creds() }).catch(
+  const fullName = named(name);
+  const sandbox = await Sandbox.get({ name: fullName, ...creds() }).catch(
     () => null,
   );
   if (sandbox !== null) {
     await sandbox.stop().catch(() => undefined);
   }
+  dropCache(fullName);
 };

--- a/apps/ai/src/features/preview/infrastructure/template-snapshot.ts
+++ b/apps/ai/src/features/preview/infrastructure/template-snapshot.ts
@@ -3,6 +3,6 @@
 // （未更新だと template-snapshot.test.ts が落ちる）。snapshotId は焼いた snapshot の ID。
 export const templateSnapshot = {
   templateHash:
-    'd7c138380b29f3f20b9eed231f288d0824ba83bfb2613a8164f8a2047207e3d0',
-  snapshotId: 'snap_C9jRaKyHPSzrcMjthodhsFckbFPP',
+    'd42bab7844a594c4ca35a621f2fb73b284c4d26e88971146782c8b20076dfbcc',
+  snapshotId: 'snap_RP7LrIDRBn9CR76wZoGzxvWyZTWg',
 } as const;

--- a/apps/ai/src/features/preview/interface/actions.ts
+++ b/apps/ai/src/features/preview/interface/actions.ts
@@ -2,9 +2,9 @@
 
 import { headers } from 'next/headers';
 
-import { findUnknownArteImports } from '@/features/generation/infrastructure/design-system-context';
 import { requireAllowedSession } from '@/shared/auth/require-allowed-session';
 
+import { applyStudioPreviewCode } from '../application/apply-preview';
 import { previewProvider } from '../application/preview-provider';
 
 // プレビューも課金/環境に関わる操作なので、オーナーゲートを通す。
@@ -26,14 +26,5 @@ export const applyPreviewCode = async (
   if (session === null) {
     return { ok: false };
   }
-  // 存在しない import を書き込むと Vite が壊れプレビューが白画面のまま復帰しないため、書き込み前に弾く。
-  const unknown = findUnknownArteImports(code);
-  if (unknown.length > 0) {
-    return {
-      ok: false,
-      error: `'@k8o/arte-odyssey' に存在しない import: ${unknown.join(', ')}。これらは実在しないため使用できません。`,
-    };
-  }
-  await previewProvider.apply(code);
-  return { ok: true };
+  return applyStudioPreviewCode(code);
 };

--- a/apps/ai/src/features/projects/interface/actions.ts
+++ b/apps/ai/src/features/projects/interface/actions.ts
@@ -3,6 +3,10 @@
 import { headers } from 'next/headers';
 
 import type { GenerationMeta } from '@/features/generation/application/parse-generation';
+import {
+  type ApplyPreviewResult,
+  applyStudioPreviewCode,
+} from '@/features/preview/application/sandbox-runtime';
 import { requireAllowedSession } from '@/shared/auth/require-allowed-session';
 
 import {
@@ -49,6 +53,24 @@ export const loadProjectAction = async (
     return null;
   }
   return getProject({ userId: session.userId, projectId });
+};
+
+// プロジェクト読込（DB）とプレビュー反映（Sandbox）を1往復・1回の認証にまとめる。
+// 切り替えで load→apply を別々に呼ぶと、ブラウザ↔サーバー往復とセッション照会が2回ずつ
+// 走って遅いため、ここで一括する。非所有/不存在は null。
+export const loadProjectAndApplyAction = async (
+  projectId: number,
+): Promise<{ project: LoadedProject; applied: ApplyPreviewResult } | null> => {
+  const session = await requireAllowedSession(await headers());
+  if (session === null) {
+    return null;
+  }
+  const project = await getProject({ userId: session.userId, projectId });
+  if (project === null) {
+    return null;
+  }
+  const applied = await applyStudioPreviewCode(project.code);
+  return { project, applied };
 };
 
 export const forkProjectAction = async (


### PR DESCRIPTION
## 概要

`apps/ai` の Studio で「プロジェクト切り替えが遅い」「生成中に全体的にもたつく」問題を、UX を変えずに高速化する。原因が複数あったため、独立して revert 可能な 3 コミットに分けた。

## 変更内容

### 1. 生成中の再レンダー抑制（`7a47e297`）
- 確定済みメッセージを memo 化した `ChatMessage` に切り出し、ストリーミング中に**履歴全体を毎トークン `parseGeneration` し直す**のをやめた（生成中の最後の 1 件だけ実況する）。
- 末尾追従スクロールの依存を `[messages]` → `[messages.length, status]` に変更。生成中に 1 トークンごと smooth スクロールが連打されてもたつくのを解消。

### 2. プロジェクト切り替えのサーバー往復削減（`fc9ab8d0`）
- 履歴/フォーク選択で別々だった `load`(DB) と `apply`(Sandbox) を **`loadProjectAndApplyAction` に統合**し、ブラウザ↔サーバー往復とセッション認証を**各 2 回 → 1 回**に。
- 反映中核を `apply-preview.ts` に切り出し、公開境界 `sandbox-runtime.ts` 経由で共有（feature 境界を維持）。
- Sandbox ハンドルと「配信確認済み」状態を warm インスタンスでキャッシュし、apply ごとの `Sandbox.get` / `isServing`(最大 2.5s) 往復を省く。失効時は `writeFiles` 失敗を検知して取り直す retry 付き。

### 3. プレビュー反映を HMR 化し強制リロードを廃止（`1e711a3e`）
- `sandbox-template` の Vite に `server.hmr.clientPort=443` を設定し、`*.vercel.run`（443→5173 proxy）越しでも HMR の websocket を張れるように。
- テンプレ `main.tsx` が HMR 適用時（`vite:afterUpdate`）に親へ通知 → Studio がローディング解除し、**iframe の強制リロード（白フラッシュ＋全読込）を省く**。
- HMR が効かない環境向けに、**2 秒反映通知が来なければ従来どおりリロードへフォールバック**（websocket 不通でもリグレッションしない）。

## レビュアーへの注意

- **snapshot が stale**：`sandbox-template/**` を変更したため `template-snapshot.test.ts` が**赤**です。これは設計どおりの drift 検知で、**CI（ai-bake）が自動で再 bake → `template-snapshot.ts` を k8o-bot がコミット**して解消されます。`templateHash` を手で書き換えると古い snapshot を指し続けるため、あえて触っていません。
- **HMR がサンドボックス越しに実際に通るかは未検証**：ローカルに `VERCEL_TOKEN` が無く bake/実機プローブができないためです。フォールバックがあるので壊れはしませんが、HMR の体感改善が出るかは**デプロイ後の確認**が必要です。確認方法：Studio で続けて指示を出し、切り替え時に**白フラッシュが消えていれば HMR 成功**（console に `[vite] connected`）。残っていれば 2 秒後フォールバック＝HMR 未到達なので別アプローチを検討。

## 確認

- `pnpm -F ai run type-check` ✅
- `pnpm run check`（lint/format）✅ 変更ファイルは 0 error
- `pnpm -F ai run test` ✅ 46 passed（`template-snapshot.test.ts` のみ stale で失敗 → 上記のとおり CI が解消）
