### PR TITLE
feat(blog): field-sizing の記事・Playground と読了時間表示を追加

### DIFF
--- a/apps/main/src/app/_components/content-card/content-card.tsx
+++ b/apps/main/src/app/_components/content-card/content-card.tsx
@@ -20,6 +20,7 @@ type ContentCardProps = {
   description: string | null;
   createdAt: string;
   updatedAt: string;
+  readingTime?: number;
 };
 
 // blog / slides の一覧カード共通の表示。差分は href プレフィックスと Heading の見出しレベル。
@@ -32,6 +33,7 @@ export const ContentCard: FC<ContentCardProps> = ({
   description,
   createdAt,
   updatedAt,
+  readingTime,
 }) => (
   <Card interactive>
     <Link
@@ -56,18 +58,23 @@ export const ContentCard: FC<ContentCardProps> = ({
               ))}
             </div>
           )}
-          <div className="text-fg-mute ml-auto flex items-center gap-4 text-xs">
-            <div className="flex items-center gap-1">
-              <PublishDateIcon size="sm" />
-              <span>
-                公開: {formatDate(new Date(createdAt), 'yyyy年M月d日')}
-              </span>
-            </div>
-            <div className="flex items-center gap-1">
-              <UpdateDateIcon size="sm" />
-              <span>
-                更新: {formatDate(new Date(updatedAt), 'yyyy年M月d日')}
-              </span>
+          <div className="text-fg-mute ml-auto flex flex-col items-end gap-1 text-xs">
+            {readingTime !== undefined && (
+              <span>約{readingTime}分で読めます</span>
+            )}
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-1">
+                <PublishDateIcon size="sm" />
+                <span>
+                  公開: {formatDate(new Date(createdAt), 'yyyy年M月d日')}
+                </span>
+              </div>
+              <div className="flex items-center gap-1">
+                <UpdateDateIcon size="sm" />
+                <span>
+                  更新: {formatDate(new Date(updatedAt), 'yyyy年M月d日')}
+                </span>
+              </div>
             </div>
           </div>
         </div>

--- a/apps/main/src/app/_components/playgrounds/field-sizing/field-sizing-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/field-sizing/field-sizing-demo.stories.tsx
@@ -1,0 +1,24 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Playground } from '../playground';
+import { FieldSizingDemo } from './field-sizing-demo';
+
+const playgroundTitle = FieldSizingDemo.name;
+
+const meta: Meta<typeof FieldSizingDemo> = {
+  title: 'playgrounds/field-sizing/FieldSizingDemo',
+  component: FieldSizingDemo,
+  decorators: [
+    (Story) => (
+      <Playground title={playgroundTitle}>
+        <Story />
+      </Playground>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof FieldSizingDemo>;
+
+export const Default: Story = {};

--- a/apps/main/src/app/_components/playgrounds/field-sizing/field-sizing-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/field-sizing/field-sizing-demo.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import {
+  Badge,
+  ChevronIcon,
+  FormControl,
+  Select,
+  Separator,
+} from '@k8o/arte-odyssey';
+import { useState } from 'react';
+
+const fruitOptions = ['りんご', 'ぶどう', 'パイナップル', 'ドラゴンフルーツ'];
+
+const fieldSizingOptions = [
+  { value: 'content', label: 'content' },
+  { value: 'fixed', label: 'fixed（既定値）' },
+];
+
+type FieldSizing = 'content' | 'fixed';
+
+export function FieldSizingDemo() {
+  const [value, setValue] = useState<FieldSizing>('content');
+  const [text, setText] = useState('短いテキスト');
+  const [email, setEmail] = useState('');
+  const [comment, setComment] = useState(
+    'ここに入力すると、内容に合わせて高さが伸び縮みします。',
+  );
+  const [fruit, setFruit] = useState(fruitOptions[1]);
+
+  const fieldStyle = { fieldSizing: value } as const;
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div className="flex flex-wrap items-end gap-x-6 gap-y-3">
+        <div className="w-44">
+          <FormControl
+            label="field-sizing を選ぶ"
+            renderInput={({ 'aria-labelledby': _, ...props }) => (
+              <Select
+                {...props}
+                onChange={(e) => {
+                  setValue(e.target.value as FieldSizing);
+                }}
+                options={fieldSizingOptions}
+                value={value}
+              />
+            )}
+          />
+        </div>
+        <p className="text-fg-mute pb-2.5 text-sm">
+          値を切り替えると、下のコントロールに反映されます。
+        </p>
+      </div>
+
+      <Separator />
+
+      <div className="flex flex-col gap-6">
+        <div className="flex flex-wrap items-center gap-3">
+          <span className="text-fg-base font-medium">プレビュー</span>
+          <Badge
+            text={`field-sizing: ${value}`}
+            tone="info"
+            variant="outline"
+          />
+        </div>
+
+        <p className="text-fg-mute text-sm">
+          各コントロールには min-width
+          を設定しているため、縮んでもその幅で止まります。テキストエリアには
+          rows も指定していますが、content
+          では無視され、高さは内容に追従し、max-height
+          に達するとスクロールします。
+        </p>
+
+        <label className="flex flex-col items-start gap-1.5">
+          <span className="text-fg-mute text-sm">テキスト入力</span>
+          <input
+            aria-label="テキスト入力"
+            className="border-border-base bg-bg-base text-fg-base max-w-full min-w-32 rounded-lg border px-3.5 py-2"
+            onChange={(e) => {
+              setText(e.target.value);
+            }}
+            style={fieldStyle}
+            type="text"
+            value={text}
+          />
+        </label>
+
+        <label className="flex flex-col items-start gap-1.5">
+          <span className="text-fg-mute text-sm">
+            プレースホルダー付き入力（空のときはプレースホルダー幅）
+          </span>
+          <input
+            aria-label="プレースホルダー付き入力"
+            className="border-border-base bg-bg-base text-fg-base max-w-full min-w-32 rounded-lg border px-3.5 py-2"
+            onChange={(e) => {
+              setEmail(e.target.value);
+            }}
+            placeholder="例: example@k8o.me"
+            style={fieldStyle}
+            type="text"
+            value={email}
+          />
+        </label>
+
+        <label className="flex flex-col items-start gap-1.5">
+          <span className="text-fg-mute text-sm">テキストエリア</span>
+          <textarea
+            aria-label="テキストエリア"
+            className="border-border-base bg-bg-base text-fg-base max-h-40 max-w-full min-w-48 rounded-lg border px-3.5 py-2"
+            onChange={(e) => {
+              setComment(e.target.value);
+            }}
+            rows={2}
+            style={fieldStyle}
+            value={comment}
+          />
+        </label>
+
+        <label className="flex flex-col items-start gap-1.5">
+          <span className="text-fg-mute text-sm">セレクトボックス</span>
+          <div className="border-border-base bg-bg-base flex w-fit items-center rounded-lg border">
+            <select
+              aria-label="セレクトボックス"
+              className="text-fg-base appearance-none bg-transparent py-2 ps-3.5 pe-1.5"
+              onChange={(e) => {
+                setFruit(e.target.value);
+              }}
+              style={fieldStyle}
+              value={fruit}
+            >
+              {fruitOptions.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </select>
+            <span aria-hidden className="text-fg-mute pointer-events-none pe-3">
+              <ChevronIcon direction="down" size="sm" />
+            </span>
+          </div>
+        </label>
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/app/_components/playgrounds/field-sizing/index.ts
+++ b/apps/main/src/app/_components/playgrounds/field-sizing/index.ts
@@ -1,0 +1,19 @@
+import type { PlaygroundSection } from '../types';
+import { FieldSizingDemo } from './field-sizing-demo';
+
+export { FieldSizingDemo } from './field-sizing-demo';
+
+export const fieldSizingSection: PlaygroundSection = {
+  id: 'field-sizing',
+  title: 'field-sizing',
+  description:
+    'field-sizing: contentでフォームコントロールを入力内容に合わせて伸縮させられます。',
+  type: 'blog',
+  slug: 'field-sizing',
+  demos: [
+    {
+      component: FieldSizingDemo,
+      title: 'field-sizing: contentの挙動',
+    },
+  ],
+};

--- a/apps/main/src/app/_components/playgrounds/index.ts
+++ b/apps/main/src/app/_components/playgrounds/index.ts
@@ -12,6 +12,7 @@ export * from './contrast-color';
 export * from './crisp-edges';
 export * from './details-content';
 export * from './event-timing';
+export * from './field-sizing';
 export * from './font-family-math';
 export * from './highlight';
 export * from './input-file-webkitdirectory';
@@ -48,6 +49,7 @@ import { contrastColorSection } from './contrast-color';
 import { crispEdgesSection } from './crisp-edges';
 import { detailsContentSection } from './details-content';
 import { eventTimingSection } from './event-timing';
+import { fieldSizingSection } from './field-sizing';
 import { fontFamilyMathSection } from './font-family-math';
 import { highlightSection } from './highlight';
 import { inputFileWebkitdirectorySection } from './input-file-webkitdirectory';
@@ -84,6 +86,7 @@ export const playgroundSections: PlaygroundSection[] = [
   crispEdgesSection,
   detailsContentSection,
   eventTimingSection,
+  fieldSizingSection,
   fontFamilyMathSection,
   inputFileWebkitdirectorySection,
   invokerCommandsSection,

--- a/apps/main/src/app/blog/(articles)/field-sizing/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/field-sizing/layout.tsx
@@ -1,0 +1,37 @@
+import type { Metadata } from 'next';
+
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+import { getBlogContent } from '@/features/blog/interface/queries';
+
+const slug = 'field-sizing';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const blog = await getBlogContent(slug);
+
+  return {
+    title: blog.title,
+    description: blog.description,
+    category: blog.tags.map((tag) => tag.name).join(', '),
+    openGraph: {
+      title: blog.title,
+      description: blog.description ?? undefined,
+      url: `https://k8o.me/blog/${slug}`,
+      publishedTime: blog.createdAt,
+      authors: ['k8o'],
+      siteName: 'k8o',
+      locale: 'ja',
+      type: 'article',
+    },
+    twitter: {
+      title: blog.title,
+      card: 'summary_large_image',
+      description: blog.description ?? undefined,
+    },
+  };
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/field-sizing'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/field-sizing/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/field-sizing/opengraph-image.tsx
@@ -1,0 +1,27 @@
+import { OgImage } from '@/app/_components/og-image';
+import {
+  getBlogContent,
+  getBlogOgCode,
+} from '@/features/blog/interface/queries';
+
+export const alt =
+  'field-sizingでフォームコントロールを内容に合わせて伸縮させる';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default async function Image() {
+  const [blog, ogCode] = await Promise.all([
+    getBlogContent('field-sizing'),
+    getBlogOgCode('field-sizing'),
+  ]);
+
+  return OgImage({
+    category: 'Blog',
+    title: blog.title,
+    code: ogCode ?? undefined,
+  });
+}

--- a/apps/main/src/app/blog/(articles)/field-sizing/page.mdx
+++ b/apps/main/src/app/blog/(articles)/field-sizing/page.mdx
@@ -1,0 +1,89 @@
+---
+title: 'field-sizingでフォームコントロールを内容に合わせて伸縮させる'
+description: 'field-sizingはinputやtextarea、selectといったフォームコントロールのサイズを入力内容にフィットさせるCSSプロパティです。Baseline 2026で主要ブラウザに揃い、JavaScriptで高さを自動調整する処理をCSSだけで置き換えられるようになりました。'
+createdAt: 2026-06-27
+updatedAt: 2026-06-27
+featureIds:
+  - field-sizing
+---
+
+import { BaselineStatus } from '@k8o/arte-odyssey';
+import { FieldSizingDemo, Playground } from '@/app/_components/playgrounds';
+
+# field-sizingでフォームコントロールを内容に合わせて伸縮させる
+
+<BaselineStatus featureId="field-sizing" />
+
+## はじめに
+
+`input`や`textarea`は、入力内容の量に関わらず最初に決めた幅や高さのまま表示されます。テキストエリアを入力に合わせて伸ばしたいときは、`scrollHeight`を読んで`height`を書き換えるようなJavaScriptをよく書いてきました。
+
+`field-sizing`プロパティを使うと、こうしたフォームコントロールのサイズを入力内容にフィットさせる挙動をCSSだけで指定できます。Chromeでは先行して使えていましたが、Safari 26.2とFirefox 152が対応したことでBaseline 2026に加わりました。
+
+## field-sizingの値
+
+`field-sizing`が取る値は`fixed`と`content`の2つです。
+
+```css
+input {
+  /* [!callout: 既定値。最初に決まったサイズで固定される] */
+  field-sizing: fixed;
+}
+
+input {
+  /* [!callout: 入力内容に合わせてサイズが変わる] */
+  field-sizing: content;
+}
+```
+
+`fixed`が既定値で、これは従来どおりの挙動です。`content`を指定すると、コントロールが内容を包み込むように縮み、テキストが増えると広がります。
+
+## 対象となる要素
+
+`field-sizing`が効くのは、内容に関わらず既定の推奨サイズを持つ要素です。HTMLでは次のフォームコントロールが対象です。
+
+- `text`・`email`・`search`・`tel`・`url`・`password`・`number`といった、テキストを直接入力する`input`
+- `file`の`input`（選択したファイル名に合わせて幅が変わる）
+- `textarea`
+- `select`
+
+`textarea`は単一行のテキスト入力に近い挙動になり、幅の制約に達すると今度は高さ方向に行が増え、高さの制約にも達するとスクロールバーが出ます。`select`はドロップダウンなら選択中の選択肢の幅にフィットし、`multiple`属性付きのリストボックスならスクロールせずに全選択肢が見える高さになります。
+
+## min/maxと組み合わせる
+
+`field-sizing: content`だけを指定すると、`input`は最小でテキストカーソルの幅まで縮みます。実用上は`min-width`や`max-width`を添えて、伸び縮みの範囲を決めておくのが扱いやすいです。
+
+```css
+/* [!og] */
+input {
+  field-sizing: content;
+  min-width: 8rem;
+  max-width: 20rem;
+}
+```
+
+範囲を制限する用途には`min-width`や`max-width`が向いています。一方で`width`や`height`を固定値で指定すると、サイズがその値に固定され、`field-sizing: content`は効かなくなります。`placeholder`を指定した`input`は、フォーカス前はプレースホルダー全体が見える幅で描画され、入力を始めると`min-width`まで縮みます。
+
+固定値の`width`以外に、レイアウト側でコントロールが幅いっぱいに引き伸ばされる場合も、内容に合わせて縮みません。たとえば`flex-direction: column`のFlexアイテムやGridアイテムは、既定でコンテナの幅まで広がります。引き伸ばしを止めれば`field-sizing: content`が効きます。コントロール側で指定するなら、`align-self`（Flex）や`justify-self`（Grid）を`start`にするといった方法があります。
+
+## 属性との関係
+
+`field-sizing: content`を指定すると、サイズに関わる一部の属性は意味を持たなくなります。`input`の`size`、`textarea`の`rows`・`cols`はいずれも既定の推奨サイズを決める属性なので、サイズが内容に追従する`content`では効きません。
+
+伸びる上限を内容側から決めたいときは`maxlength`が使えます。文字数の上限に達するとコントロールはそれ以上大きくなりません。
+
+```html
+<input type="tel" maxlength="15" />
+```
+
+## デモ
+
+`field-sizing`を`content`と`fixed`に切り替えながら、各コントロールに入力してサイズの変化を確かめられます。テキストエリアは行を増やすと高さが伸び、セレクトボックスは選んだ選択肢に幅が合います。
+
+<Playground title="field-sizing: contentの挙動">
+  <FieldSizingDemo />
+</Playground>
+
+## おわりに
+
+`field-sizing: content`は、フォームコントロールのサイズを入力内容に追従させるためのCSSプロパティです。Baseline 2026で主要ブラウザに揃ったので、テキストエリアの高さをJavaScriptで調整していた処理を、`field-sizing`と`min-width`・`max-width`の組み合わせに置き換えていけます。

--- a/apps/main/src/app/blog/_components/blog-card/blog-card.tsx
+++ b/apps/main/src/app/blog/_components/blog-card/blog-card.tsx
@@ -9,6 +9,7 @@ type BlogCardProps = {
   description: string | null;
   createdAt: string;
   updatedAt: string;
+  readingTime?: number;
 };
 
 export const BlogCard: FC<BlogCardProps> = (props) => (

--- a/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -77,7 +77,10 @@ export const BlogLayoutContent: FC<BlogLayoutContentProps> = ({
                   <SlideLinkButton href={blog.slideUrl} />
                 </div>
               )}
-              <div className="text-fg-mute flex flex-col items-end gap-1 text-xs sm:flex-row sm:items-center sm:justify-end sm:gap-2 sm:text-sm">
+              <div className="text-fg-mute flex flex-col items-end gap-1 text-xs sm:text-sm">
+                <div className="flex items-center gap-1">
+                  <span>約{readingTime}分で読めます</span>
+                </div>
                 <div className="flex flex-wrap items-center justify-end gap-1">
                   <div className="flex items-center gap-1">
                     <PublishDateIcon size="sm" />
@@ -87,9 +90,6 @@ export const BlogLayoutContent: FC<BlogLayoutContentProps> = ({
                     <UpdateDateIcon size="sm" />
                     <span>更新: {formatDate(new Date(blog.updatedAt))}</span>
                   </div>
-                </div>
-                <div className="flex items-center gap-1">
-                  <span>約{readingTime}分で読めます</span>
                 </div>
               </div>
               {blog.tags.length > 0 && (

--- a/apps/main/src/app/blog/_utils/types.ts
+++ b/apps/main/src/app/blog/_utils/types.ts
@@ -6,4 +6,5 @@ export type BlogSummary = {
   description: string | null;
   createdAt: string;
   updatedAt: string;
+  readingTime?: number;
 };

--- a/apps/main/src/features/blog/application/reading-time.test.ts
+++ b/apps/main/src/features/blog/application/reading-time.test.ts
@@ -26,10 +26,11 @@ describe('estimateReadingTimeMinutes', () => {
   });
 
   describe('エッジケース', () => {
-    it('コードブロックは読了時間に含めない', () => {
-      const text = ['```ts', 'const x = 1;'.repeat(500), '```'].join('\n');
+    it('コードブロックはコード用のレートで算入する', () => {
+      // コード内 約1000文字 / 300cpm ≈ 3.3 → 4分
+      const text = ['```ts', 'a'.repeat(1000), '```'].join('\n');
 
-      expect(estimateReadingTimeMinutes(text)).toBe(1);
+      expect(estimateReadingTimeMinutes(text)).toBe(4);
     });
 
     it('リンクはテキストのみカウントしURLは除外する', () => {

--- a/apps/main/src/features/blog/application/reading-time.ts
+++ b/apps/main/src/features/blog/application/reading-time.ts
@@ -1,16 +1,26 @@
 // 記事本文（マークダウン）から推定読了時間（分）を算出する。
-// 日本語(CJK)は文字数、英数字は単語数で見積もり、合算して切り上げる。
-// コードブロック・URL は読み飛ばされる前提で除外する。
+// 日本語(CJK)は文字数、英数字は単語数で見積もる。
+// コードブロックは本文より読むのに時間がかかるため、低めのレートで別に算入する。
+// インラインコード・画像・URL は読み飛ばされる前提で除外する。
 
 const CJK_CHARS_PER_MINUTE = 500;
 const WORDS_PER_MINUTE = 250;
+const CODE_CHARS_PER_MINUTE = 300;
 
 const CJK_RE = /[぀-ヿ㐀-䶿一-鿿ｦ-ﾟ]/gu;
 
 export const estimateReadingTimeMinutes = (markdown: string): number => {
-  const text = markdown
-    // フェンスドコードブロック
-    .replaceAll(/```[\s\S]*?```/gu, ' ')
+  // フェンスドコードブロックは本文と別レートで数えるため、中身の文字数を控えてから除去する
+  let codeCharCount = 0;
+  const withoutFencedCode = markdown.replaceAll(
+    /```[^\n]*\n([\s\S]*?)```/gu,
+    (_match, body: string) => {
+      codeCharCount += body.length;
+      return ' ';
+    },
+  );
+
+  const text = withoutFencedCode
     // インラインコード
     .replaceAll(/`[^`]*`/gu, ' ')
     // 画像
@@ -28,7 +38,9 @@ export const estimateReadingTimeMinutes = (markdown: string): number => {
     .filter((token) => /[a-z0-9]/iu.test(token)).length;
 
   const minutes = Math.ceil(
-    cjkCount / CJK_CHARS_PER_MINUTE + wordCount / WORDS_PER_MINUTE,
+    cjkCount / CJK_CHARS_PER_MINUTE +
+      wordCount / WORDS_PER_MINUTE +
+      codeCharCount / CODE_CHARS_PER_MINUTE,
   );
 
   return Math.max(1, minutes);

--- a/apps/main/src/features/blog/interface/queries.ts
+++ b/apps/main/src/features/blog/interface/queries.ts
@@ -22,6 +22,7 @@ export async function getBlogContents() {
   return Promise.all(
     blogs.map(async (blog) => {
       const metadata = await getBlogMetadata(blog.slug);
+      const markdown = await getMarkdown(blog.slug);
       return {
         id: blog.id,
         slug: blog.slug,
@@ -30,6 +31,7 @@ export async function getBlogContents() {
         description: metadata.description,
         createdAt: metadata.createdAt,
         updatedAt: metadata.updatedAt,
+        readingTime: estimateReadingTimeMinutes(markdown),
       };
     }),
   );

--- a/apps/main/src/features/blog/interface/queries.ts
+++ b/apps/main/src/features/blog/interface/queries.ts
@@ -21,8 +21,10 @@ export async function getBlogContents() {
   const blogs = await getBlogs();
   return Promise.all(
     blogs.map(async (blog) => {
-      const metadata = await getBlogMetadata(blog.slug);
-      const markdown = await getMarkdown(blog.slug);
+      const [metadata, readingTime] = await Promise.all([
+        getBlogMetadata(blog.slug),
+        getBlogReadingTime(blog.slug),
+      ]);
       return {
         id: blog.id,
         slug: blog.slug,
@@ -31,7 +33,7 @@ export async function getBlogContents() {
         description: metadata.description,
         createdAt: metadata.createdAt,
         updatedAt: metadata.updatedAt,
-        readingTime: estimateReadingTimeMinutes(markdown),
+        readingTime,
       };
     }),
   );

--- a/packages/database/migrations/0057_bitter_tenebrous.sql
+++ b/packages/database/migrations/0057_bitter_tenebrous.sql
@@ -1,0 +1,25 @@
+-- 新しいタグの追加（既存なら何もしない）
+INSERT INTO tags (name) VALUES ('field-sizing') ON CONFLICT (name) DO NOTHING;--> statement-breakpoint
+
+-- ブログレコードの追加（slug が一意なので id は書かない）
+INSERT INTO blogs (slug, published, created_at)
+VALUES ('field-sizing', 1, '2026-06-27T00:00:00.000Z') ON CONFLICT (slug) DO NOTHING;--> statement-breakpoint
+
+-- ビューカウント初期化
+INSERT INTO blog_views (blog_id, views)
+VALUES ((SELECT id FROM blogs WHERE slug = 'field-sizing'), 0)
+ON CONFLICT (blog_id) DO NOTHING;--> statement-breakpoint
+
+-- タグ紐付け (CSS, Baseline 2026, field-sizing)
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (
+  (SELECT id FROM blogs WHERE slug = 'field-sizing'),
+  (SELECT id FROM tags WHERE name = 'CSS')
+) ON CONFLICT DO NOTHING;--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (
+  (SELECT id FROM blogs WHERE slug = 'field-sizing'),
+  (SELECT id FROM tags WHERE name = 'Baseline 2026')
+) ON CONFLICT DO NOTHING;--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (
+  (SELECT id FROM blogs WHERE slug = 'field-sizing'),
+  (SELECT id FROM tags WHERE name = 'field-sizing')
+) ON CONFLICT DO NOTHING;

--- a/packages/database/migrations/meta/0057_snapshot.json
+++ b/packages/database/migrations/meta/0057_snapshot.json
@@ -1,0 +1,1833 @@
+{
+  "id": "259ee860-5af5-42e3-b1dd-b9df120d0604",
+  "prevId": "70fec50f-11e9-46f6-b78e-51db34c1a9e4",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "ai_project_versions": {
+      "name": "ai_project_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_project_versions_project_id_idx": {
+          "name": "ai_project_versions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_project_versions_project_id_ai_projects_id_fk": {
+          "name": "ai_project_versions_project_id_ai_projects_id_fk",
+          "tableFrom": "ai_project_versions",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "ai_projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_projects": {
+      "name": "ai_projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "fork_of": {
+          "name": "fork_of",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_snapshot": {
+          "name": "public_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_projects_slug_idx": {
+          "name": "ai_projects_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "ai_projects_user_id_idx": {
+          "name": "ai_projects_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "ai_projects_app_idx": {
+          "name": "ai_projects_app_idx",
+          "columns": [
+            "app"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_projects_user_id_user_id_fk": {
+          "name": "ai_projects_user_id_user_id_fk",
+          "tableFrom": "ai_projects",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_usages": {
+      "name": "ai_usages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_usages_user_id_idx": {
+          "name": "ai_usages_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "ai_usages_created_at_idx": {
+          "name": "ai_usages_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_usages_user_id_user_id_fk": {
+          "name": "ai_usages_user_id_user_id_fk",
+          "tableFrom": "ai_usages",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_attempts": {
+          "name": "summary_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "tableTo": "article_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_view_dailies": {
+      "name": "blog_view_dailies",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "blog_view_dailies_date_idx": {
+          "name": "blog_view_dailies_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_view_dailies_blog_id_blogs_id_fk": {
+          "name": "blog_view_dailies_blog_id_blogs_id_fk",
+          "tableFrom": "blog_view_dailies",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_view_dailies_blog_id_date_pk": {
+          "columns": [
+            "blog_id",
+            "date"
+          ],
+          "name": "blog_view_dailies_blog_id_date_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_logs": {
+      "name": "push_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "succeeded": {
+          "name": "succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed": {
+          "name": "failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_logs_dedupe_key_idx": {
+          "name": "push_logs_dedupe_key_idx",
+          "columns": [
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "push_logs_sent_at_idx": {
+          "name": "push_logs_sent_at_idx",
+          "columns": [
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "push_logs_kind_check": {
+          "name": "push_logs_kind_check",
+          "value": "\"push_logs\".\"kind\" IN ('readings_updated', 'baseline_updated')"
+        }
+      }
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_idx": {
+          "name": "push_subscriptions_endpoint_idx",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_tag": {
+      "name": "slide_tag",
+      "columns": {
+        "slide_id": {
+          "name": "slide_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slide_tag_slide_id_idx": {
+          "name": "slide_tag_slide_id_idx",
+          "columns": [
+            "slide_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_tag_id_idx": {
+          "name": "slide_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_unique_idx": {
+          "name": "slide_tag_unique_idx",
+          "columns": [
+            "slide_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "slide_tag_slide_id_slides_id_fk": {
+          "name": "slide_tag_slide_id_slides_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "tableTo": "slides",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "slide_tag_tag_id_tags_id_fk": {
+          "name": "slide_tag_tag_id_tags_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slides": {
+      "name": "slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slides_slug_idx": {
+          "name": "slides_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -400,6 +400,13 @@
       "when": 1782147135502,
       "tag": "0056_kind_otto_octavius",
       "breakpoints": true
+    },
+    {
+      "idx": 57,
+      "version": "6",
+      "when": 1782562625568,
+      "tag": "0057_bitter_tenebrous",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

Baseline 2026 入りした CSS の `field-sizing` を解説する記事と Playground デモを追加します。あわせて、ブログの読了時間表示を一覧・記事ヘッダーに追加し、見積もりロジックを調整します。

## 詳細

記事・Playground:
- `field-sizing` の記事（page.mdx / layout / opengraph-image）
- Playground デモ（`content`/`fixed` の切り替え、`min-width`・`max-height`・`rows` の挙動、プレースホルダー幅）
- タグ・記事の seed マイグレーション（0057、slug/name 参照の冪等 INSERT）

読了時間:
- 一覧カードと記事ヘッダーに「約X分で読めます」を表示（ヘッダーは日付の上に配置）
- 見積もりにコードブロックを算入（300字/分）。これまで完全除外でコード例の多い記事が短く出ていた
- `getBlogContents` は `getBlogReadingTime` を再利用（slug 単位キャッシュ共有・metadata と並列取得）

## 気をつけるポイント

- 記事ヘッダーのメタ情報を縦並び（読了時間 → 公開/更新日）に変更。全記事に影響します
- 読了時間にコードを算入したため、既存記事の表示分数が増える場合があります
- 読了時間は `ContentCard` の任意プロパティ。slides など未指定の利用側は非表示のまま

## 影響範囲

- `/blog` 一覧、`/blog/[slug]` の記事ヘッダー
- `getBlogContents` 経由の recent-blogs / feed / sitemap / llms.txt

## テスト

- type-check / lint / Storybook（364）通過、`reading-time` の単体テストを更新
- ブラウザで記事・一覧・Playground を目視確認

Closes #1901