### PR TITLE
chore: pnpm-workspace の不要な依存設定を整理

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,8 @@ allowBuilds:
   '@swc/core': false
   esbuild: false
   msgpackr-extract: false
-  msw: true
+  msw: false
   sharp: false
-  # wranglerの依存。pages deployはAPIアップロードのみでworkerd実行は不要
   workerd: false
 
 blockExoticSubdeps: true
@@ -51,12 +50,6 @@ minimumReleaseAge: 10080
 
 minimumReleaseAgeExclude:
   - '@k8o/*'
-  # Renovate security update: turbo@2.9.14
-  - turbo@2.9.14
-  - storybook-addon-vrt
-  - storybook-addon-mock-date
-  - storybook-addon-determinism
-  - vite-plus-inspector
 
 verifyDepsBeforeRun: install
 


### PR DESCRIPTION
`pnpm-workspace.yaml` の一時的・不要になった設定を整理する。

- 取り込みが済んだ `minimumReleaseAgeExclude` のエントリ（`turbo@2.9.14` / `storybook-addon-vrt` / `storybook-addon-mock-date` / `storybook-addon-determinism` / `vite-plus-inspector`）を削除
- `msw` の `allowBuilds` を `false` に変更し、不要になった `workerd` のコメントを削除