### PR TITLE
feat(ai): 生成中の先行プレビュー（逐次描画）を追加

### DIFF
--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/component-registry.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/component-registry.tsx
@@ -1,0 +1,81 @@
+import {
+  AIIcon,
+  Alert,
+  AlertIcon,
+  Anchor,
+  Avatar,
+  Badge,
+  Button,
+  Card,
+  CheckIcon,
+  ChevronIcon,
+  CloseIcon,
+  Code,
+  CopyIcon,
+  ExternalLinkIcon,
+  GitHubIcon,
+  Grid,
+  Heading,
+  IconButton,
+  InformativeIcon,
+  LinkIcon,
+  MailIcon,
+  MinusIcon,
+  PlusIcon,
+  Progress,
+  SendIcon,
+  Separator,
+  Skeleton,
+  SparklesIcon,
+  Spinner,
+  Stack,
+  ViewIcon,
+} from '@k8o/arte-odyssey';
+import type { ComponentType } from 'react';
+
+// 描画側は任意の props を spread するため、arte-odyssey の厳密な型を緩い型に寄せる。
+type AnyComponent = ComponentType<Record<string, unknown>>;
+
+const asAny = (component: ComponentType<never>): AnyComponent =>
+  component as unknown as AnyComponent;
+
+// PoC の登録対象は「宣言的に確実に描けるサブセット」のみ。
+// 複合コンポーネント（Dialog / Tabs / FormControl 等）は未登録のままにして、
+// UnknownChip として可視化し、どこまで素直に流せるかを測る。
+const registry: Record<string, AnyComponent> = {
+  Alert: asAny(Alert),
+  Anchor: asAny(Anchor),
+  Avatar: asAny(Avatar),
+  Badge: asAny(Badge),
+  Button: asAny(Button),
+  Card: asAny(Card),
+  Code: asAny(Code),
+  Grid: asAny(Grid),
+  Heading: asAny(Heading),
+  IconButton: asAny(IconButton),
+  Progress: asAny(Progress),
+  Separator: asAny(Separator),
+  Skeleton: asAny(Skeleton),
+  Spinner: asAny(Spinner),
+  Stack: asAny(Stack),
+  // よく使われるアイコンの代表セット。未登録アイコンは UnknownChip になる。
+  AIIcon: asAny(AIIcon),
+  AlertIcon: asAny(AlertIcon),
+  CheckIcon: asAny(CheckIcon),
+  ChevronIcon: asAny(ChevronIcon),
+  CloseIcon: asAny(CloseIcon),
+  CopyIcon: asAny(CopyIcon),
+  ExternalLinkIcon: asAny(ExternalLinkIcon),
+  GitHubIcon: asAny(GitHubIcon),
+  InformativeIcon: asAny(InformativeIcon),
+  LinkIcon: asAny(LinkIcon),
+  MailIcon: asAny(MailIcon),
+  MinusIcon: asAny(MinusIcon),
+  PlusIcon: asAny(PlusIcon),
+  SendIcon: asAny(SendIcon),
+  SparklesIcon: asAny(SparklesIcon),
+  ViewIcon: asAny(ViewIcon),
+};
+
+export const resolveComponent = (name: string): AnyComponent | null =>
+  registry[name] ?? null;

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/index.ts
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/index.ts
@@ -1,0 +1,1 @@
+export { StreamPreview } from './stream-preview';

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/pending-mark.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/pending-mark.tsx
@@ -1,0 +1,9 @@
+import { Skeleton } from '@k8o/arte-odyssey';
+import type { FC } from 'react';
+
+// 未受信の先端を表すスケルトン。生成が進むとこの位置に実コンテンツが入る。
+export const PendingMark: FC = () => (
+  <output aria-label="生成中" className="flex flex-col gap-2 py-1">
+    <Skeleton shape="rect" size="md" />
+  </output>
+);

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/pending-mark.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/pending-mark.tsx
@@ -1,9 +1,12 @@
-import { Skeleton } from '@k8o/arte-odyssey';
 import type { FC } from 'react';
 
-// 未受信の先端を表すスケルトン。生成が進むとこの位置に実コンテンツが入る。
+// 未受信の先端を表すスケルトン。arte の Skeleton は固定幅（rect=w-40 等）で小さく見えるため、
+// ここでは同じトークン（bg-bg-mute）で幅いっぱいのコンテンツブロック風プレースホルダを組む。
+// 生成が進むとこの位置に実コンテンツが入る。
 export const PendingMark: FC = () => (
-  <output aria-label="生成中" className="flex flex-col gap-2 py-1">
-    <Skeleton shape="rect" size="md" />
+  <output aria-label="生成中" className="flex w-full flex-col gap-2.5 py-2">
+    <div className="bg-bg-mute h-5 w-1/2 animate-pulse rounded-md" />
+    <div className="bg-bg-mute h-4 w-full animate-pulse rounded-md" />
+    <div className="bg-bg-mute h-4 w-5/6 animate-pulse rounded-md" />
   </output>
 );

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/render-jsx-node.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/render-jsx-node.tsx
@@ -1,0 +1,171 @@
+import { type ReactNode, Fragment, createElement } from 'react';
+
+import type {
+  JsxElement,
+  JsxNode,
+  JsxProp,
+} from '@/features/preview/application/incremental-jsx/types';
+
+import { resolveComponent } from './component-registry';
+import { PendingMark } from './pending-mark';
+import { SafeNode } from './safe-node';
+import { UnknownChip } from './unknown-chip';
+
+// 生成コードが使う素の HTML 要素。未知タグはコンテナ（div）に寄せて安全側に倒す。
+const HOST_TAGS = new Set([
+  'div',
+  'p',
+  'span',
+  'section',
+  'header',
+  'footer',
+  'main',
+  'article',
+  'aside',
+  'nav',
+  'ul',
+  'ol',
+  'li',
+  'a',
+  'label',
+  'form',
+  'strong',
+  'em',
+  'small',
+  'b',
+  'i',
+  'h1',
+  'h2',
+  'h3',
+  'h4',
+  'h5',
+  'h6',
+  'img',
+  'hr',
+  'br',
+  'figure',
+  'figcaption',
+  'blockquote',
+  'pre',
+  'code',
+]);
+
+const RESERVED = new Set(['key', 'ref']);
+
+const resolveAttrValue = (prop: JsxProp, key: string): unknown => {
+  switch (prop.value.kind) {
+    case 'string':
+      return prop.value.value;
+    case 'literal':
+      return prop.value.value;
+    case 'boolean':
+      return true;
+    case 'element':
+      return renderElement(prop.value.value, `${key}@`);
+    case 'unsupported':
+      return undefined;
+    default:
+      return undefined;
+  }
+};
+
+const buildProps = (el: JsxElement, key: string): Record<string, unknown> => {
+  const props: Record<string, unknown> = {};
+  for (const prop of el.props) {
+    if (
+      prop.name === '' ||
+      prop.name === '...spread' ||
+      RESERVED.has(prop.name)
+    ) {
+      continue;
+    }
+    const value = resolveAttrValue(prop, key);
+    if (value === undefined) {
+      continue;
+    }
+    props[prop.name] = value;
+  }
+  return props;
+};
+
+const renderChildren = (
+  children: readonly JsxNode[],
+  key: string,
+): ReactNode[] => {
+  const out: ReactNode[] = [];
+  for (const [i, child] of children.entries()) {
+    const node = renderNode(child, `${key}.${i}`);
+    if (node !== null) {
+      out.push(node);
+    }
+  }
+  return out;
+};
+
+function renderElement(el: JsxElement, key: string): ReactNode {
+  const children = renderChildren(el.children, key);
+  const childArg = children.length > 0 ? children : undefined;
+
+  // フラグメント
+  if (el.name === '') {
+    return <Fragment key={key}>{childArg}</Fragment>;
+  }
+
+  const props = buildProps(el, key);
+  const first = el.name[0] ?? '';
+
+  // ホスト要素（小文字始まり）
+  if (first === first.toLowerCase()) {
+    const tag = HOST_TAGS.has(el.name) ? el.name : 'div';
+    return createElement(tag, { ...props, key }, childArg);
+  }
+
+  // コンポーネント（大文字始まり）
+  const Component = resolveComponent(el.name);
+  if (Component === null) {
+    return (
+      <UnknownChip key={key} name={el.name}>
+        {childArg}
+      </UnknownChip>
+    );
+  }
+  return (
+    <SafeNode key={key} name={el.name}>
+      <Component {...props}>{childArg}</Component>
+    </SafeNode>
+  );
+}
+
+function renderNode(node: JsxNode, key: string): ReactNode {
+  if (node.type === 'pending') {
+    return <PendingMark key={key} />;
+  }
+  if (node.type === 'text') {
+    // 要素間の空白のみのテキストは描かない（レイアウトは gap で取る前提）。
+    return node.value.trim() === '' ? null : (
+      <Fragment key={key}>{node.value}</Fragment>
+    );
+  }
+  return renderElement(node, key);
+}
+
+// トップレベルの末尾に残る `);}` のような句読点だけのテキストは描かない。
+const isPunctuationText = (node: JsxNode): boolean =>
+  node.type === 'text' && /^[\s);,}]*$/u.test(node.value);
+
+export const renderRoot = (nodes: readonly JsxNode[]): ReactNode => {
+  const rendered: ReactNode[] = [];
+  for (const [i, node] of nodes.entries()) {
+    if (isPunctuationText(node)) {
+      continue;
+    }
+    const el = renderNode(node, String(i));
+    if (el !== null) {
+      rendered.push(el);
+    }
+  }
+  if (rendered.length === 0) {
+    return <PendingMark />;
+  }
+  return rendered;
+};

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/render-jsx-node.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/render-jsx-node.tsx
@@ -51,7 +51,11 @@ const HOST_TAGS = new Set([
   'code',
 ]);
 
-const RESERVED = new Set(['key', 'ref']);
+// key/ref は React 予約。style は生成コードでは使わせない方針（文字列 style は React が throw）。
+const RESERVED = new Set(['key', 'ref', 'style']);
+
+// 子を取らない void 要素。children を渡すと React が throw するため分けて生成する。
+const VOID_TAGS = new Set(['img', 'br', 'hr', 'input']);
 
 const resolveAttrValue = (prop: JsxProp, key: string): unknown => {
   switch (prop.value.kind) {
@@ -118,6 +122,9 @@ function renderElement(el: JsxElement, key: string): ReactNode {
   // ホスト要素（小文字始まり）
   if (first === first.toLowerCase()) {
     const tag = HOST_TAGS.has(el.name) ? el.name : 'div';
+    if (VOID_TAGS.has(tag)) {
+      return createElement(tag, { ...props, key });
+    }
     return createElement(tag, { ...props, key }, childArg);
   }
 

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/render-jsx-node.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/render-jsx-node.tsx
@@ -9,6 +9,7 @@ import type {
 import { resolveComponent } from './component-registry';
 import { PendingMark } from './pending-mark';
 import { SafeNode } from './safe-node';
+import { StreamLoading } from './stream-loading';
 import { UnknownChip } from './unknown-chip';
 
 // 生成コードが使う素の HTML 要素。未知タグはコンテナ（div）に寄せて安全側に倒す。
@@ -164,8 +165,9 @@ export const renderRoot = (nodes: readonly JsxNode[]): ReactNode => {
       rendered.push(el);
     }
   }
+  // まだ何も描けない（return 未到達など）＝空っぽフェーズはスケルトンではなくスピナー。
   if (rendered.length === 0) {
-    return <PendingMark />;
+    return <StreamLoading />;
   }
   return rendered;
 };

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/safe-node.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/safe-node.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { Component, type ReactNode } from 'react';
+
+import { UnknownChip } from './unknown-chip';
+
+type Props = { name: string; children: ReactNode };
+type State = { failed: boolean };
+
+// 1 コンポーネントが prop 不整合などで描画失敗しても、兄弟と全体は描き続けるための境界。
+// 途中コードはサブセット外の prop を渡しがちなので、要素単位で握りつぶしてフォールバック表示する。
+export class SafeNode extends Component<Props, State> {
+  override state: State = { failed: false };
+
+  static getDerivedStateFromError(): State {
+    return { failed: true };
+  }
+
+  override render(): ReactNode {
+    if (this.state.failed) {
+      return <UnknownChip name={this.props.name} />;
+    }
+    return this.props.children;
+  }
+}

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-boundary.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-boundary.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Component, type ReactNode } from 'react';
+
+import { StreamLoading } from './stream-loading';
+
+type Props = {
+  // 入力（途中コード）が変わるたびに失敗状態をリセットして再描画を試みる鍵。
+  resetKey: number;
+  children: ReactNode;
+};
+type State = { failed: boolean; lastKey: number };
+
+// 先行プレビュー全体のエラー境界。途中コードの不正 prop 等で描画が throw しても、
+// 島ごと白画面にせずスピナーへフォールバックし、次のトークン（resetKey 変化）で再挑戦する。
+export class StreamBoundary extends Component<Props, State> {
+  override state: State = { failed: false, lastKey: -1 };
+
+  static getDerivedStateFromError(): Partial<State> {
+    return { failed: true };
+  }
+
+  // resetKey が変わったら失敗状態を解除して再描画を試みる（setState を使わないリセット）。
+  static getDerivedStateFromProps(
+    props: Props,
+    state: State,
+  ): Partial<State> | null {
+    if (props.resetKey !== state.lastKey) {
+      return { failed: false, lastKey: props.resetKey };
+    }
+    return null;
+  }
+
+  override render(): ReactNode {
+    return this.state.failed ? <StreamLoading /> : this.props.children;
+  }
+}

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-loading.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-loading.tsx
@@ -1,0 +1,10 @@
+import { Spinner } from '@k8o/arte-odyssey';
+import type { FC } from 'react';
+
+// 先行プレビューの「まだ構造が来ていない」フェーズ用ローディング。
+// JSX が届き始めたらスケルトン → 実描画の積み上げへ替わる。
+export const StreamLoading: FC = () => (
+  <div className="flex h-full min-h-40 items-center justify-center p-8">
+    <Spinner label="生成しています" size="lg" />
+  </div>
+);

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.stories.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.stories.tsx
@@ -39,6 +39,37 @@ export default function Preview() {
   );
 }`;
 
+// インラインデータ + .map() で複製するグリッド（実際の生成でよく出るパターン）。
+const SAMPLE_GRID = `import { Grid, Card, Avatar, Heading, Badge, IconButton, GitHubIcon, MailIcon } from '@k8o/arte-odyssey';
+
+const members = [
+  { name: '田中 太郎', role: 'フロントエンド', initials: 'TT' },
+  { name: '佐藤 花子', role: 'UIデザイナー', initials: 'SH' },
+  { name: '鈴木 一郎', role: 'バックエンド', initials: 'SI' },
+];
+
+export default function Preview() {
+  return (
+    <div className="bg-bg-surface p-8">
+      <Grid cols={3} gap="md">
+        {members.map((m) => (
+          <Card appearance="shadow">
+            <div className="flex flex-col items-center gap-3 p-6">
+              <Avatar fallback={m.initials} size="lg" />
+              <Heading type="h3">{m.name}</Heading>
+              <Badge text={m.role} tone="info" />
+              <div className="flex gap-2">
+                <IconButton label="GitHub" color="base" size="sm"><GitHubIcon size="sm" /></IconButton>
+                <IconButton label="メール" color="base" size="sm"><MailIcon size="sm" /></IconButton>
+              </div>
+            </div>
+          </Card>
+        ))}
+      </Grid>
+    </div>
+  );
+}`;
+
 const meta = {
   component: StreamPreview,
 } satisfies Meta<typeof StreamPreview>;
@@ -83,6 +114,25 @@ export const UnsupportedSubset: Story = {
     const canvas = within(canvasElement);
     await expect(canvas.getByText('送信')).toBeInTheDocument();
     await expect(canvas.getByText('<Tabs>')).toBeInTheDocument();
+  },
+};
+
+// .map() でデータ配列からカードを複製（完成形）。3枚が並ぶ。
+export const MapGridComplete: Story = {
+  args: { code: SAMPLE_GRID },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('田中 太郎')).toBeInTheDocument();
+    await expect(canvas.getByText('鈴木 一郎')).toBeInTheDocument();
+  },
+};
+
+// .map() のテンプレートが途中。データ件数ぶんの部分カードが並び、先端にスケルトン。
+export const MapGridStreaming: Story = {
+  args: { code: SAMPLE_GRID.slice(0, Math.floor(SAMPLE_GRID.length * 0.78)) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('status').length).toBeGreaterThan(0);
   },
 };
 

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.stories.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.stories.tsx
@@ -1,0 +1,98 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { StreamPreview } from './stream-preview';
+
+// 生成プロンプトのお手本に倣った宣言的サンプル（完成形）。
+const SAMPLE_RICH = `import { Card, Heading, Stack, Button, Badge, Separator } from '@k8o/arte-odyssey';
+
+export default function Preview() {
+  return (
+    <div className="bg-bg-surface flex min-h-screen items-center justify-center p-8">
+      <Card appearance="shadow">
+        <div className="flex flex-col gap-6 p-8">
+          <div className="flex items-center gap-3">
+            <Heading type="h2">プラン</Heading>
+            <Badge text="人気" tone="info" />
+          </div>
+          <p className="text-fg-mute text-sm leading-relaxed">月額プランのご案内です。</p>
+          <Separator orientation="horizontal" />
+          <Button color="primary" variant="solid" startIcon={<SparklesIcon />}>申し込む</Button>
+        </div>
+      </Card>
+    </div>
+  );
+}`;
+
+// サブセット外（Tabs / .map / FormControl の renderInput）を含むサンプル。
+const SAMPLE_HARD = `import { Tabs, FormControl, TextField, Button } from '@k8o/arte-odyssey';
+
+export default function Preview() {
+  const items = ['A', 'B'];
+  return (
+    <div className="flex flex-col gap-6 p-8">
+      <Tabs>...</Tabs>
+      <ul className="flex flex-col gap-2">{items.map((i) => <li key={i}>{i}</li>)}</ul>
+      <FormControl label="お名前" renderInput={(props) => <TextField {...props} />} />
+      <Button color="primary" variant="solid">送信</Button>
+    </div>
+  );
+}`;
+
+const meta = {
+  component: StreamPreview,
+} satisfies Meta<typeof StreamPreview>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+// 完成形。アイコン付きボタンまで含めて素直に描けることを確認する。
+export const Complete: Story = {
+  args: { code: SAMPLE_RICH },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('申し込む')).toBeInTheDocument();
+    await expect(canvas.getByText('プラン')).toBeInTheDocument();
+  },
+};
+
+// 生成 4 割時点。受信済みまで描き、先端にスケルトンが出る。
+export const StreamingEarly: Story = {
+  args: { code: SAMPLE_RICH.slice(0, Math.floor(SAMPLE_RICH.length * 0.4)) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('status').length).toBeGreaterThan(0);
+  },
+};
+
+// 生成 7 割時点。骨格が出揃い、末尾だけ未受信。
+export const StreamingLate: Story = {
+  args: { code: SAMPLE_RICH.slice(0, Math.floor(SAMPLE_RICH.length * 0.7)) },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('プラン')).toBeInTheDocument();
+    await expect(canvas.getAllByRole('status').length).toBeGreaterThan(0);
+  },
+};
+
+// サブセット外がどこに出るかを可視化（UnknownChip）。Button は素直に描ける。
+export const UnsupportedSubset: Story = {
+  args: { code: SAMPLE_HARD },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('送信')).toBeInTheDocument();
+    await expect(canvas.getByText('<Tabs>')).toBeInTheDocument();
+  },
+};
+
+// 生成開始直後（return 未到達）。何も壊さず先端スケルトンだけ出す。
+export const Empty: Story = {
+  args: {
+    code: "import { Card } from '@k8o/arte-odyssey';\n\nexport default function Preview() {",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('status')).toBeInTheDocument();
+  },
+};

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.stories.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.stories.tsx
@@ -86,7 +86,7 @@ export const UnsupportedSubset: Story = {
   },
 };
 
-// 生成開始直後（return 未到達）。何も壊さず先端スケルトンだけ出す。
+// 生成開始直後（return 未到達＝まだ構造なし）。スケルトンではなくスピナーを出す。
 export const Empty: Story = {
   args: {
     code: "import { Card } from '@k8o/arte-odyssey';\n\nexport default function Preview() {",

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { type FC, useMemo } from 'react';
+
+import { parseStreamingTsx } from '@/features/preview/application/incremental-jsx/parse-partial-jsx';
+
+import { renderRoot } from './render-jsx-node';
+
+type Props = {
+  // 生成中の途中 TSX（studio の streamingCode をそのまま渡せる）。
+  code: string | null;
+};
+
+// 生成ストリームの途中 TSX を、Sandbox/Vite を介さずホスト側で直接・逐次描画する island。
+// コンパイルしないので未完入力でも壊れず、未受信の先端はスケルトンで表す。
+export const StreamPreview: FC<Props> = ({ code }) => {
+  const nodes = useMemo(
+    () => (code === null || code === '' ? [] : parseStreamingTsx(code)),
+    [code],
+  );
+
+  return (
+    <div className="bg-bg-base text-fg-base size-full overflow-auto">
+      {renderRoot(nodes)}
+    </div>
+  );
+};

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.tsx
@@ -5,6 +5,7 @@ import { type FC, useMemo } from 'react';
 import { parseStreamingTsx } from '@/features/preview/application/incremental-jsx/parse-partial-jsx';
 
 import { renderRoot } from './render-jsx-node';
+import { StreamBoundary } from './stream-boundary';
 
 type Props = {
   // 生成中の途中 TSX（studio の streamingCode をそのまま渡せる）。
@@ -14,14 +15,23 @@ type Props = {
 // 生成ストリームの途中 TSX を、Sandbox/Vite を介さずホスト側で直接・逐次描画する island。
 // コンパイルしないので未完入力でも壊れず、未受信の先端はスケルトンで表す。
 export const StreamPreview: FC<Props> = ({ code }) => {
-  const nodes = useMemo(
-    () => (code === null || code === '' ? [] : parseStreamingTsx(code)),
-    [code],
-  );
+  const nodes = useMemo(() => {
+    if (code === null || code === '') {
+      return [];
+    }
+    try {
+      return parseStreamingTsx(code);
+    } catch {
+      // パーサが万一 throw しても島を落とさず、空（スピナー）にフォールバックする。
+      return [];
+    }
+  }, [code]);
 
   return (
     <div className="bg-bg-base text-fg-base size-full overflow-auto">
-      {renderRoot(nodes)}
+      <StreamBoundary resetKey={code?.length ?? 0}>
+        {renderRoot(nodes)}
+      </StreamBoundary>
     </div>
   );
 };

--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/unknown-chip.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/unknown-chip.tsx
@@ -1,0 +1,13 @@
+import type { FC, PropsWithChildren } from 'react';
+
+// レジストリ未登録 / 描画失敗のコンポーネントを可視化するフォールバック。
+// PoC では「サブセット外がどこに出るか」をそのまま見えるようにして網羅率を測る。
+export const UnknownChip: FC<PropsWithChildren<{ name: string }>> = ({
+  name,
+  children,
+}) => (
+  <span className="border-border-mute text-fg-mute inline-flex items-center gap-1 rounded-md border border-dashed px-2 py-1 text-xs">
+    <span className="font-mono">{`<${name || 'fragment'}>`}</span>
+    {children}
+  </span>
+);

--- a/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
@@ -218,6 +218,11 @@ export const Studio = () => {
     ? (streamingCode ?? state.currentFile)
     : state.currentFile;
   const hasResult = state.currentFile !== null;
+  // 生成中〜反映確定までは先行プレビュー（island）を最前面に出す。空の間はスピナー、構造が
+  // 届いたらスケルトン→逐次描画へ。これが出ている間は反映スピナー(PreviewLoading)を抑制し、
+  // 「島→いきなり円→完成」のチラつきを防ぐ。
+  const showStreamPreview =
+    isBusy || (previewLoading && streamingCode !== null);
   // 履歴から読み込んだ直後はチャットが空になるため、空状態でも「何を編集中か」を示す。
   const emptyStateTitle = hasResult
     ? `「${state.lastMeta?.title ?? 'プロジェクト'}」を編集中`
@@ -675,7 +680,7 @@ export const Studio = () => {
                     title="preview"
                     url={previewUrl}
                   />
-                  {previewLoading ? (
+                  {previewLoading && !showStreamPreview ? (
                     <PreviewLoading message="プレビューを反映しています…" />
                   ) : null}
                 </>
@@ -685,11 +690,11 @@ export const Studio = () => {
                 </div>
               )}
               {/* 生成中〜反映確定までは、途中コードをホスト側で逐次描画した先行プレビューを
-                  iframe の上に重ねる。Sandbox の cold start や HMR 反映を待たずに構造が見え、
-                  反映が確定（previewLoading=false かつ生成完了）すると外れて実 iframe が出る。
-                  iframe は下で読み込み継続するため onLoad/HMR 通知の経路は壊さない。 */}
-              {streamingCode !== null && (isBusy || previewLoading) ? (
-                <div className="bg-bg-base absolute inset-0 overflow-auto">
+                  iframe（と PreviewLoading の z-10）の上（z-20）に重ねる。Sandbox の cold start や
+                  HMR 反映を待たずに構造が見え、反映が確定（previewLoading=false かつ生成完了）すると
+                  外れて実 iframe が出る。iframe は下で読み込み継続するため通知経路は壊さない。 */}
+              {showStreamPreview ? (
+                <div className="bg-bg-base absolute inset-0 z-20 overflow-auto">
                   <StreamPreview code={streamingCode} />
                 </div>
               ) : null}

--- a/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
@@ -39,6 +39,7 @@ import {
 } from '@/features/preview/interface/actions';
 import { loadProjectAndApplyAction } from '@/features/projects/interface/actions';
 
+import { StreamPreview } from '../stream-preview';
 import { ChatMessage } from './chat-message';
 import { CodePanel } from './code-panel';
 import { CopyCodeButton } from './copy-code-button';
@@ -238,9 +239,10 @@ export const Studio = () => {
     setApplyError(null);
     // 直前の反映待ちタイマーが生成中にリロードを起こさないよう始末する。
     clearReloadFallback();
-    // 生成中はコードが組み上がる様子を実況する（完了後に onFinish がプレビューへ戻す）。
-    // モバイルはチャットの「考えています…」を残したいので mobileTab は切り替えない。
-    setView('code');
+    // 生成中は途中コードを先行プレビュー（StreamPreview）で逐次描画して見せる。完了で
+    // onFinish が実コンパイル版（iframe）へ切り替える。モバイルはチャットの「考えています…」を
+    // 残したいので mobileTab は切り替えない。
+    setView('preview');
     lastPromptRef.current = text;
     await sendMessage(
       { text },
@@ -682,6 +684,15 @@ export const Studio = () => {
                   生成すると、ここにライブプレビューが表示されます
                 </div>
               )}
+              {/* 生成中〜反映確定までは、途中コードをホスト側で逐次描画した先行プレビューを
+                  iframe の上に重ねる。Sandbox の cold start や HMR 反映を待たずに構造が見え、
+                  反映が確定（previewLoading=false かつ生成完了）すると外れて実 iframe が出る。
+                  iframe は下で読み込み継続するため onLoad/HMR 通知の経路は壊さない。 */}
+              {streamingCode !== null && (isBusy || previewLoading) ? (
+                <div className="bg-bg-base absolute inset-0 overflow-auto">
+                  <StreamPreview code={streamingCode} />
+                </div>
+              ) : null}
             </div>
             <div className={view === 'code' ? 'h-full' : 'hidden'}>
               <CodePanel code={displayedCode} isStreaming={isBusy} />

--- a/apps/ai/src/features/preview/application/incremental-jsx/js-literal.test.ts
+++ b/apps/ai/src/features/preview/application/incremental-jsx/js-literal.test.ts
@@ -1,0 +1,134 @@
+import { buildScope, parseJsLiteral } from './js-literal';
+
+describe('parseJsLiteral', () => {
+  describe('正常系', () => {
+    it('オブジェクト配列を JS 値へ変換する', () => {
+      // Arrange
+      const src = "[{ name: '田中', age: 20, admin: true }]";
+
+      // Act
+      const result = parseJsLiteral(src, 0);
+
+      // Assert
+      expect(result?.value).toEqual([{ name: '田中', age: 20, admin: true }]);
+    });
+
+    it('末尾カンマとネストを許容する', () => {
+      // Arrange
+      const src = "{ tags: ['a', 'b',], meta: { n: 1 } }";
+
+      // Act
+      const result = parseJsLiteral(src, 0);
+
+      // Assert
+      expect(result?.value).toEqual({ tags: ['a', 'b'], meta: { n: 1 } });
+    });
+
+    it('null / false を解決する', () => {
+      // Arrange & Act
+      const result = parseJsLiteral('[null, false]', 0);
+
+      // Assert
+      expect(result?.value).toEqual([null, false]);
+    });
+
+    it('指数・16進・桁区切りの数値を解決する', () => {
+      // Arrange & Act
+      const result = parseJsLiteral('[1e3, 0x10, 1_000, -2.5]', 0);
+
+      // Assert
+      expect(result?.value).toEqual([1000, 16, 1000, -2.5]);
+    });
+  });
+
+  describe('セキュリティ', () => {
+    it('__proto__ キーはプロトタイプを汚染せず無視される', () => {
+      // Arrange
+      const src = '[{ __proto__: { name: "PWNED" }, name: "real" }]';
+
+      // Act
+      const result = parseJsLiteral(src, 0);
+
+      // Assert
+      expect(result?.value).toEqual([{ name: 'real' }]);
+    });
+
+    it('深すぎるネストは throw せず null を返す', () => {
+      // Arrange
+      const deep = `${'['.repeat(300)}1${']'.repeat(300)}`;
+
+      // Act & Assert
+      expect(parseJsLiteral(deep, 0)).toBeNull();
+    });
+  });
+
+  describe('異常系', () => {
+    it('識別子参照を含む値は null', () => {
+      // Arrange & Act & Assert
+      expect(parseJsLiteral('[foo]', 0)).toBeNull();
+    });
+
+    it('テンプレートリテラルの補間は null', () => {
+      // Arrange & Act & Assert
+      expect(parseJsLiteral('[`${x}`]', 0)).toBeNull();
+    });
+
+    it('閉じていない配列は null', () => {
+      // Arrange & Act & Assert
+      expect(parseJsLiteral('[1, 2', 0)).toBeNull();
+    });
+  });
+});
+
+describe('buildScope', () => {
+  describe('正常系', () => {
+    it('const のインライン配列/オブジェクトを拾う', () => {
+      // Arrange
+      const tsx = "const members = [{ name: 'A' }];\nreturn (<div/>);";
+
+      // Act
+      const scope = buildScope(tsx);
+
+      // Assert
+      expect(scope['members']).toEqual([{ name: 'A' }]);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('プリミティブや解決不能な const は無視する', () => {
+      // Arrange
+      const tsx = 'const n = 3;\nconst data = fetchData();\nconst items = [1];';
+
+      // Act
+      const scope = buildScope(tsx);
+
+      // Assert
+      expect('n' in scope).toBe(false);
+      expect('data' in scope).toBe(false);
+      expect(scope['items']).toEqual([1]);
+    });
+
+    it('同名 const は最初の宣言を優先する', () => {
+      // Arrange
+      const tsx = 'const x = [1];\nconst x = [2];';
+
+      // Act
+      const scope = buildScope(tsx);
+
+      // Assert
+      expect(scope['x']).toEqual([1]);
+    });
+
+    it('const __proto__ はスコープを汚染しない', () => {
+      // Arrange
+      const tsx = 'const __proto__ = [9];\nconst items = [1];';
+
+      // Act
+      const scope = buildScope(tsx);
+
+      // Assert
+      expect(Object.hasOwn(scope, '__proto__')).toBe(false);
+      expect(scope['items']).toEqual([1]);
+    });
+  });
+});

--- a/apps/ai/src/features/preview/application/incremental-jsx/js-literal.ts
+++ b/apps/ai/src/features/preview/application/incremental-jsx/js-literal.ts
@@ -1,0 +1,256 @@
+// 生成コードの `const X = [...]` / `{...}` のインラインリテラルを JS 値へ変換する小さなパーサ。
+// `.map()` の展開時に配列データを解決するために使う。式・関数・JSX を含む値は非対応として null を返す。
+
+type Parsed = { value: unknown } | null;
+type LiteralResult = { value: unknown; end: number };
+
+const isIdentStart = (c: string): boolean => /[A-Za-z_$]/u.test(c);
+const isIdentChar = (c: string): boolean => /[\w$]/u.test(c);
+
+// src[start] からリテラルを 1 つ読む。読めなければ null。end は読み終えた次の位置。
+export const parseJsLiteral = (
+  src: string,
+  start: number,
+): LiteralResult | null => {
+  const len = src.length;
+  let pos = start;
+  const at = (i: number): string => src[i] ?? '';
+  const ws = (): void => {
+    while (pos < len && /\s/u.test(at(pos))) {
+      pos += 1;
+    }
+  };
+
+  const parseString = (quote: string): Parsed => {
+    pos += 1;
+    let out = '';
+    while (pos < len) {
+      const c = at(pos);
+      if (c === '\\') {
+        out += at(pos + 1);
+        pos += 2;
+        continue;
+      }
+      // テンプレートリテラルの ${ 補間は静的に解決できないため非対応。
+      if (quote === '`' && c === '$' && at(pos + 1) === '{') {
+        return null;
+      }
+      if (c === quote) {
+        pos += 1;
+        return { value: out };
+      }
+      out += c;
+      pos += 1;
+    }
+    return null;
+  };
+
+  const parseNumber = (): Parsed => {
+    const s = pos;
+    if (at(pos) === '0' && /[xXoObB]/u.test(at(pos + 1))) {
+      // 16/8/2 進。
+      pos += 2;
+      while (pos < len && /[0-9a-fA-F_]/u.test(at(pos))) {
+        pos += 1;
+      }
+    } else {
+      if (at(pos) === '-') {
+        pos += 1;
+      }
+      while (pos < len && /[\d_]/u.test(at(pos))) {
+        pos += 1;
+      }
+      if (at(pos) === '.') {
+        pos += 1;
+        while (pos < len && /[\d_]/u.test(at(pos))) {
+          pos += 1;
+        }
+      }
+      if (at(pos) === 'e' || at(pos) === 'E') {
+        pos += 1;
+        if (at(pos) === '+' || at(pos) === '-') {
+          pos += 1;
+        }
+        while (pos < len && /\d/u.test(at(pos))) {
+          pos += 1;
+        }
+      }
+    }
+    if (at(pos) === 'n') {
+      // BigInt サフィックス。
+      pos += 1;
+    }
+    const raw = src.slice(s, pos).replaceAll(/_/gu, '').replace(/n$/u, '');
+    const num = Number(raw);
+    return Number.isNaN(num) ? null : { value: num };
+  };
+
+  const parseWord = (): Parsed => {
+    const s = pos;
+    while (pos < len && isIdentChar(at(pos))) {
+      pos += 1;
+    }
+    const word = src.slice(s, pos);
+    if (word === 'true') {
+      return { value: true };
+    }
+    if (word === 'false') {
+      return { value: false };
+    }
+    if (word === 'null' || word === 'undefined') {
+      return { value: null };
+    }
+    // 識別子参照は静的に解決できない。
+    return null;
+  };
+
+  const parseArray = (depth: number): Parsed => {
+    pos += 1;
+    const arr: unknown[] = [];
+    for (;;) {
+      ws();
+      if (pos >= len) {
+        return null;
+      }
+      if (at(pos) === ']') {
+        pos += 1;
+        return { value: arr };
+      }
+      const item = parseValue(depth);
+      if (item === null) {
+        return null;
+      }
+      arr.push(item.value);
+      ws();
+      if (at(pos) === ',') {
+        pos += 1;
+        continue;
+      }
+      if (at(pos) === ']') {
+        pos += 1;
+        return { value: arr };
+      }
+      return null;
+    }
+  };
+
+  const parseObject = (depth: number): Parsed => {
+    pos += 1;
+    const obj: Record<string, unknown> = {};
+    for (;;) {
+      ws();
+      if (pos >= len) {
+        return null;
+      }
+      if (at(pos) === '}') {
+        pos += 1;
+        return { value: obj };
+      }
+      const c = at(pos);
+      let key: string;
+      if (c === '"' || c === "'") {
+        const k = parseString(c);
+        if (k === null) {
+          return null;
+        }
+        key = String(k.value);
+      } else if (isIdentStart(c)) {
+        const s = pos;
+        while (pos < len && isIdentChar(at(pos))) {
+          pos += 1;
+        }
+        key = src.slice(s, pos);
+      } else {
+        return null;
+      }
+      ws();
+      if (at(pos) !== ':') {
+        return null;
+      }
+      pos += 1;
+      const value = parseValue(depth);
+      if (value === null) {
+        return null;
+      }
+      // __proto__ / constructor / prototype は代入しない（プロトタイプ汚染防止）。
+      if (key !== '__proto__' && key !== 'constructor' && key !== 'prototype') {
+        obj[key] = value.value;
+      }
+      ws();
+      if (at(pos) === ',') {
+        pos += 1;
+        continue;
+      }
+      if (at(pos) === '}') {
+        pos += 1;
+        return { value: obj };
+      }
+      return null;
+    }
+  };
+
+  function parseValue(depth: number): Parsed {
+    // 深いネストでのスタック超過を避けるためのガード。
+    if (depth > 100) {
+      return null;
+    }
+    ws();
+    const c = at(pos);
+    if (c === '[') {
+      return parseArray(depth + 1);
+    }
+    if (c === '{') {
+      return parseObject(depth + 1);
+    }
+    if (c === '"' || c === "'" || c === '`') {
+      return parseString(c);
+    }
+    if (c === '-' || /\d/u.test(c)) {
+      return parseNumber();
+    }
+    if (isIdentStart(c)) {
+      return parseWord();
+    }
+    return null;
+  }
+
+  const result = parseValue(0);
+  if (result === null) {
+    return null;
+  }
+  return { value: result.value, end: pos };
+};
+
+const CONST_DECL = /\bconst\s+([A-Za-z_$][\w$]*)\s*=\s*/gu;
+
+// TSX 全文から `const NAME = [..]` / `const NAME = {..}` を拾い、解決できたものだけを
+// スコープ（名前→値）にする。`.map()` 展開時の配列解決に使う。
+export const buildScope = (tsx: string): Record<string, unknown> => {
+  const scope: Record<string, unknown> = {};
+  for (const match of tsx.matchAll(CONST_DECL)) {
+    const name = match[1];
+    if (name === undefined) {
+      continue;
+    }
+    const valueStart = match.index + match[0].length;
+    const head = tsx[valueStart] ?? '';
+    // 配列/オブジェクトリテラルのみ対象（関数・式・プリミティブは無視）。
+    if (head !== '[' && head !== '{') {
+      continue;
+    }
+    // 危険キーは登録しない。同名は最初の宣言を優先（文字列内の偽宣言で上書きさせない）。
+    if (
+      name === '__proto__' ||
+      name === 'constructor' ||
+      name === 'prototype' ||
+      Object.hasOwn(scope, name)
+    ) {
+      continue;
+    }
+    const lit = parseJsLiteral(tsx, valueStart);
+    if (lit !== null) {
+      scope[name] = lit.value;
+    }
+  }
+  return scope;
+};

--- a/apps/ai/src/features/preview/application/incremental-jsx/js-literal.ts
+++ b/apps/ai/src/features/preview/application/incremental-jsx/js-literal.ts
@@ -80,7 +80,7 @@ export const parseJsLiteral = (
       // BigInt サフィックス。
       pos += 1;
     }
-    const raw = src.slice(s, pos).replaceAll(/_/gu, '').replace(/n$/u, '');
+    const raw = src.slice(s, pos).replaceAll('_', '').replace(/n$/u, '');
     const num = Number(raw);
     return Number.isNaN(num) ? null : { value: num };
   };

--- a/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.test.ts
+++ b/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.test.ts
@@ -1,4 +1,8 @@
-import { extractJsxBody, parsePartialJsx } from './parse-partial-jsx';
+import {
+  extractJsxBody,
+  parsePartialJsx,
+  parseStreamingTsx,
+} from './parse-partial-jsx';
 import type { JsxElement, JsxNode } from './types';
 
 const firstElement = (nodes: readonly JsxNode[]): JsxElement => {
@@ -9,6 +13,18 @@ const firstElement = (nodes: readonly JsxNode[]): JsxElement => {
   }
   throw new Error('element ノードが見つかりません');
 };
+
+// 要素配下のテキストを連結して取り出す（map 展開の解決結果を検証する用）。
+const textOf = (node: JsxNode): string => {
+  if (node.type === 'element') {
+    return node.children.map(textOf).join('');
+  }
+  return node.type === 'text' ? node.value : '';
+};
+
+// ノードの種別ラベル（要素なら名前、それ以外は type）。テスト内で条件分岐を書かないための補助。
+const labelOf = (node: JsxNode): string =>
+  node.type === 'element' ? node.name : node.type;
 
 describe('parsePartialJsx', () => {
   describe('正常系', () => {
@@ -185,6 +201,159 @@ describe('extractJsxBody', () => {
 
       // Act & Assert
       expect(extractJsxBody(tsx)).toBe('');
+    });
+  });
+});
+
+describe('map 展開とスコープ解決', () => {
+  describe('正常系', () => {
+    it('配列データから要素を複製し {item.field} を解決する', () => {
+      // Arrange
+      const scope = { items: [{ label: 'A' }, { label: 'B' }] };
+
+      // Act
+      const ul = firstElement(
+        parsePartialJsx(
+          '<ul>{items.map((it) => <li>{it.label}</li>)}</ul>',
+          scope,
+        ),
+      );
+
+      // Assert
+      expect(ul.children).toHaveLength(2);
+      expect(ul.children.map(textOf)).toEqual(['A', 'B']);
+    });
+
+    it('index 引数を解決する', () => {
+      // Arrange
+      const scope = { items: ['a', 'b', 'c'] };
+
+      // Act
+      const ul = firstElement(
+        parsePartialJsx('<ul>{items.map((it, i) => <li>{i}</li>)}</ul>', scope),
+      );
+
+      // Assert
+      expect(ul.children.map(textOf)).toEqual(['0', '1', '2']);
+    });
+
+    it('TSX 全文（const データ + return）を展開する', () => {
+      // Arrange
+      const tsx = [
+        "import { Heading } from '@k8o/arte-odyssey';",
+        "const members = [{ name: '田中' }, { name: '佐藤' }];",
+        'export default function Preview() {',
+        '  return (',
+        '    <div>{members.map((m) => <span>{m.name}</span>)}</div>',
+        '  );',
+        '}',
+      ].join('\n');
+
+      // Act
+      const div = firstElement(parseStreamingTsx(tsx));
+
+      // Assert
+      expect(div.children.map(textOf)).toEqual(['田中', '佐藤']);
+    });
+  });
+
+  describe('異常系（ストリーミング途中）', () => {
+    it('テンプレートが未完なら配列ぶんの部分要素を出す', () => {
+      // Arrange
+      const scope = { items: [{ x: 1 }, { x: 2 }] };
+
+      // Act
+      const div = firstElement(
+        parsePartialJsx('<div>{items.map((it) => <Card><Avatar', scope),
+      );
+
+      // Assert: 2 枚の Card がそれぞれ pending を抱えて並ぶ
+      expect(div.children.map(labelOf)).toEqual(['Card', 'Card']);
+      expect(div.children.map(textOf)).toEqual(['', '']);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('配列を解決できない map は描かない', () => {
+      // Arrange & Act
+      const ul = firstElement(
+        parsePartialJsx('<ul>{items.map((it) => <li>{it}</li>)}</ul>', {}),
+      );
+
+      // Assert
+      expect(ul.children).toEqual([]);
+    });
+
+    it('ネストした map（arr.field.map）を解決する', () => {
+      // Arrange
+      const scope = {
+        groups: [
+          { title: 'A', items: ['a1', 'a2'] },
+          { title: 'B', items: ['b1'] },
+        ],
+      };
+      const source =
+        '<div>{groups.map((g) => (<section><h2>{g.title}</h2><ul>{g.items.map((it) => (<li>{it}</li>))}</ul></section>))}</div>';
+
+      // Act
+      const div = firstElement(parsePartialJsx(source, scope));
+
+      // Assert: A(a1,a2) と B(b1) が入れ子で展開される
+      expect(textOf(div)).toBe('Aa1a2Bb1');
+    });
+
+    it('複製数は上限で打ち切る（巨大配列保護）', () => {
+      // Arrange
+      const items = Array.from({ length: 600 }, (_, i) => String(i));
+
+      // Act
+      const ul = firstElement(
+        parsePartialJsx('<ul>{items.map((it) => <i>{it}</i>)}</ul>', { items }),
+      );
+
+      // Assert
+      expect(ul.children).toHaveLength(500);
+    });
+  });
+
+  describe('セキュリティ・堅牢性', () => {
+    it('存在しないフィールドは prop/子に出さない', () => {
+      // Arrange & Act
+      const span = firstElement(
+        parsePartialJsx('<span>{it.missing}</span>', { it: { name: 'x' } }),
+      );
+
+      // Assert
+      expect(span.children).toEqual([]);
+    });
+
+    it('__proto__ で汚染されたデータ越境値を描かない', () => {
+      // Arrange: 1件目は __proto__ 経由で name を偽装、2件目は実データ
+      const tsx = [
+        'const items = [{ __proto__: { name: "PWNED" } }, { name: "real" }];',
+        'export default function Preview() {',
+        '  return <div>{items.map((it) => <span>{it.name}</span>)}</div>;',
+        '}',
+      ].join('\n');
+
+      // Act
+      const div = firstElement(parseStreamingTsx(tsx));
+
+      // Assert: PWNED は出ず、実データのみ
+      expect(textOf(div)).toBe('real');
+    });
+
+    it('テンプレートが要素を形成する前に切れたら pending は 1 つだけ', () => {
+      // Arrange
+      const scope = { items: [{}, {}, {}] };
+
+      // Act
+      const div = firstElement(
+        parsePartialJsx('<div>{items.map((it) => <', scope),
+      );
+
+      // Assert
+      expect(div.children).toEqual([{ type: 'pending' }]);
     });
   });
 });

--- a/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.test.ts
+++ b/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.test.ts
@@ -1,0 +1,190 @@
+import { extractJsxBody, parsePartialJsx } from './parse-partial-jsx';
+import type { JsxElement, JsxNode } from './types';
+
+const firstElement = (nodes: readonly JsxNode[]): JsxElement => {
+  for (const node of nodes) {
+    if (node.type === 'element') {
+      return node;
+    }
+  }
+  throw new Error('element ノードが見つかりません');
+};
+
+describe('parsePartialJsx', () => {
+  describe('正常系', () => {
+    it('単一要素の className とテキスト子をパースする', () => {
+      // Arrange
+      const source = '<div className="box">Hello</div>';
+
+      // Act
+      const el = firstElement(parsePartialJsx(source));
+
+      // Assert
+      expect(el.name).toBe('div');
+      expect(el.props).toEqual([
+        { name: 'className', value: { kind: 'string', value: 'box' } },
+      ]);
+      expect(el.children).toEqual([{ type: 'text', value: 'Hello' }]);
+    });
+
+    it('コンポーネントのネストと文字列属性をパースする', () => {
+      // Arrange
+      const source =
+        '<Card appearance="shadow"><Heading type="h2">Title</Heading></Card>';
+
+      // Act
+      const card = firstElement(parsePartialJsx(source));
+      const heading = firstElement(card.children);
+
+      // Assert
+      expect(card.name).toBe('Card');
+      expect(heading.name).toBe('Heading');
+      expect(heading.props).toEqual([
+        { name: 'type', value: { kind: 'string', value: 'h2' } },
+      ]);
+      expect(heading.children).toEqual([{ type: 'text', value: 'Title' }]);
+    });
+
+    it('自己終了タグと数値リテラル属性をパースする', () => {
+      // Arrange
+      const source = '<Grid cols={2} gap="md" />';
+
+      // Act
+      const el = firstElement(parsePartialJsx(source));
+
+      // Assert
+      expect(el.children).toEqual([]);
+      expect(el.props).toEqual([
+        { name: 'cols', value: { kind: 'literal', value: 2 } },
+        { name: 'gap', value: { kind: 'string', value: 'md' } },
+      ]);
+    });
+
+    it('prop に渡したネスト JSX（アイコン）を element として保持する', () => {
+      // Arrange
+      const source = '<Button startIcon={<SparklesIcon />}>送信</Button>';
+
+      // Act
+      const el = firstElement(parsePartialJsx(source));
+
+      // Assert
+      expect(el.props).toEqual([
+        {
+          name: 'startIcon',
+          value: {
+            kind: 'element',
+            value: {
+              type: 'element',
+              name: 'SparklesIcon',
+              props: [],
+              children: [],
+            },
+          },
+        },
+      ]);
+    });
+
+    it('真偽値短縮属性を boolean として扱う', () => {
+      // Arrange
+      const source = '<button disabled>x</button>';
+
+      // Act
+      const el = firstElement(parsePartialJsx(source));
+
+      // Assert
+      expect(el.props).toEqual([
+        { name: 'disabled', value: { kind: 'boolean' } },
+      ]);
+    });
+  });
+
+  describe('異常系（ストリーミング途中）', () => {
+    it('開始タグが途中で切れたら親の子を pending にする', () => {
+      // Arrange
+      const source = '<div><Card appea';
+
+      // Act
+      const div = firstElement(parsePartialJsx(source));
+
+      // Assert
+      expect(div.children).toEqual([{ type: 'pending' }]);
+    });
+
+    it('子テキストの途中で切れたら末尾に pending を足す', () => {
+      // Arrange
+      const source = '<div className="x">Hello';
+
+      // Act
+      const div = firstElement(parsePartialJsx(source));
+
+      // Assert
+      expect(div.children).toEqual([
+        { type: 'text', value: 'Hello' },
+        { type: 'pending' },
+      ]);
+    });
+
+    it('文字列属性が閉じ未到達なら pending のみを返す', () => {
+      // Arrange
+      const source = '<div className="bo';
+
+      // Act
+      const nodes = parsePartialJsx(source);
+
+      // Assert
+      expect(nodes).toEqual([{ type: 'pending' }]);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('未対応の式（.map）は子として描かない', () => {
+      // Arrange
+      const source = '<ul>{items.map((i) => <li>{i}</li>)}</ul>';
+
+      // Act
+      const ul = firstElement(parsePartialJsx(source));
+
+      // Assert
+      expect(ul.children).toEqual([]);
+    });
+
+    it('フラグメントを名前なし要素としてパースする', () => {
+      // Arrange
+      const source = '<><span>a</span></>';
+
+      // Act
+      const fragment = firstElement(parsePartialJsx(source));
+
+      // Assert
+      expect(fragment.name).toBe('');
+      expect(firstElement(fragment.children).name).toBe('span');
+    });
+  });
+});
+
+describe('extractJsxBody', () => {
+  describe('正常系', () => {
+    it('return より後の最初の < から本体を切り出す', () => {
+      // Arrange
+      const tsx =
+        'export default function Preview() {\n  return (\n    <div>hi</div>\n  );\n}';
+
+      // Act
+      const body = extractJsxBody(tsx);
+
+      // Assert
+      expect(body.startsWith('<div>hi</div>')).toBe(true);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('return 未到達（import 中）なら空文字を返す', () => {
+      // Arrange
+      const tsx =
+        "import { Card } from '@k8o/arte-odyssey';\n\nexport default function Preview() {";
+
+      // Act & Assert
+      expect(extractJsxBody(tsx)).toBe('');
+    });
+  });
+});

--- a/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.ts
+++ b/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.ts
@@ -1,0 +1,326 @@
+import type { JsxAttr, JsxNode, JsxProp } from './types';
+
+// ストリーミング途中の TSX 文字列を寛容にパースし、受信済みの部分だけを軽量 AST にする。
+// Vite/esbuild に途中コードを食わせる方式と違い、コンパイルを介さないので未完入力でも壊れない。
+// 未受信の先端（開いたままの最深要素）には 1 つだけ pending ノードを差す（single frontier）。
+
+const isNameStart = (c: string): boolean => /[A-Za-z]/u.test(c);
+const isNameChar = (c: string): boolean => /[A-Za-z0-9]/u.test(c);
+
+// TSX 全文から `return` 直後の JSX 本体を切り出す。まだ JSX に到達していなければ空文字。
+export const extractJsxBody = (tsx: string): string => {
+  const returnIdx = tsx.search(/\breturn\b/u);
+  if (returnIdx === -1) {
+    return '';
+  }
+  const lt = tsx.indexOf('<', returnIdx);
+  if (lt === -1) {
+    return '';
+  }
+  return tsx.slice(lt);
+};
+
+export const parsePartialJsx = (source: string): readonly JsxNode[] => {
+  const len = source.length;
+  let pos = 0;
+  // 最深の未完点に pending を 1 つだけ置くためのフラグ。立ったら以降の兄弟・末尾は読まない。
+  let truncated = false;
+
+  const at = (i: number): string => source[i] ?? '';
+
+  const skipWs = (): void => {
+    while (pos < len && /\s/u.test(at(pos))) {
+      pos += 1;
+    }
+  };
+
+  // 文字列リテラルを末尾の同種クォートまで読み飛ばす。EOF なら false。
+  const skipString = (quote: string): boolean => {
+    pos += 1;
+    while (pos < len) {
+      const c = at(pos);
+      if (c === '\\') {
+        pos += 2;
+        continue;
+      }
+      if (c === quote) {
+        pos += 1;
+        return true;
+      }
+      pos += 1;
+    }
+    return false;
+  };
+
+  // `{` から対応する `}` までの内側文字列を返す（クォート内のブレースは無視）。EOF なら null。
+  const readBracedInner = (): string | null => {
+    const start = pos;
+    let depth = 0;
+    while (pos < len) {
+      const c = at(pos);
+      if (c === '"' || c === "'" || c === '`') {
+        if (!skipString(c)) {
+          return null;
+        }
+        continue;
+      }
+      if (c === '{') {
+        depth += 1;
+      } else if (c === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          const inner = source.slice(start + 1, pos);
+          pos += 1;
+          return inner;
+        }
+      }
+      pos += 1;
+    }
+    return null;
+  };
+
+  // `{...}` の内側を分類する。リテラル・ネスト JSX 以外は unsupported。
+  const classifyExpression = (innerRaw: string): JsxAttr => {
+    const inner = innerRaw.trim();
+    if (inner === '') {
+      return { kind: 'unsupported', raw: innerRaw };
+    }
+    const head = inner[0] ?? '';
+    const tail = inner.at(-1) ?? '';
+    if ((head === '"' || head === "'") && tail === head && inner.length >= 2) {
+      return { kind: 'string', value: inner.slice(1, -1) };
+    }
+    if (head === '`' && tail === '`' && !inner.includes('${')) {
+      return { kind: 'string', value: inner.slice(1, -1) };
+    }
+    if (/^-?\d+(?:\.\d+)?$/u.test(inner)) {
+      return { kind: 'literal', value: Number(inner) };
+    }
+    if (inner === 'true' || inner === 'false') {
+      return { kind: 'literal', value: inner === 'true' };
+    }
+    if (inner === 'null' || inner === 'undefined') {
+      return { kind: 'literal', value: null };
+    }
+    if (head === '<') {
+      // ネスト JSX（startIcon={<SparklesIcon />} 等）。
+      const nested = parsePartialJsx(inner);
+      for (const node of nested) {
+        if (node.type === 'element') {
+          return { kind: 'element', value: node };
+        }
+      }
+    }
+    return { kind: 'unsupported', raw: innerRaw };
+  };
+
+  // 属性を 1 つ読む。タグ途中で EOF なら null。
+  const parseAttribute = (): JsxProp | null => {
+    if (at(pos) === '{') {
+      // {...props} など。対応外だが消費はする。
+      const inner = readBracedInner();
+      if (inner === null) {
+        return null;
+      }
+      return { name: '...spread', value: { kind: 'unsupported', raw: inner } };
+    }
+    let name = '';
+    while (pos < len && (isNameChar(at(pos)) || at(pos) === '-')) {
+      name += at(pos);
+      pos += 1;
+    }
+    if (name === '') {
+      // 想定外文字。1 文字進めて無害なダミー（描画側で空名はスキップ）。
+      pos += 1;
+      return { name: '', value: { kind: 'boolean' } };
+    }
+    skipWs();
+    if (at(pos) !== '=') {
+      // 真偽値短縮（<input disabled> 等）。
+      return { name, value: { kind: 'boolean' } };
+    }
+    pos += 1;
+    if (pos >= len) {
+      return null;
+    }
+    const v = at(pos);
+    if (v === '"' || v === "'") {
+      const start = pos;
+      if (!skipString(v)) {
+        return null;
+      }
+      return {
+        name,
+        value: { kind: 'string', value: source.slice(start + 1, pos - 1) },
+      };
+    }
+    if (v === '{') {
+      const inner = readBracedInner();
+      if (inner === null) {
+        return null;
+      }
+      return { name, value: classifyExpression(inner) };
+    }
+    // 裸の値（想定外）。空白までを raw として保持。
+    const start = pos;
+    while (pos < len && !/[\s/>]/u.test(at(pos))) {
+      pos += 1;
+    }
+    return {
+      name,
+      value: { kind: 'unsupported', raw: source.slice(start, pos) },
+    };
+  };
+
+  // 親の閉じタグ `</...>`（または `</>`）を寛容に消費する。名前は照合しない。
+  const consumeCloseTag = (): void => {
+    if (at(pos) === '<' && at(pos + 1) === '/') {
+      while (pos < len && at(pos) !== '>') {
+        pos += 1;
+      }
+      if (pos < len) {
+        pos += 1;
+      }
+    }
+  };
+
+  // `<` 始まりの要素を読む。開始タグが途中で切れたら null（= 先端）。
+  const parseElement = (): JsxNode | null => {
+    // 先頭の `<` を消費する。
+    pos += 1;
+    if (at(pos) === '>') {
+      // フラグメント <>...</>
+      pos += 1;
+      const children = parseChildren();
+      if (pos >= len && !truncated) {
+        children.push({ type: 'pending' });
+        truncated = true;
+      }
+      consumeCloseTag();
+      return { type: 'element', name: '', props: [], children };
+    }
+    if (pos >= len || !isNameStart(at(pos))) {
+      return null;
+    }
+    let name = '';
+    while (pos < len && isNameChar(at(pos))) {
+      name += at(pos);
+      pos += 1;
+    }
+    const props: JsxProp[] = [];
+    for (;;) {
+      skipWs();
+      if (pos >= len) {
+        return null;
+      }
+      const c = at(pos);
+      if (c === '/') {
+        if (at(pos + 1) === '>') {
+          pos += 2;
+          return { type: 'element', name, props, children: [] };
+        }
+        if (pos + 1 >= len) {
+          return null;
+        }
+        // 不正な `/` はスキップする。
+        pos += 1;
+        continue;
+      }
+      if (c === '>') {
+        pos += 1;
+        const children = parseChildren();
+        if (pos >= len && !truncated) {
+          // 子は読めたが閉じタグ未到達 → ここが先端。
+          children.push({ type: 'pending' });
+          truncated = true;
+        }
+        consumeCloseTag();
+        return { type: 'element', name, props, children };
+      }
+      const attr = parseAttribute();
+      if (attr === null) {
+        return null;
+      }
+      props.push(attr);
+    }
+  };
+
+  // 子要素の式 `{...}`。truncated を表す 'pending'、描かない場合は null。
+  const parseExpressionChild = (): JsxNode | 'pending' | null => {
+    const inner = readBracedInner();
+    if (inner === null) {
+      return 'pending';
+    }
+    const attr = classifyExpression(inner);
+    if (attr.kind === 'string') {
+      return { type: 'text', value: attr.value };
+    }
+    if (attr.kind === 'literal') {
+      return attr.value === null
+        ? null
+        : { type: 'text', value: String(attr.value) };
+    }
+    if (attr.kind === 'element') {
+      return attr.value;
+    }
+    // unsupported は子として描かない。
+    return null;
+  };
+
+  const parseText = (): string => {
+    const start = pos;
+    while (pos < len && at(pos) !== '<' && at(pos) !== '{') {
+      pos += 1;
+    }
+    return source.slice(start, pos);
+  };
+
+  function parseChildren(): JsxNode[] {
+    const children: JsxNode[] = [];
+    // pos は parseElement / parseText 等の内部で前進するため直接の変更が見えない。
+    // eslint-disable-next-line no-unmodified-loop-condition
+    while (pos < len) {
+      const c = at(pos);
+      if (c === '<') {
+        if (at(pos + 1) === '/') {
+          // 親の閉じタグ。呼び出し側が消費する。
+          return children;
+        }
+        const el = parseElement();
+        if (el === null) {
+          children.push({ type: 'pending' });
+          truncated = true;
+          return children;
+        }
+        children.push(el);
+        if (truncated) {
+          return children;
+        }
+        continue;
+      }
+      if (c === '{') {
+        const node = parseExpressionChild();
+        if (node === 'pending') {
+          children.push({ type: 'pending' });
+          truncated = true;
+          return children;
+        }
+        if (node !== null) {
+          children.push(node);
+        }
+        continue;
+      }
+      const text = parseText();
+      if (text !== '') {
+        children.push({ type: 'text', value: text });
+      }
+    }
+    return children;
+  }
+
+  return parseChildren();
+};
+
+// TSX 全文を受け取り、JSX 本体を抽出してパースする薄いラッパ。
+export const parseStreamingTsx = (tsx: string): readonly JsxNode[] =>
+  parsePartialJsx(extractJsxBody(tsx));

--- a/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.ts
+++ b/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.ts
@@ -1,11 +1,48 @@
+import { buildScope } from './js-literal';
 import type { JsxAttr, JsxNode, JsxProp } from './types';
 
 // ストリーミング途中の TSX 文字列を寛容にパースし、受信済みの部分だけを軽量 AST にする。
 // Vite/esbuild に途中コードを食わせる方式と違い、コンパイルを介さないので未完入力でも壊れない。
 // 未受信の先端（開いたままの最深要素）には 1 つだけ pending ノードを差す（single frontier）。
+//
+// scope は `const X = [...]` 由来のデータと、`.map()` 展開時のループ変数を保持する。
+// これにより `{item.name}` の解決と、配列データからのカード複製（逐次表示）ができる。
 
 const isNameStart = (c: string): boolean => /[A-Za-z]/u.test(c);
 const isNameChar = (c: string): boolean => /[A-Za-z0-9]/u.test(c);
+const isIdentStart = (c: string): boolean => /[A-Za-z_$]/u.test(c);
+const isIdentChar = (c: string): boolean => /[\w$]/u.test(c);
+
+// `item` / `item.field.sub` のような純粋なドット参照のみ受け付ける。
+const IDENT_PATH = /^[A-Za-z_$][\w$]*(?:\.[A-Za-z_$][\w$]*)*$/u;
+
+// 1 回の map 展開で生成する要素数の上限（巨大配列でのクラッシュ/フリーズ防止）。
+const MAX_MAP_ITEMS = 500;
+
+// スコープから式パスを解決する。各段で hasOwn を確認し、継承プロパティ（toString 等）や
+// 存在しないフィールドは found:false にして「データに無い値」を描かない。
+const resolvePath = (
+  expr: string,
+  scope: Record<string, unknown>,
+): { found: boolean; value: unknown } => {
+  const parts = expr.split('.');
+  const head = parts[0];
+  if (head === undefined || !Object.hasOwn(scope, head)) {
+    return { found: false, value: undefined };
+  }
+  let current: unknown = scope[head];
+  for (const key of parts.slice(1)) {
+    if (
+      current === null ||
+      typeof current !== 'object' ||
+      !Object.hasOwn(current, key)
+    ) {
+      return { found: false, value: undefined };
+    }
+    current = (current as Record<string, unknown>)[key];
+  }
+  return { found: true, value: current };
+};
 
 // TSX 全文から `return` 直後の JSX 本体を切り出す。まだ JSX に到達していなければ空文字。
 export const extractJsxBody = (tsx: string): string => {
@@ -20,7 +57,10 @@ export const extractJsxBody = (tsx: string): string => {
   return tsx.slice(lt);
 };
 
-export const parsePartialJsx = (source: string): readonly JsxNode[] => {
+export const parsePartialJsx = (
+  source: string,
+  scope: Record<string, unknown> = {},
+): readonly JsxNode[] => {
   const len = source.length;
   let pos = 0;
   // 最深の未完点に pending を 1 つだけ置くためのフラグ。立ったら以降の兄弟・末尾は読まない。
@@ -32,6 +72,17 @@ export const parsePartialJsx = (source: string): readonly JsxNode[] => {
     while (pos < len && /\s/u.test(at(pos))) {
       pos += 1;
     }
+  };
+
+  const readIdent = (): string => {
+    if (pos >= len || !isIdentStart(at(pos))) {
+      return '';
+    }
+    const start = pos;
+    while (pos < len && isIdentChar(at(pos))) {
+      pos += 1;
+    }
+    return source.slice(start, pos);
   };
 
   // 文字列リテラルを末尾の同種クォートまで読み飛ばす。EOF なら false。
@@ -79,7 +130,7 @@ export const parsePartialJsx = (source: string): readonly JsxNode[] => {
     return null;
   };
 
-  // `{...}` の内側を分類する。リテラル・ネスト JSX 以外は unsupported。
+  // `{...}` の内側を分類する。リテラル・スコープ解決・ネスト JSX 以外は unsupported。
   const classifyExpression = (innerRaw: string): JsxAttr => {
     const inner = innerRaw.trim();
     if (inner === '') {
@@ -102,9 +153,26 @@ export const parsePartialJsx = (source: string): readonly JsxNode[] => {
     if (inner === 'null' || inner === 'undefined') {
       return { kind: 'literal', value: null };
     }
+    // スコープ解決（`{item.name}` 等）。map 展開時にループ変数が入っている。
+    if (IDENT_PATH.test(inner)) {
+      const resolved = resolvePath(inner, scope);
+      if (resolved.found) {
+        const { value } = resolved;
+        if (typeof value === 'string') {
+          return { kind: 'string', value };
+        }
+        if (typeof value === 'number' || typeof value === 'boolean') {
+          return { kind: 'literal', value };
+        }
+        if (value === null || value === undefined) {
+          return { kind: 'literal', value: null };
+        }
+        return { kind: 'unsupported', raw: innerRaw };
+      }
+    }
     if (head === '<') {
-      // ネスト JSX（startIcon={<SparklesIcon />} 等）。
-      const nested = parsePartialJsx(inner);
+      // ネスト JSX（startIcon={<SparklesIcon />} 等）。スコープを引き継ぐ。
+      const nested = parsePartialJsx(inner, scope);
       for (const node of nested) {
         if (node.type === 'element') {
           return { kind: 'element', value: node };
@@ -184,6 +252,29 @@ export const parsePartialJsx = (source: string): readonly JsxNode[] => {
     }
   };
 
+  // map 式の `{` に対応する `}` まで（テンプレ後の `))` も含めて）寛容に消費する。
+  const consumeMapTail = (): void => {
+    let depth = 1;
+    while (pos < len) {
+      const c = at(pos);
+      if (c === '"' || c === "'" || c === '`') {
+        skipString(c);
+        continue;
+      }
+      if (c === '{') {
+        depth += 1;
+      } else if (c === '}') {
+        depth -= 1;
+        pos += 1;
+        if (depth === 0) {
+          return;
+        }
+        continue;
+      }
+      pos += 1;
+    }
+  };
+
   // `<` 始まりの要素を読む。開始タグが途中で切れたら null（= 先端）。
   const parseElement = (): JsxNode | null => {
     // 先頭の `<` を消費する。
@@ -245,6 +336,113 @@ export const parsePartialJsx = (source: string): readonly JsxNode[] => {
     }
   };
 
+  // `{配列.map((item, i) => ( <JSX> ))}` を検出して配列要素ぶん複製する。
+  // map でなければ pos を戻して null（呼び出し側が通常の式として処理する）。
+  const parseMap = (): JsxNode[] | null => {
+    const save = pos;
+    // 先頭の `{` を消費する。
+    pos += 1;
+    skipWs();
+    // 配列パス（`items` / `g.items` 等）と末尾の `.map` を読む。
+    let path = readIdent();
+    while (path !== '' && at(pos) === '.' && isIdentStart(at(pos + 1))) {
+      pos += 1;
+      path += `.${readIdent()}`;
+    }
+    const segments = path.split('.');
+    if (segments.length < 2 || segments.at(-1) !== 'map') {
+      pos = save;
+      return null;
+    }
+    const arrPath = segments.slice(0, -1).join('.');
+    skipWs();
+    if (at(pos) !== '(') {
+      pos = save;
+      return null;
+    }
+    pos += 1;
+    skipWs();
+    // コールバックの引数（(item) / (item, i) / item）。
+    const params: string[] = [];
+    if (at(pos) === '(') {
+      pos += 1;
+      for (;;) {
+        skipWs();
+        const param = readIdent();
+        if (param !== '') {
+          params.push(param);
+        }
+        skipWs();
+        if (at(pos) === ',') {
+          pos += 1;
+          continue;
+        }
+        if (at(pos) === ')') {
+          pos += 1;
+          break;
+        }
+        // 分割代入など想定外 → 通常式に委ねる。
+        pos = save;
+        return null;
+      }
+    } else {
+      const param = readIdent();
+      if (param === '') {
+        pos = save;
+        return null;
+      }
+      params.push(param);
+    }
+    skipWs();
+    if (at(pos) !== '=' || at(pos + 1) !== '>') {
+      pos = save;
+      return null;
+    }
+    pos += 2;
+    skipWs();
+    if (at(pos) === '(') {
+      pos += 1;
+      skipWs();
+    }
+    if (at(pos) !== '<') {
+      // テンプレートが要素で始まらない（ブロック本体・三項等）→ 通常式に委ねる。
+      pos = save;
+      return null;
+    }
+    // テンプレート（単一の根要素）の文字列を切り出す。未完なら truncated が立つ。
+    const tplStart = pos;
+    const tplEl = parseElement();
+    const templateStr = source.slice(tplStart, pos);
+    consumeMapTail();
+
+    const resolved = resolvePath(arrPath, scope);
+    if (!resolved.found || !Array.isArray(resolved.value)) {
+      // 配列を解決できない（外部データ・props 等）→ 描かない。消費だけ済ませる。
+      return [];
+    }
+    if (tplEl === null) {
+      // テンプレートが根要素を形成する前に切れた → 複製せず単一 pending（先端）。
+      truncated = true;
+      return [{ type: 'pending' }];
+    }
+    const items = resolved.value.slice(0, MAX_MAP_ITEMS);
+    const nodes: JsxNode[] = [];
+    for (const [index, item] of items.entries()) {
+      const itemScope: Record<string, unknown> = { ...scope };
+      if (params[0] !== undefined) {
+        itemScope[params[0]] = item;
+      }
+      if (params[1] !== undefined) {
+        itemScope[params[1]] = index;
+      }
+      // spread を避けて逐次 push（巨大配列でのスタック超過防止）。
+      for (const node of parsePartialJsx(templateStr, itemScope)) {
+        nodes.push(node);
+      }
+    }
+    return nodes;
+  };
+
   // 子要素の式 `{...}`。truncated を表す 'pending'、描かない場合は null。
   const parseExpressionChild = (): JsxNode | 'pending' | null => {
     const inner = readBracedInner();
@@ -299,6 +497,18 @@ export const parsePartialJsx = (source: string): readonly JsxNode[] => {
         continue;
       }
       if (c === '{') {
+        // まず map 展開を試し、map でなければ通常の式として処理する。
+        const mapNodes = parseMap();
+        if (mapNodes !== null) {
+          // spread を避けて逐次 push（巨大配列でのスタック超過防止）。
+          for (const node of mapNodes) {
+            children.push(node);
+          }
+          if (truncated) {
+            return children;
+          }
+          continue;
+        }
         const node = parseExpressionChild();
         if (node === 'pending') {
           children.push({ type: 'pending' });
@@ -321,6 +531,6 @@ export const parsePartialJsx = (source: string): readonly JsxNode[] => {
   return parseChildren();
 };
 
-// TSX 全文を受け取り、JSX 本体を抽出してパースする薄いラッパ。
+// TSX 全文を受け取り、データスコープを作って JSX 本体をパースする薄いラッパ。
 export const parseStreamingTsx = (tsx: string): readonly JsxNode[] =>
-  parsePartialJsx(extractJsxBody(tsx));
+  parsePartialJsx(extractJsxBody(tsx), buildScope(tsx));

--- a/apps/ai/src/features/preview/application/incremental-jsx/types.ts
+++ b/apps/ai/src/features/preview/application/incremental-jsx/types.ts
@@ -1,0 +1,33 @@
+// 自前のインクリメンタル JSX パーサが生成する軽量 AST。
+// ストリーミング途中の未完入力を寛容に扱い、未受信の先端は pending ノードで表す。
+// 対応するのは「宣言的サブセット」のみ: ホスト要素 / コンポーネント / フラグメント、
+// 文字列・リテラル・真偽値短縮・ネスト JSX の属性、テキストとネスト。
+// 関数・三項・.map・スプレッドなどは unsupported として保持し、描画側でスキップする。
+
+// 属性値の種類。描画側でこのタグに応じて実際の prop 値へ解決する。
+export type JsxAttr =
+  | { readonly kind: 'string'; readonly value: string }
+  | {
+      readonly kind: 'literal';
+      readonly value: string | number | boolean | null;
+    }
+  | { readonly kind: 'element'; readonly value: JsxElement }
+  | { readonly kind: 'boolean' }
+  | { readonly kind: 'unsupported'; readonly raw: string };
+
+export type JsxProp = { readonly name: string; readonly value: JsxAttr };
+
+// name === '' はフラグメント（<>...</>）。
+export type JsxElement = {
+  readonly type: 'element';
+  readonly name: string;
+  readonly props: readonly JsxProp[];
+  readonly children: readonly JsxNode[];
+};
+
+export type JsxText = { readonly type: 'text'; readonly value: string };
+
+// 未受信の先端。描画側でスケルトンに置き換える。
+export type JsxPending = { readonly type: 'pending' };
+
+export type JsxNode = JsxElement | JsxText | JsxPending;


### PR DESCRIPTION
## 概要

AI 生成中に、Sandbox / Vite の起動や HMR を待たず、途中の TSX をホスト側で逐次描画する「先行プレビュー」を追加。生成完了で従来の Sandbox iframe（実コンパイル版）へ滑らかに切り替わる 2 段プレビューにした。

## 動機

従来はプレビューが `onFinish`（生成の完全終了）まで一切更新されず、「全部生成し終わるまで待つ」体感が長かった。途中コード（`streamingCode`）はすでにクライアントにあるのに表示に使っていなかったので、最初に構造が見えるまで（first paint）を前倒しする。

## 詳細

- **自前のインクリメンタル JSX パーサ**（`features/preview/application/incremental-jsx/`）
  - コンパイルを介さず、寛容に未完 TSX を軽量 AST 化。未受信の先端に pending を 1 つだけ差す。
  - 対応サブセット: ホスト要素 / arte-odyssey コンポーネント / フラグメント、文字列・リテラル・真偽値短縮・ネスト JSX 属性、テキスト。サブセット外（hooks・関数・`.map`・スプレッド）は描かずスキップ。
- **先行プレビュー island**（`app/(authenticated)/_components/stream-preview/`）
  - パース結果を arte-odyssey の registry で React 描画。未登録 / 描画失敗は `UnknownChip` で可視化、pending はスケルトン。
  - コンポーネント単位のエラー境界で、1 個失敗しても全体は描き続ける。
- **studio 結線**（`studio.tsx`）
  - 生成中の既定ビューを preview に変更。生成中〜反映確定まで island を iframe の上にオーバーレイし、確定で外す。

## 気をつけるポイント

- island は iframe を**置換せず上に重ねる**のが要。置換すると iframe がマウントされず `onLoad` / HMR 通知が来ず `previewLoading` が解除されないため、下で iframe を読み込み続けたまま重ねている。
- registry は現状 arte-odyssey の代表サブセット（15 コンポーネント + 16 アイコン）。未登録は `UnknownChip` 表示。網羅を広げる余地あり。
- 先行プレビューは宣言的サブセットのみ描画。インタラクション（state / handler）は最終の Sandbox 版で動く。

## 影響範囲

- apps/ai の Studio プレビュー枠のみ。生成 / Sandbox / 共有のサーバー側ロジックは無改修。

## テスト

- パーサ単体: 12 tests pass
- StreamPreview Storybook: 5 stories pass（a11y=error 含む）
- type-check / lint / format / ls-lint: pass
- live（実 LLM 生成）は本 PR の Vercel preview で確認予定
