### PR TITLE
feat(blog): 本文のフォントサイズ・行間とフォールバックを整備

### DIFF
--- a/apps/main/.storybook/preview.tsx
+++ b/apps/main/.storybook/preview.tsx
@@ -10,7 +10,7 @@ import { sb } from 'storybook/test';
 
 import { Background } from '../src/app/_components/global-layout/background/background';
 import { AppProvider } from '../src/app/_providers/app';
-import { mPlus2, notoSansJp } from '../src/app/_styles/font';
+import { mPlus2 } from '../src/app/_styles/font';
 import { handlers } from '../src/mocks/handlers';
 
 import '../src/app/_styles/globals.css';
@@ -61,10 +61,10 @@ const preview: Preview = {
   },
   loaders: [
     mswLoader,
-    // Noto Sans JPはfont-display: optionalのため、初回ペイントまでに
-    // ロードが間に合わないとそのページではフォールバック表示に固定され、
-    // VRTのスクリーンショットが二値的に揺れる。Story描画前に登録済み
-    // フォントをすべてロードして折り返し位置を決定的にする
+    // M PLUS 2はfont-display: swapのため、初回ペイントまでにロードが
+    // 間に合わないとフォールバック表示になり、VRTのスクリーンショットが
+    // 揺れる。Story描画前に登録済みフォントをすべてロードして折り返し
+    // 位置を決定的にする
     async () => {
       await Promise.all(
         [...document.fonts].map((font) => font.load().catch(() => undefined)),
@@ -102,7 +102,6 @@ const preview: Preview = {
           <Script id="storybook-body-class">
             {`document.body.classList.add(${cn(
               mPlus2.variable,
-              notoSansJp.variable,
               'text-fg-base font-medium font-m-plus-2',
             )
               .split(' ')

--- a/apps/main/src/app/_styles/font.ts
+++ b/apps/main/src/app/_styles/font.ts
@@ -1,15 +1,18 @@
-import { M_PLUS_2, Noto_Sans_JP } from 'next/font/google';
+import { M_PLUS_2 } from 'next/font/google';
 
 const mPlus2 = M_PLUS_2({
   subsets: ['latin'],
+  display: 'swap',
   variable: '--font-m-plus-2',
+  // 'Yu Gothic UI' は 'Yu Gothic' より前に置く（後者は本文ウェイトが細りすぎる）
+  fallback: [
+    'Hiragino Sans',
+    'Hiragino Kaku Gothic ProN',
+    'Yu Gothic UI',
+    'Yu Gothic',
+    'Noto Sans CJK JP',
+    'sans-serif',
+  ],
 });
 
-const notoSansJp = Noto_Sans_JP({
-  subsets: ['latin'],
-  variable: '--font-noto-sans-jp',
-  display: 'optional',
-  fallback: ['system-ui', 'sans-serif'],
-});
-
-export { mPlus2, notoSansJp };
+export { mPlus2 };

--- a/apps/main/src/app/global-error.tsx
+++ b/apps/main/src/app/global-error.tsx
@@ -9,7 +9,7 @@ import { useEffect } from 'react';
 
 import { reportClientError } from '@/shared/browser/report-client-error';
 
-import { mPlus2, notoSansJp } from './_styles/font';
+import { mPlus2 } from './_styles/font';
 
 // root layout ごと失敗した場合のフォールバックなので、Provider に依存しない最小構成にする
 export default function GlobalError({
@@ -28,7 +28,6 @@ export default function GlobalError({
       <body
         className={cn(
           mPlus2.variable,
-          notoSansJp.variable,
           'bg-bg-surface font-m-plus-2 font-medium text-fg-base tracking-none antialiased',
         )}
       >

--- a/apps/main/src/app/layout.tsx
+++ b/apps/main/src/app/layout.tsx
@@ -12,7 +12,7 @@ import { GlobalLayout } from './_components/global-layout';
 import { ServiceWorkerRegister } from './_components/service-worker-register';
 import { TrustedTypesInit } from './_components/trusted-types-init';
 import { AppProvider } from './_providers/app';
-import { mPlus2, notoSansJp } from './_styles/font';
+import { mPlus2 } from './_styles/font';
 
 export const metadata = {
   metadataBase: new URL('https://k8o.me'),
@@ -59,7 +59,6 @@ export default function RootLayout({ children }: LayoutProps<'/'>) {
       <body
         className={cn(
           mPlus2.variable,
-          notoSansJp.variable,
           'bg-bg-surface font-m-plus-2 font-medium text-fg-base tracking-none antialiased',
         )}
       >

--- a/apps/main/src/mdx-components.tsx
+++ b/apps/main/src/mdx-components.tsx
@@ -84,7 +84,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         <p>{children}</p>
       ),
     p: ({ children }) => (
-      <p className="sm:text-md vertical:indent-em my-2 text-xs leading-normal">
+      <p className="sm:text-md vertical:indent-em my-2 text-sm leading-relaxed">
         {children}
       </p>
     ),
@@ -93,7 +93,7 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         return <Code>{children}</Code>;
       }
       return (
-        <code {...props} className="sm:text-md text-xs">
+        <code {...props} className="sm:text-md text-sm">
           {children}
         </code>
       );
@@ -106,14 +106,16 @@ export function useMDXComponents(components: MDXComponents): MDXComponents {
         {children}
       </pre>
     ),
-    li: ({ children }) => <li className="sm:text-md text-xs">{children}</li>,
+    li: ({ children }) => (
+      <li className="sm:text-md text-sm leading-relaxed">{children}</li>
+    ),
     ul: ({ children }) => (
-      <ul className="sm:text-md my-4 flex list-disc flex-col gap-1 ps-5 text-xs">
+      <ul className="sm:text-md my-4 flex list-disc flex-col gap-1 ps-5 text-sm">
         {children}
       </ul>
     ),
     ol: ({ children }) => (
-      <ol className="sm:text-md my-4 flex list-decimal flex-col gap-1 ps-5 text-xs">
+      <ol className="sm:text-md my-4 flex list-decimal flex-col gap-1 ps-5 text-sm">
         {children}
       </ol>
     ),


### PR DESCRIPTION
## 概要

ブログ本文（日本語 MDX）のフォント周りを整備する。本文サイズ・行間の可読性改善と、フォント読み込み／フォールバックの無駄解消を行う。

## 動機

- モバイルの本文が 12px と小さく、日本語長文の可読性が低かった
- 行間が 1.5（リストは 1.33）で詰まり気味かつ要素間で不揃いだった
- Noto Sans JP を読み込んでいたが本文・UI のどこでも未使用で、約 5MB 相当の死荷重になっていた
- M PLUS 2 にフォールバック連鎖が無く、未ロード時に和文 system フォントへ落ちる指定が無かった

## 詳細

- `mdx-components.tsx`: 本文 `p` / `li` / `ul` / `ol` / インライン外 `code` を `text-xs`(12px) → `text-sm`(14px) に引き上げ（PC = sm 以上は従来どおり 16px）。本文 `p` と `li` の行間を `leading-relaxed`(1.625) に統一。
- `font.ts`: 未使用の Noto Sans JP を削除。M PLUS 2 に `display: 'swap'` を明示し、和文 system フォールバック（`Hiragino Sans → Hiragino Kaku Gothic ProN → Yu Gothic UI → Yu Gothic → Noto Sans CJK JP → sans-serif`）を追加。
- `layout.tsx` / `global-error.tsx`: 不要になった `notoSansJp` の参照を除去。

## 気をつけるポイント・影響範囲

- 全ブログ記事の本文サイズ・行間が変わるため、VRT に広く差分が出る想定（意図どおり。承認の上ベースライン更新が必要）。
- body は引き続き `font-medium`(450)。本文 weight の 400 化は今回スコープ外。
- Windows 向けに `Yu Gothic UI` を `Yu Gothic` より前に置いている（後者は本文ウェイトが細りすぎるため）。

## テスト

- `pnpm -F main run type-check` と `vp check`（lint・format）が通過。
- ローカル dev でトップ・ブログ一覧・記事ページが 200 で表示され、本文に新クラス（`text-sm` / `leading-relaxed`）が反映されることを確認。

## 今回見送り（別途検討）

`size-adjust` によるフォールバック面の作り込み（和文では効果が限定的なため見送り）、本文 weight の 400 化、PC 18px 化、メタ情報(12px) の調整。

関連 Issue: #1042
