### PR TITLE
fix(ai): 先行プレビューの文字列漏れ修正と履歴切り替えの即時フィードバック

### DIFF
--- a/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.stories.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/stream-preview/stream-preview.stories.tsx
@@ -70,6 +70,24 @@ export default function Preview() {
   );
 }`;
 
+// 文字列連結式（`'…' + x + '…'`）を含むサンプル。連結式は単一リテラルではないため
+// 値として描かず、生のコード片が画面に漏れないことを確認する。
+const SAMPLE_CONCAT = `import { Card, Heading } from '@k8o/arte-odyssey';
+
+export default function Preview() {
+  const name = 'k8o';
+  return (
+    <div className="bg-bg-surface p-8">
+      <Card appearance="shadow">
+        <div className="flex flex-col gap-4 p-8">
+          <Heading type="h2">ようこそ</Heading>
+          <p className="text-fg-mute text-sm leading-relaxed">{'こんにちは、' + name + ' さん'}</p>
+        </div>
+      </Card>
+    </div>
+  );
+}`;
+
 const meta = {
   component: StreamPreview,
 } satisfies Meta<typeof StreamPreview>;
@@ -133,6 +151,20 @@ export const MapGridStreaming: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getAllByRole('status').length).toBeGreaterThan(0);
+  },
+};
+
+// 文字列連結式は値として描かず、生のコード片（`' + name + '`）が画面に漏れない。
+// 連結式を含む <p> は空になるが、周囲の本文（見出し）は通常どおり描ける。
+export const ConcatExpression: Story = {
+  args: { code: SAMPLE_CONCAT },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('ようこそ')).toBeInTheDocument();
+    // 生のコード片がそのままテキストとして出ていないこと（漏れの回帰防止）。
+    await expect(canvasElement.textContent).not.toContain('+ name');
+    await expect(canvasElement.textContent).not.toContain("' +");
+    await expect(canvasElement.textContent).not.toContain('こんにちは、');
   },
 };
 

--- a/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/studio.tsx
@@ -73,6 +73,11 @@ export const Studio = () => {
   );
   const [applyError, setApplyError] = useState<string | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
+  // 履歴/フォーク選択の読込中。Sandbox 書込待ちで反映まで時間がかかるため、押した直後に
+  // 「読み込み中」を見せて無反応に見えるのを防ぐ。タイトルは既知のリスト項目から先行表示する。
+  const [pendingSelect, setPendingSelect] = useState<{ title: string } | null>(
+    null,
+  );
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const frameRef = useRef<HTMLDivElement>(null);
   // 直近の指示。onFinish（一度きりのクロージャ）から版に保存して会話復元に使う。
@@ -286,6 +291,7 @@ export const Studio = () => {
     setMessages([]);
     setApplyError(null);
     setHistoryOpen(false);
+    setPendingSelect(null);
     setView('preview');
     setMobileTab('chat');
     router.replace('/');
@@ -295,52 +301,63 @@ export const Studio = () => {
     // 生成中なら中断してから切り替える（生成中表示が切替先に漏れるのを防ぐ）。
     void stop();
     setHistoryOpen(false);
-    // 読込（DB）と反映（Sandbox）を1サーバー往復にまとめ、往復・認証を半減する。
-    const result = await loadProjectAndApplyAction(id);
-    if (result === null) {
-      return;
-    }
-    const { project, applied } = result;
-    persistence.markLoaded(project);
-    dispatch({
-      type: 'load-project',
-      code: project.code,
-      meta: project.meta,
-    });
-    // 履歴を切り替えてもトークが消えないよう会話を復元する。各版を [user(指示) → assistant(meta JSON)] に展開し、
-    // assistant は json フェンスにすることで既存の描画ロジック（parseGeneration の description 抽出）で説明文が出る。
-    const restored: UIMessage[] = project.conversation.flatMap(
-      (turn, index): UIMessage[] => {
-        const turnMessages: UIMessage[] = [];
-        if (turn.prompt !== null && turn.prompt !== '') {
+    // クリック直後に読込中を見せる（反映＝Sandbox 書込待ちで遅いため、何も変化せず無反応に
+    // 見えるのを防ぐ）。タイトルは既知のリスト項目から先行表示し、プレビューへ即切り替える。
+    const known = persistence.projects.find((project) => project.id === id);
+    setPendingSelect({ title: known?.title ?? '読み込み中…' });
+    setView('preview');
+    setMobileTab('preview');
+    try {
+      // 読込（DB）と反映（Sandbox）を1サーバー往復にまとめ、往復・認証を半減する。
+      const result = await loadProjectAndApplyAction(id);
+      if (result === null) {
+        return;
+      }
+      const { project, applied } = result;
+      persistence.markLoaded(project);
+      dispatch({
+        type: 'load-project',
+        code: project.code,
+        meta: project.meta,
+      });
+      // 履歴を切り替えてもトークが消えないよう会話を復元する。各版を [user(指示) → assistant(meta JSON)] に展開し、
+      // assistant は json フェンスにすることで既存の描画ロジック（parseGeneration の description 抽出）で説明文が出る。
+      const restored: UIMessage[] = project.conversation.flatMap(
+        (turn, index): UIMessage[] => {
+          const turnMessages: UIMessage[] = [];
+          if (turn.prompt !== null && turn.prompt !== '') {
+            turnMessages.push({
+              id: `h-u-${index.toString()}`,
+              role: 'user',
+              parts: [{ type: 'text', text: turn.prompt }],
+            });
+          }
           turnMessages.push({
-            id: `h-u-${index.toString()}`,
-            role: 'user',
-            parts: [{ type: 'text', text: turn.prompt }],
+            id: `h-a-${index.toString()}`,
+            role: 'assistant',
+            parts: [
+              {
+                type: 'text',
+                text: `\`\`\`json\n${JSON.stringify(turn.meta)}\n\`\`\``,
+              },
+            ],
           });
-        }
-        turnMessages.push({
-          id: `h-a-${index.toString()}`,
-          role: 'assistant',
-          parts: [
-            {
-              type: 'text',
-              text: `\`\`\`json\n${JSON.stringify(turn.meta)}\n\`\`\``,
-            },
-          ],
-        });
-        return turnMessages;
-      },
-    );
-    setMessages(restored);
-    setApplyError(null);
-    if (applied.ok) {
-      // 反映済み。HMR の差分反映を待ち、来なければリロードへフォールバックする。
-      reflectPreview();
-      setView('preview');
-      setMobileTab('preview');
+          return turnMessages;
+        },
+      );
+      setMessages(restored);
+      setApplyError(null);
+      if (applied.ok) {
+        // 反映済み。HMR の差分反映を待ち、来なければリロードへフォールバックする。
+        reflectPreview();
+        setView('preview');
+        setMobileTab('preview');
+      }
+      // 反映失敗（保存済みコードでは稀）時はプレビューを前版のまま据え置く。
+    } finally {
+      // 読込が終わったら（成功/失敗/非所有いずれも）読込中表示を必ず外す。
+      setPendingSelect(null);
     }
-    // 反映失敗（保存済みコードでは稀）時はプレビューを前版のまま据え置く。
   };
 
   const handleFork = async (): Promise<void> => {
@@ -399,13 +416,20 @@ export const Studio = () => {
             k8o AI Studio
           </span>
           <span className="text-fg-mute shrink-0 text-sm">/</span>
-          {persistence.projectId === null ? (
-            <span className="text-fg-mute truncate text-sm">
-              新しいプロジェクト
-            </span>
+          {pendingSelect === null ? (
+            persistence.projectId === null ? (
+              <span className="text-fg-mute truncate text-sm">
+                新しいプロジェクト
+              </span>
+            ) : (
+              <span className="text-fg-base truncate text-sm font-medium">
+                {persistence.projectTitle ?? '無題'}
+              </span>
+            )
           ) : (
+            // 読込中は選んだプロジェクト名を先行表示し、クリックが効いたことを示す。
             <span className="text-fg-base truncate text-sm font-medium">
-              {persistence.projectTitle ?? '無題'}
+              {pendingSelect.title}
             </span>
           )}
         </div>
@@ -698,6 +722,13 @@ export const Studio = () => {
                   <StreamPreview code={streamingCode} />
                 </div>
               ) : null}
+              {/* 履歴/フォーク選択の読込中オーバーレイ。空状態でも確実に出すため最前面(z-30)に重ね、
+                  反映が始まると下の PreviewLoading(z-10) → iframe へと途切れず引き継ぐ。 */}
+              {pendingSelect === null ? null : (
+                <div className="absolute inset-0 z-30">
+                  <PreviewLoading message="プロジェクトを読み込んでいます…" />
+                </div>
+              )}
             </div>
             <div className={view === 'code' ? 'h-full' : 'hidden'}>
               <CodePanel code={displayedCode} isStreaming={isBusy} />

--- a/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.test.ts
+++ b/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.test.ts
@@ -175,6 +175,27 @@ describe('parsePartialJsx', () => {
       expect(fragment.name).toBe('');
       expect(firstElement(fragment.children).name).toBe('span');
     });
+
+    it('連結式は単一リテラルでないので中身をテキストに漏らさない', () => {
+      // Arrange: 先頭と末尾がクォートでも `'a' + 'b'` は文字列リテラルではない。
+      const source = "<p>{'前半 ' + x + ' 後半'}</p>";
+
+      // Act
+      const p = firstElement(parsePartialJsx(source));
+
+      // Assert: コード片（"前半 ' + x + ' 後半"）がそのまま描かれない。
+      expect(p.children).toEqual([]);
+    });
+
+    it('単一の文字列/数値リテラルはそのまま値として扱う', () => {
+      // Arrange
+      const str = firstElement(parsePartialJsx("<p>{'こんにちは'}</p>"));
+      const num = firstElement(parsePartialJsx('<p>{42}</p>'));
+
+      // Assert
+      expect(str.children).toEqual([{ type: 'text', value: 'こんにちは' }]);
+      expect(num.children).toEqual([{ type: 'text', value: '42' }]);
+    });
   });
 });
 

--- a/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.ts
+++ b/apps/ai/src/features/preview/application/incremental-jsx/parse-partial-jsx.ts
@@ -1,4 +1,4 @@
-import { buildScope } from './js-literal';
+import { buildScope, parseJsLiteral } from './js-literal';
 import type { JsxAttr, JsxNode, JsxProp } from './types';
 
 // ストリーミング途中の TSX 文字列を寛容にパースし、受信済みの部分だけを軽量 AST にする。
@@ -136,22 +136,24 @@ export const parsePartialJsx = (
     if (inner === '') {
       return { kind: 'unsupported', raw: innerRaw };
     }
-    const head = inner[0] ?? '';
-    const tail = inner.at(-1) ?? '';
-    if ((head === '"' || head === "'") && tail === head && inner.length >= 2) {
-      return { kind: 'string', value: inner.slice(1, -1) };
-    }
-    if (head === '`' && tail === '`' && !inner.includes('${')) {
-      return { kind: 'string', value: inner.slice(1, -1) };
-    }
-    if (/^-?\d+(?:\.\d+)?$/u.test(inner)) {
-      return { kind: 'literal', value: Number(inner) };
-    }
-    if (inner === 'true' || inner === 'false') {
-      return { kind: 'literal', value: inner === 'true' };
-    }
-    if (inner === 'null' || inner === 'undefined') {
-      return { kind: 'literal', value: null };
+    // 「単一の完全なリテラル」だけを値として採用する。先頭と末尾がクォートでも、
+    // `'前半' + x + '後半'` のような連結式は literal ではない。リテラルが inner 全体を
+    // 消費したときのみ採用し、そうでなければ式として後段（スコープ解決/JSX）に委ねる。
+    // これで連結式の中身がそのままテキストとして漏れるのを防ぐ。
+    const literal = parseJsLiteral(inner, 0);
+    if (literal !== null && literal.end === inner.length) {
+      const { value } = literal;
+      if (typeof value === 'string') {
+        return { kind: 'string', value };
+      }
+      if (typeof value === 'number' || typeof value === 'boolean') {
+        return { kind: 'literal', value };
+      }
+      if (value === null) {
+        return { kind: 'literal', value: null };
+      }
+      // 配列/オブジェクトリテラルは子・属性値として素直に描けないため非対応に倒す。
+      return { kind: 'unsupported', raw: innerRaw };
     }
     // スコープ解決（`{item.name}` 等）。map 展開時にループ変数が入っている。
     if (IDENT_PATH.test(inner)) {
@@ -170,7 +172,7 @@ export const parsePartialJsx = (
         return { kind: 'unsupported', raw: innerRaw };
       }
     }
-    if (head === '<') {
+    if (inner[0] === '<') {
       // ネスト JSX（startIcon={<SparklesIcon />} 等）。スコープを引き継ぐ。
       const nested = parsePartialJsx(inner, scope);
       for (const node of nested) {


### PR DESCRIPTION
## 概要

apps/ai の AI Studio で報告された 2 つの不具合を修正する。

1. 履歴の切り替えで、押してから遷移するまで無反応に見える
2. 組み立て中のコンポーネントに文字列がそのまま出てしまうことがある

## 詳細

### 1. 先行プレビューの文字列連結漏れ（`fix(ai): 先行プレビューで文字列連結式…`）

`classifyExpression` が「先頭と末尾がクォート」というだけで文字列リテラルと誤判定し、外側クォートを剥がして返していた。そのため `{'前半 ' + x + ' 後半'}` のような連結式が `前半 ' + x + ' 後半` という生コードのままテキスト描画されていた（バッククォート連結も同様）。

単一の完全なリテラルが式全体を消費したときだけ値として採用するよう、`parseJsLiteral` で `end === inner.length` を検証する方式へ置き換え。連結式・配列・オブジェクトは非対応に倒し、単一の文字列/数値（`1_000`・`0xff` 等含む）/真偽/`null` は従来どおり描画する。

### 2. 履歴/フォーク選択の即時フィードバック（`fix(ai): 履歴/フォーク選択時に…`）

`loadProjectAndApplyAction` は DB 読込と Sandbox 反映を 1 往復にまとめており、遅い反映が終わるまでクライアントへ何も返らない。そのため履歴を押してもチャット/コード/タイトル/プレビューが旧プロジェクトのまま据え置かれ、無反応に見えていた。

クリック直後に `pendingSelect` を立て、選んだプロジェクト名をヘッダーへ先行表示し、プレビュー面に読み込み中オーバーレイ（z-30）を重ね、プレビュー表示へ即切り替える。読込完了は `try/finally` で必ず解除し、成功時は既存の反映ローディング → iframe へ途切れず引き継ぐ。

## 気をつけるポイント

- パーサ修正は `classifyExpression` のリテラル判定ロジックを丸ごと差し替えている。`{item.name}` のスコープ解決と `startIcon={<Icon />}` のネスト JSX 経路は据え置き（既存テストで担保）。
- Studio 側は `handleSelectProject` の本体を `try/finally` で包んだため diff が大きく見えるが、読込ロジック自体は不変で、追加したのは即時フィードバック（タイトル先行表示＋オーバーレイ）と確実な解除のみ。

## 影響範囲

- 生成中の先行プレビュー（`StreamPreview` / incremental-jsx パーサ）
- AI Studio の履歴・フォークからのプロジェクト切り替え（`studio.tsx`）

## テスト

- `pnpm -F ai run type-check` / `pnpm run check`（lint・format）: パス
- features 75 件・storybook 18 件パス（`ConcatExpression` Story を追加）
- 問題2: 実ブラウザの Story で red→green を確認（修正前は描画 DOM に `+ name` が混入、修正後は消失）
- 問題1: ローカル dev（`localhost:3101`）+ Playwright で、履歴クリック直後にヘッダーへ選択名・プレビューに「プロジェクトを読み込んでいます…」が即表示されることを実機確認。読込失敗時もオーバーレイが残らないことも確認