### PR TITLE
chore: pnpm knip の指摘を解消する

### DIFF
--- a/.github/workflows/ai-bake.yml
+++ b/.github/workflows/ai-bake.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Check snapshot drift
         id: drift
         run: |
-          if pnpm -F ai exec vitest run --project="features test" src/features/preview/infrastructure/template-snapshot.test.ts; then
+          if pnpm -F @repo/ai exec vitest run --project="features test" src/features/preview/infrastructure/template-snapshot.test.ts; then
             echo "stale=false" >> "$GITHUB_OUTPUT"
           else
             echo "stale=true" >> "$GITHUB_OUTPUT"

--- a/apps/ai/package.json
+++ b/apps/ai/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ai",
+  "name": "@repo/ai",
   "version": "1.0.0",
   "private": true,
   "description": "k8o AI tools site",

--- a/apps/ai/src/features/preview/application/incremental-jsx/types.ts
+++ b/apps/ai/src/features/preview/application/incremental-jsx/types.ts
@@ -25,9 +25,9 @@ export type JsxElement = {
   readonly children: readonly JsxNode[];
 };
 
-export type JsxText = { readonly type: 'text'; readonly value: string };
+type JsxText = { readonly type: 'text'; readonly value: string };
 
 // 未受信の先端。描画側でスケルトンに置き換える。
-export type JsxPending = { readonly type: 'pending' };
+type JsxPending = { readonly type: 'pending' };
 
 export type JsxNode = JsxElement | JsxText | JsxPending;

--- a/apps/ai/src/features/projects/application/projects.ts
+++ b/apps/ai/src/features/projects/application/projects.ts
@@ -24,7 +24,7 @@ export type UiStudioContent = {
   prompt?: string;
 };
 
-export type ConversationTurn = {
+type ConversationTurn = {
   prompt: string | null;
   meta: GenerationMeta;
 };

--- a/apps/ai/src/features/projects/interface/actions.ts
+++ b/apps/ai/src/features/projects/interface/actions.ts
@@ -45,16 +45,6 @@ export const listProjectsAction = async (): Promise<ProjectListItem[]> => {
   return getProjectsForUser(session.userId);
 };
 
-export const loadProjectAction = async (
-  projectId: number,
-): Promise<LoadedProject | null> => {
-  const session = await requireAllowedSession(await headers());
-  if (session === null) {
-    return null;
-  }
-  return getProject({ userId: session.userId, projectId });
-};
-
 // プロジェクト読込（DB）とプレビュー反映（Sandbox）を1往復・1回の認証にまとめる。
 // 切り替えで load→apply を別々に呼ぶと、ブラウザ↔サーバー往復とセッション照会が2回ずつ
 // 走って遅いため、ここで一括する。非所有/不存在は null。

--- a/apps/ai/vercel.json
+++ b/apps/ai/vercel.json
@@ -1,3 +1,3 @@
 {
-  "ignoreCommand": "bash ../../scripts/ignore-build.sh ai"
+  "ignoreCommand": "bash ../../scripts/ignore-build.sh ai @repo/ai"
 }

--- a/apps/main/src/app/html-nest/_utils/content-model.ts
+++ b/apps/main/src/app/html-nest/_utils/content-model.ts
@@ -115,7 +115,7 @@ export const canContain = (
 };
 
 // 選択要素から見た候補要素の関係種別。
-export type RelationKind = 'self' | 'both' | 'parent' | 'child' | 'none';
+type RelationKind = 'self' | 'both' | 'parent' | 'child' | 'none';
 
 export type Relation = {
   kind: RelationKind;

--- a/knip.json
+++ b/knip.json
@@ -2,7 +2,8 @@
   "$schema": "https://unpkg.com/knip/schema.json",
   "ignore": [
     "apps/main/public/sw.js",
-    "apps/main/public/playgrounds/shared-worker.worker.js"
+    "apps/main/public/playgrounds/shared-worker.worker.js",
+    "apps/ai/sandbox-template/**"
   ],
   "treatConfigHintsAsErrors": true,
   "tags": ["-lintignore"],

--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 # Vercel Ignored Build Step
-# 使い方: bash scripts/ignore-build.sh <app-name>
+# 使い方: bash scripts/ignore-build.sh <app-name> [pkg-name]
+#   app-name: ディレクトリ名（apps/<app-name>）
+#   pkg-name: turbo affected で判定するパッケージ名（省略時は app-name）
+#             ディレクトリ名とパッケージ名が異なる場合に指定する（例: ai → @repo/ai）
 # exit 0 = ビルドスキップ, exit 1 = ビルド実行
 
 set -euo pipefail
 
 readonly APP_NAME="${1:-}"
+readonly PKG_NAME="${2:-${1:-}}"
 
 log() {
   echo ">> $*" >&2
@@ -83,7 +87,7 @@ if ! AFFECTED=$(pnpm turbo query affected --packages --base "$BASE_SHA"); then
 fi
 echo "$AFFECTED"
 
-if echo "$AFFECTED" | grep -q "\"name\": \"$APP_NAME\""; then
+if echo "$AFFECTED" | grep -q "\"name\": \"$PKG_NAME\""; then
   log "Proceeding: $APP_NAME is affected"
   exit 1
 fi


### PR DESCRIPTION
## 概要

`pnpm knip` が exit 1 で報告していた指摘（Unused files / dependency / exports / exported types）をすべて解消する。誤検知は設定・名前衝突の根本修正で、実体のあるものはコード整理で対応した。

## 動機

`apps/ai` のパッケージ名が `ai` で、npm の `ai` SDK と同名のため衝突していた。knip が `import ... from 'ai'` を自ワークスペースと誤解決し、外部依存 `ai` を未使用と誤検知していた。これはモノレポ内での `ai` 解決を曖昧にする潜在バグでもある。あわせて誤検知・デッドコードを整理する。

## 詳細

- **`apps/ai` を `@repo/ai` にリネーム**し、npm `ai` との名前衝突を根本解消
  - 波及箇所を追従: `ai-bake.yml` の `pnpm -F ai`、`apps/ai/vercel.json` の ignoreCommand
  - `scripts/ignore-build.sh` にパッケージ名用の第2引数を追加（ディレクトリ名と turbo パッケージ名を分離。`main`/`admin` は引数1つのままで後方互換）
- **knip 設定で `apps/ai/sandbox-template/**` を ignore**（Vite 独立テンプレで raw 読み込み用途、tsconfig でも exclude 済み）
- **デッドコード/未使用 export の整理**
  - `loadProjectAction` を削除（`loadProjectAndApplyAction` に統合済みで参照なし）
  - ファイル内のみで使う型の `export` を除去: `JsxText` / `JsxPending` / `ConversationTurn` / `RelationKind`（型自体は維持）

## 気をつけるポイント

- `ignore-build.sh` は Vercel のビルドスキップ判定に関わる共有スクリプト。第2引数は省略時に第1引数へフォールバックするため `main`/`admin` の挙動は不変。`@repo/ai` は `turbo query affected` の `"name"` 判定にのみ使われる
- Vercel プロジェクト側の設定はパッケージ名ではなくルートディレクトリ（`apps/ai`）参照のため影響なしと判断

## 影響範囲

- `apps/ai` のパッケージ識別子（turbo フィルタ / CI）
- Vercel のビルドスキップ判定（main/admin は不変）

## テスト

- `pnpm knip` → exit 0
- `pnpm run type-check` → 8 packages 成功
- `pnpm run check`（lint/format）→ 0 errors
- `pnpm -F @repo/ai exec vitest run`（preview/projects）→ 37 passed