### PR TITLE
feat: apps/ai・apps/admin の遷移／操作に即時フィードバックを追加

### DIFF
--- a/apps/admin/src/app/(authenticated)/_components/admin-sidebar/sidebar-nav.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/admin-sidebar/sidebar-nav.tsx
@@ -1,8 +1,9 @@
 'use client';
 
+import { Spinner } from '@k8o/arte-odyssey';
 import { cn } from '@repo/helpers/cn';
 import type { Route } from 'next';
-import Link from 'next/link';
+import Link, { useLinkStatus } from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { FC } from 'react';
 
@@ -12,6 +13,24 @@ const isActive = (pathname: string, href: string): boolean =>
   href === '/'
     ? pathname === '/'
     : pathname === href || pathname.startsWith(`${href}/`);
+
+type NavIcon = (typeof NAV_GROUPS)[number]['items'][number]['icon'];
+
+// useLinkStatus は <Link> の子孫でのみ機能する。Link 内に置き、遷移中の保留状態を取得して
+// クリックしたリンクだけにスピナーを出す（どのメニューを押したかが即わかる）。
+const NavItemContent: FC<{ Icon: NavIcon; label: string }> = ({
+  Icon,
+  label,
+}) => {
+  const { pending } = useLinkStatus();
+  return (
+    <>
+      <Icon size="sm" />
+      <span className="flex-1 truncate">{label}</span>
+      {pending ? <Spinner label="読み込み中" size="sm" /> : null}
+    </>
+  );
+};
 
 export const SidebarNavList: FC<{
   pathname: string | null;
@@ -31,7 +50,6 @@ export const SidebarNavList: FC<{
             </p>
           )}
           {group.items.map((item) => {
-            const Icon = item.icon;
             const active = pathname !== null && isActive(pathname, item.href);
             return (
               <Link
@@ -46,8 +64,7 @@ export const SidebarNavList: FC<{
                 key={item.href}
                 onClick={handleNavigate}
               >
-                <Icon size="sm" />
-                {item.label}
+                <NavItemContent Icon={item.icon} label={item.label} />
               </Link>
             );
           })}

--- a/apps/admin/src/app/(authenticated)/_components/filter-select/filter-select.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/filter-select/filter-select.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Select } from '@k8o/arte-odyssey';
+import { Select, Spinner } from '@k8o/arte-odyssey';
 import type { Route } from 'next';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import type { ChangeEvent, FC } from 'react';
+import { type ChangeEvent, type FC, useTransition } from 'react';
 
 import { buildSearchString } from '@/shared/search-params';
 
@@ -17,6 +17,7 @@ export const FilterSelect: FC<Props> = ({ paramKey, label, options }) => {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
   const value = searchParams.get(paramKey) ?? options[0]?.value ?? '';
 
   const handleChange = (e: ChangeEvent<HTMLSelectElement>): void => {
@@ -24,15 +25,24 @@ export const FilterSelect: FC<Props> = ({ paramKey, label, options }) => {
       [paramKey]: e.target.value,
       page: null,
     });
-    router.push(`${pathname}${qs}` as Route);
+    // 遷移を transition でラップすると、再フェッチ完了まで現在の一覧が dim されたまま
+    // 残り、Suspense fallback への点滅を防げる。isPending で操作中も表示する。
+    startTransition(() => {
+      router.push(`${pathname}${qs}` as Route);
+    });
   };
 
   return (
-    <Select
-      aria-label={label}
-      onChange={handleChange}
-      options={options}
-      value={value}
-    />
+    <div className="flex items-center gap-2">
+      <Select
+        aria-busy={isPending}
+        aria-label={label}
+        disabled={isPending}
+        onChange={handleChange}
+        options={options}
+        value={value}
+      />
+      {isPending ? <Spinner label="絞り込み中" size="sm" /> : null}
+    </div>
   );
 };

--- a/apps/admin/src/app/(authenticated)/_components/list-pagination/list-pagination.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/list-pagination/list-pagination.tsx
@@ -3,7 +3,7 @@
 import { Pagination } from '@k8o/arte-odyssey';
 import type { Route } from 'next';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import type { FC } from 'react';
+import { type FC, useTransition } from 'react';
 
 import { buildSearchString } from '@/shared/search-params';
 
@@ -16,6 +16,7 @@ export const ListPagination: FC<Props> = ({ totalPages, currentPage }) => {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
 
   if (totalPages <= 1) {
     return null;
@@ -25,12 +26,16 @@ export const ListPagination: FC<Props> = ({ totalPages, currentPage }) => {
     const qs = buildSearchString(searchParams.toString(), {
       page: page === 1 ? null : String(page),
     });
-    router.push(`${pathname}${qs}` as Route);
+    // transition でラップし、ページ取得中も現在の一覧を維持したまま操作を無効化する。
+    startTransition(() => {
+      router.push(`${pathname}${qs}` as Route);
+    });
   };
 
   return (
     <Pagination
       currentPage={currentPage}
+      disabled={isPending}
       onPageChange={handlePageChange}
       totalPages={totalPages}
     />

--- a/apps/admin/src/app/(authenticated)/_components/search-field/search-field.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/search-field/search-field.tsx
@@ -1,9 +1,16 @@
 'use client';
 
-import { TextField } from '@k8o/arte-odyssey';
+import { Spinner, TextField } from '@k8o/arte-odyssey';
 import type { Route } from 'next';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { type ChangeEvent, type FC, useEffect, useRef, useState } from 'react';
+import {
+  type ChangeEvent,
+  type FC,
+  useEffect,
+  useRef,
+  useState,
+  useTransition,
+} from 'react';
 
 import { buildSearchString } from '@/shared/search-params';
 
@@ -21,6 +28,7 @@ export const SearchField: FC<Props> = ({
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+  const [isPending, startTransition] = useTransition();
   const urlValue = searchParams.get(paramKey) ?? '';
   const [value, setValue] = useState(urlValue);
   const [prevUrlValue, setPrevUrlValue] = useState(urlValue);
@@ -53,19 +61,27 @@ export const SearchField: FC<Props> = ({
         [paramKey]: next,
         page: null,
       });
-      router.push(`${pathname}${qs}` as Route);
+      // transition でラップして、再フェッチ中も入力欄とフォーカスを保ったまま現在の一覧を
+      // 維持する（Suspense fallback への点滅を防ぐ）。入力は妨げず、横にスピナーで状態を示す。
+      startTransition(() => {
+        router.push(`${pathname}${qs}` as Route);
+      });
     }, DEBOUNCE_MS);
   };
 
   return (
-    <TextField
-      aria-label={placeholder}
-      onChange={handleChange}
-      placeholder={placeholder}
-      // ArteOdyssey の TextField は幅ユーティリティを持たないため、
-      // size 属性で実用的な横幅を確保する。
-      size={32}
-      value={value}
-    />
+    <div className="flex items-center gap-2">
+      <TextField
+        aria-busy={isPending}
+        aria-label={placeholder}
+        onChange={handleChange}
+        placeholder={placeholder}
+        // ArteOdyssey の TextField は幅ユーティリティを持たないため、
+        // size 属性で実用的な横幅を確保する。
+        size={32}
+        value={value}
+      />
+      {isPending ? <Spinner label="検索中" size="sm" /> : null}
+    </div>
   );
 };

--- a/apps/admin/src/app/(authenticated)/_components/sign-out-button/sign-out-button.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/sign-out-button/sign-out-button.tsx
@@ -1,16 +1,20 @@
 'use client';
 
-import { useToast } from '@k8o/arte-odyssey';
+import { Spinner, useToast } from '@k8o/arte-odyssey';
 import { useRouter } from 'next/navigation';
-import type { FC } from 'react';
+import { type FC, useState } from 'react';
 
 import { authClient } from '@/shared/auth/auth-client';
 
 export const SignOutButton: FC = () => {
   const router = useRouter();
   const { onOpen } = useToast();
+  // signOut は fetchOptions のコールバック方式で promise を待てないため、useState で
+  // 押下直後に保留中を出す。成功時は遷移して unmount するので解除は失敗時のみ。
+  const [isPending, setIsPending] = useState(false);
 
   const handleSignOut = () => {
+    setIsPending(true);
     void authClient.signOut({
       fetchOptions: {
         onSuccess: () => {
@@ -18,6 +22,7 @@ export const SignOutButton: FC = () => {
           router.refresh();
         },
         onError: () => {
+          setIsPending(false);
           onOpen('error', 'ログアウトに失敗しました');
         },
       },
@@ -26,11 +31,13 @@ export const SignOutButton: FC = () => {
 
   return (
     <button
-      className="text-fg-mute hover:bg-bg-mute hover:text-fg-base flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors"
+      className="text-fg-mute hover:bg-bg-mute hover:text-fg-base flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-60"
+      disabled={isPending}
       onClick={handleSignOut}
       type="button"
     >
-      ログアウト
+      {isPending ? <Spinner label="ログアウト中" size="sm" /> : null}
+      {isPending ? 'ログアウト中…' : 'ログアウト'}
     </button>
   );
 };

--- a/apps/admin/src/app/(authenticated)/loading.tsx
+++ b/apps/admin/src/app/(authenticated)/loading.tsx
@@ -1,0 +1,30 @@
+import { range } from '@repo/helpers/array/range';
+
+// ルートセグメント共通のローディング。prefetch 済みの静的シェルが間に合わない遷移でも、
+// 即座に骨組みを描画して白画面のブロックを防ぐ。各ページの実シェルが届くと差し替わる。
+export default function Loading() {
+  return (
+    <div aria-busy aria-label="読み込み中" className="flex flex-col gap-10">
+      <div className="flex flex-col gap-2">
+        <div className="bg-bg-mute h-7 w-48 rounded-md motion-safe:animate-pulse" />
+        <div className="bg-bg-mute h-4 w-72 rounded-md motion-safe:animate-pulse" />
+      </div>
+      <div className="grid grid-cols-1 gap-6 sm:grid-cols-3">
+        {range(0, 3).map((n) => (
+          <div
+            className="bg-bg-base h-24 rounded-xl shadow-sm motion-safe:animate-pulse"
+            key={`stat-skeleton-${n}`}
+          />
+        ))}
+      </div>
+      <div className="flex flex-col gap-4">
+        {range(0, 6).map((n) => (
+          <div
+            className="bg-bg-base h-16 rounded-lg shadow-sm motion-safe:animate-pulse"
+            key={`row-skeleton-${n}`}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/src/app/(public)/sign-in/_components/sign-in-form/sign-in-form.tsx
+++ b/apps/admin/src/app/(public)/sign-in/_components/sign-in-form/sign-in-form.tsx
@@ -1,19 +1,24 @@
 'use client';
 
-import { Button, GitHubIcon, useToast } from '@k8o/arte-odyssey';
-import type { FC } from 'react';
+import { Button, GitHubIcon, Spinner, useToast } from '@k8o/arte-odyssey';
+import { type FC, useState } from 'react';
 
 import { authClient } from '@/shared/auth/auth-client';
 
 export const SignInForm: FC = () => {
   const { onOpen } = useToast();
+  // social ログインは GitHub への全画面リダイレクト。押下からリダイレクトまでの間が
+  // 無反応に見えるため、保留中はボタンを無効化してスピナーを出す。失敗時のみ解除する。
+  const [isPending, setIsPending] = useState(false);
 
   const handleSignIn = () => {
+    setIsPending(true);
     void authClient.signIn.social({
       provider: 'github',
       callbackURL: '/',
       fetchOptions: {
         onError: () => {
+          setIsPending(false);
           onOpen('error', 'ログインに失敗しました');
         },
       },
@@ -23,12 +28,19 @@ export const SignInForm: FC = () => {
   return (
     <Button
       color="gray"
+      disabled={isPending}
       fullWidth
       onClick={handleSignIn}
-      startIcon={<GitHubIcon size="md" />}
+      startIcon={
+        isPending ? (
+          <Spinner label="ログイン中" size="sm" />
+        ) : (
+          <GitHubIcon size="md" />
+        )
+      }
       variant="solid"
     >
-      GitHubでログイン
+      {isPending ? 'ログイン中…' : 'GitHubでログイン'}
     </Button>
   );
 };

--- a/apps/ai/src/app/(authenticated)/_components/studio/index.ts
+++ b/apps/ai/src/app/(authenticated)/_components/studio/index.ts
@@ -1,1 +1,2 @@
 export { Studio } from './studio';
+export { StudioSkeleton } from './studio-skeleton';

--- a/apps/ai/src/app/(authenticated)/_components/studio/share-control-view.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/share-control-view.tsx
@@ -4,6 +4,7 @@ import {
   LockIcon,
   LockOpenIcon,
   Popover,
+  Spinner,
 } from '@k8o/arte-odyssey';
 import type { FC } from 'react';
 
@@ -52,7 +53,13 @@ export const ShareControlView: FC<ShareControlViewProps> = ({
             tooltipDisabled
             {...props}
           >
-            {isPublic ? <LockOpenIcon size="sm" /> : <LockIcon size="sm" />}
+            {busy ? (
+              <Spinner label="処理中" size="sm" />
+            ) : isPublic ? (
+              <LockOpenIcon size="sm" />
+            ) : (
+              <LockIcon size="sm" />
+            )}
           </IconButton>
         )}
       />

--- a/apps/ai/src/app/(authenticated)/_components/studio/studio-skeleton.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/studio-skeleton.tsx
@@ -1,0 +1,37 @@
+import { range } from '@repo/helpers/array/range';
+import type { FC } from 'react';
+
+// Studio のシェル（ヘッダ＋チャット列＋プレビュー列）を模した骨組み。認証ゲート（DB/cookie）の
+// 解決中やスタジオへの遷移中に、白画面ではなく構造を見せて待ちのブロック感を減らす。
+export const StudioSkeleton: FC = () => (
+  <div
+    aria-busy
+    aria-label="読み込み中"
+    className="flex min-h-0 flex-1 flex-col"
+  >
+    <div className="border-border-mute flex flex-wrap items-center gap-x-4 gap-y-2 border-b px-4 py-2">
+      <div className="flex min-w-0 items-center gap-2">
+        <div className="bg-bg-mute h-4 w-28 rounded-md motion-safe:animate-pulse" />
+        <span className="text-fg-mute text-sm">/</span>
+        <div className="bg-bg-mute h-4 w-40 rounded-md motion-safe:animate-pulse" />
+      </div>
+      <div className="ml-auto flex items-center gap-2">
+        <div className="bg-bg-mute h-8 w-16 rounded-md motion-safe:animate-pulse" />
+        <div className="bg-bg-mute h-8 w-16 rounded-md motion-safe:animate-pulse" />
+      </div>
+    </div>
+    <div className="grid min-h-0 flex-1 grid-rows-1 lg:grid-cols-[440px_minmax(0,1fr)]">
+      <div className="border-border-mute hidden min-h-0 flex-col gap-5 border-r p-6 lg:flex">
+        {range(0, 4).map((n) => (
+          <div className="flex flex-col gap-2" key={`studio-msg-skeleton-${n}`}>
+            <div className="bg-bg-mute h-3 w-10 rounded motion-safe:animate-pulse" />
+            <div className="bg-bg-mute h-16 w-full rounded-lg motion-safe:animate-pulse" />
+          </div>
+        ))}
+      </div>
+      <div className="bg-bg-surface flex min-h-0 items-stretch justify-center p-6">
+        <div className="bg-bg-mute size-full rounded-xl motion-safe:animate-pulse" />
+      </div>
+    </div>
+  </div>
+);

--- a/apps/ai/src/app/(authenticated)/loading.tsx
+++ b/apps/ai/src/app/(authenticated)/loading.tsx
@@ -1,0 +1,6 @@
+import { StudioSkeleton } from './_components/studio';
+
+// スタジオへの遷移中（サインイン後など）に即座にシェルの骨組みを描画する。
+export default function Loading() {
+  return <StudioSkeleton />;
+}

--- a/apps/ai/src/app/(authenticated)/page.tsx
+++ b/apps/ai/src/app/(authenticated)/page.tsx
@@ -2,7 +2,7 @@ import { Suspense } from 'react';
 
 import { verifySession } from '@/shared/auth/verify-session';
 
-import { Studio } from './_components/studio';
+import { Studio, StudioSkeleton } from './_components/studio';
 
 // Sandbox プレビューの cold start（起動～配信確保）に数十秒かかることがあるため、
 // preview 系 server action がタイムアウトしないよう関数の上限を延ばす。
@@ -17,7 +17,7 @@ const AuthenticatedStudio = async () => {
 
 export default function Page() {
   return (
-    <Suspense fallback={null}>
+    <Suspense fallback={<StudioSkeleton />}>
       <AuthenticatedStudio />
     </Suspense>
   );

--- a/apps/ai/src/app/(public)/sign-in/_components/sign-in-form/sign-in-form.tsx
+++ b/apps/ai/src/app/(public)/sign-in/_components/sign-in-form/sign-in-form.tsx
@@ -1,19 +1,24 @@
 'use client';
 
-import { Button, GitHubIcon, useToast } from '@k8o/arte-odyssey';
-import type { FC } from 'react';
+import { Button, GitHubIcon, Spinner, useToast } from '@k8o/arte-odyssey';
+import { type FC, useState } from 'react';
 
 import { authClient } from '@/shared/auth/auth-client';
 
 export const SignInForm: FC = () => {
   const { onOpen } = useToast();
+  // social ログインは GitHub への全画面リダイレクト。押下からリダイレクトまでの間が
+  // 無反応に見えるため、保留中はボタンを無効化してスピナーを出す。失敗時のみ解除する。
+  const [isPending, setIsPending] = useState(false);
 
   const handleSignIn = () => {
+    setIsPending(true);
     void authClient.signIn.social({
       provider: 'github',
       callbackURL: '/',
       fetchOptions: {
         onError: () => {
+          setIsPending(false);
           onOpen('error', 'ログインに失敗しました');
         },
       },
@@ -23,12 +28,19 @@ export const SignInForm: FC = () => {
   return (
     <Button
       color="gray"
+      disabled={isPending}
       fullWidth
       onClick={handleSignIn}
-      startIcon={<GitHubIcon size="md" />}
+      startIcon={
+        isPending ? (
+          <Spinner label="ログイン中" size="sm" />
+        ) : (
+          <GitHubIcon size="md" />
+        )
+      }
       variant="solid"
     >
-      GitHubでログイン
+      {isPending ? 'ログイン中…' : 'GitHubでログイン'}
     </Button>
   );
 };

--- a/apps/ai/src/app/s/[slug]/page.tsx
+++ b/apps/ai/src/app/s/[slug]/page.tsx
@@ -1,3 +1,4 @@
+import { Spinner } from '@k8o/arte-odyssey';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { notFound } from 'next/navigation';
@@ -66,7 +67,13 @@ const ShareContent = async ({ params }: SharePageProps) => {
 
 export default function SharePage({ params }: SharePageProps) {
   return (
-    <Suspense fallback={<div className="bg-bg-surface h-dvh" />}>
+    <Suspense
+      fallback={
+        <div className="bg-bg-surface flex h-dvh items-center justify-center">
+          <Spinner label="読み込み中" size="lg" />
+        </div>
+      }
+    >
       <ShareContent params={params} />
     </Suspense>
   );


### PR DESCRIPTION
## 概要

apps/ai（AI UI生成スタジオ）と apps/admin（管理サイト）で、操作後にコンテンツ準備が終わるまで遷移がブロックして無反応に見える体感の遅さを解消する。React 19 / Next 16 の標準APIで「クリック → 即フィードバック」を主要導線に揃えた。

## 動機

リンク・フィルタ・Server Action などの操作後、サーバー側のデータ取得が終わるまで画面が固まり、何のフィードバックも出ないまま遷移が完了していた。`viewTransition` / `cacheComponents` / `prefetchInlining` は既に有効だが、クライアント側で遷移APIを使っていないためフィードバックが欠落していたのが原因。**next.config の変更は不要**で、既存設定を活かす形で埋めた。

## 詳細

### apps/admin
- フィルタ/検索/ページングの `router.push` を `useTransition` でラップ。再フェッチ中も現在の一覧を保ったまま（Suspense fallback への点滅を防止）、スピナー・`disabled` で操作中を表示。検索は入力を止めず横にスピナー。
- サイドバーの各 `<Link>` に `useLinkStatus` を導入し、押したメニューだけにスピナーを表示。
- ルートセグメントに `loading.tsx`（スケルトン）を追加し、コールド遷移の白画面ブロックを解消。
- ログアウト/ログインボタンに保留状態（押下直後にスピナー＋「〜中…」）。

### apps/ai
- Studio のシェル骨組み `StudioSkeleton` を追加し、認証ゲート解決中の Suspense fallback を `null` → スケルトンに変更（白画面を解消）。ルート `loading.tsx` にも適用。
- 共有（公開/非公開化）トリガーに busy スピナーを追加し、数秒かかる処理中を可視化。
- 共有ページ `/s/[slug]` の空 fallback を中央スピナーに変更（cold start の白画面を解消）。
- ログインボタンに保留状態（OAuth リダイレクト待ちの無反応を解消）。

## 気をつけるポイント

- **本番ビルド未実行**：`cacheComponents`(PPR) の prerender 制約は `next build` でのみ完全検証される。今回の変更はいずれもデータ取得を動かさない純粋な表示変更だが、**Vercel プレビュービルドで最終確認したい**。
- フィルタ Select は controlled（URL由来）のため、pending 中は前の値を表示する（disabled＋スピナーは出る）。旧実装の「一覧ごと消える」より良いが、選択が一瞬効かないように見える点は許容。
- 意図的に触っていない箇所：スタジオの生成・プレビュー・プロジェクト切替は既に十分なフィードバックがあるため現状維持。admin のフォーム送信も既存の `useActionState` で対応済み。

## 影響範囲

- apps/admin：全認証ページの遷移、サイドバー、フィルタ/検索/ページング、サインイン/アウト
- apps/ai：スタジオ初期表示、共有操作、共有ページ、サインイン

## テスト

- `pnpm run type-check` ✅ / `pnpm run check`（lint+format）✅ 0 errors / `pnpm run ls-lint` ✅
- 影響を受ける Storybook：admin `admin-sidebar`・`sign-in-form` 4/4、ai `share-control-view` 3/3 ✅
- 本番ビルドはこの PR の Vercel プレビューで確認予定