### PR TITLE
refactor(admin): Baseline 同期の型共有とキー順非依存の差分比較 (#1905 フォローアップ)

### DIFF
--- a/apps/admin/src/features/baseline/application/sync-baseline.ts
+++ b/apps/admin/src/features/baseline/application/sync-baseline.ts
@@ -1,10 +1,6 @@
 import { db } from '@repo/database';
+import type { BrowserImplementations } from '@repo/database/schema';
 import { eq } from 'drizzle-orm';
-
-type BrowserImplementations = Record<
-  string,
-  { version?: string; status?: string; date?: string }
->;
 
 type ApiFeature = {
   feature_id: string;
@@ -161,6 +157,19 @@ type SnapshotRow = {
   browserImplementations: BrowserImplementations | undefined;
 };
 
+// browser_implementations の差分検知はキー順に依存しないよう正規化して比較する。
+// DB 由来(JSON.parse)と webstatus API レスポンスでキー順が異なり得るため。
+const stableStringify = (value: unknown): string =>
+  JSON.stringify(value, (_key, v: unknown) =>
+    v !== null && typeof v === 'object' && !Array.isArray(v)
+      ? Object.fromEntries(
+          Object.entries(v as Record<string, unknown>).toSorted(([a], [b]) =>
+            a.localeCompare(b),
+          ),
+        )
+      : v,
+  );
+
 export async function syncBaseline(): Promise<SyncResult> {
   const [newlyFeatures, widelyFeatures] = await Promise.all([
     fetchAllFeatures('newly'),
@@ -201,8 +210,8 @@ export async function syncBaseline(): Promise<SyncResult> {
     const statusChanged = existing.status !== feature.status;
     // browser_implementations は status 変化が無くても更新され得るため差分で検知する。
     const implementationsChanged =
-      JSON.stringify(existing.browserImplementations ?? null) !==
-      JSON.stringify(row.browserImplementations ?? null);
+      stableStringify(existing.browserImplementations ?? null) !==
+      stableStringify(row.browserImplementations ?? null);
     if (statusChanged) {
       statusChanges.push({ feature, previousStatus: existing.status });
     }


### PR DESCRIPTION
## 概要

[#1905](https://github.com/k35o/k8o/pull/1905) のフォローアップ。マージ後に届いた k8o-bot の追加レビュー指摘 2 件（いずれも `apps/admin/src/features/baseline/application/sync-baseline.ts`）に対応する。

## 変更点

- 🔵 **`BrowserImplementations` 型の二重定義を解消** — `sync-baseline.ts` 内のローカル定義を削除し、`@repo/database/schema`（クライアント非依存の型エントリ）の同名型を import して一元化。将来 API 形状が変わっても修正箇所が 1 つで済む。
- 🔵 **`browser_implementations` の差分検知をキー順非依存に** — `JSON.stringify` の直接比較は DB 由来（`JSON.parse`）と webstatus API レスポンスでキー順が異なると、値が同じでも差分ありと誤判定し不要な UPDATE が走る。キーを再帰的にソートして正規化する `stableStringify` を導入して比較する。

## 検証

- `pnpm run check`（0 errors）、`pnpm -F admin run type-check`、`pnpm run test`（369 tests pass）すべてグリーン。

> 元 PR の bot inline コメントへの返信・スレッド解決は、リポジトリ規約（bot inline には返信しない／解決は人間判断）に従い行っていません。
