### PR TITLE
feat: adminでの更新をmainのキャッシュへ即時反映するrevalidate経路を追加

### DIFF
--- a/apps/admin/.env.example
+++ b/apps/admin/.env.example
@@ -10,3 +10,7 @@ BETTER_AUTH_URL=https://admin.k8o.localhost/
 LOCAL_AUTH_BYPASS=true
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
+# main のキャッシュ再検証エンドポイント（例: https://www.k8o.me/api/revalidate）。未設定なら呼び出しをスキップ
+MAIN_REVALIDATE_URL=
+# main 側 REVALIDATE_SECRET と同じ値
+REVALIDATE_SECRET=

--- a/apps/admin/src/features/blog/interface/actions.ts
+++ b/apps/admin/src/features/blog/interface/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 
 import type { ActionState } from '@/shared/actions/action-state';
 import { verifySession } from '@/shared/auth/verify-session';
+import { revalidateMainCache } from '@/shared/cache/revalidate-main';
 
 import { updateBlogPublished } from '../infrastructure/blog-repository';
 
@@ -19,6 +20,7 @@ export async function setBlogPublished(
     return { error: '公開状態の更新に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/blogs');
   revalidatePath('/');
   return { success: true };

--- a/apps/admin/src/features/slides/interface/actions.ts
+++ b/apps/admin/src/features/slides/interface/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 
 import type { ActionState } from '@/shared/actions/action-state';
 import { verifySession } from '@/shared/auth/verify-session';
+import { revalidateMainCache } from '@/shared/cache/revalidate-main';
 
 import { updateSlidePublished } from '../infrastructure/slide-repository';
 
@@ -19,6 +20,7 @@ export async function setSlidePublished(
     return { error: '公開状態の更新に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/slides');
   return { success: true };
 }

--- a/apps/admin/src/features/tags/interface/actions.ts
+++ b/apps/admin/src/features/tags/interface/actions.ts
@@ -4,6 +4,7 @@ import { revalidatePath } from 'next/cache';
 
 import type { ActionState } from '@/shared/actions/action-state';
 import { verifySession } from '@/shared/auth/verify-session';
+import { revalidateMainCache } from '@/shared/cache/revalidate-main';
 
 import {
   countTagUsage,
@@ -34,6 +35,7 @@ export async function createTag(
     return { error: 'タグの作成に失敗しました（重複の可能性があります）' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/tags');
   return { success: true };
 }
@@ -54,6 +56,7 @@ export async function renameTag(
     return { error: 'タグ名の更新に失敗しました（重複の可能性があります）' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/tags');
   return { success: true };
 }
@@ -72,6 +75,7 @@ export async function deleteTag(id: number): Promise<ActionState> {
     return { error: 'タグの削除に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/tags');
   return { success: true };
 }

--- a/apps/admin/src/features/talks/interface/actions.ts
+++ b/apps/admin/src/features/talks/interface/actions.ts
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation';
 
 import type { ActionState } from '@/shared/actions/action-state';
 import { verifySession } from '@/shared/auth/verify-session';
+import { revalidateMainCache } from '@/shared/cache/revalidate-main';
 
 import {
   deleteTalkById,
@@ -30,6 +31,7 @@ export async function createTalk(
     return { error: 'トークの作成に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/talks');
   return redirect('/talks');
 }
@@ -52,6 +54,7 @@ export async function updateTalk(
     return { error: 'トークの更新に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/talks');
   return redirect('/talks');
 }
@@ -65,6 +68,7 @@ export async function deleteTalk(id: number): Promise<ActionState> {
     return { error: 'トークの削除に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/talks');
   return { success: true };
 }

--- a/apps/admin/src/shared/cache/revalidate-main.ts
+++ b/apps/admin/src/shared/cache/revalidate-main.ts
@@ -28,6 +28,8 @@ export async function revalidateMainCache(): Promise<void> {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ tag: DB_CONTENT_CACHE_TAG }),
+      // main が無応答でも Server Action を Vercel 関数タイムアウトまで待たせない
+      signal: AbortSignal.timeout(5000),
     });
     if (!res.ok) {
       console.error(`mainの再検証に失敗しました: ${res.status}`);

--- a/apps/admin/src/shared/cache/revalidate-main.ts
+++ b/apps/admin/src/shared/cache/revalidate-main.ts
@@ -1,0 +1,38 @@
+// main 側の DB 由来キャッシュに付与している共通タグ
+// （apps/main/src/shared/cache/cache-tags.ts と揃える）。
+const DB_CONTENT_CACHE_TAG = 'db-content';
+
+// main は別デプロイのため revalidatePath では再検証できない。
+// secret 検証付きの main の /api/revalidate を叩いてタグを無効化する。
+// 失敗しても呼び出し元の Server Action は成功扱いのままにする。
+export async function revalidateMainCache(): Promise<void> {
+  const url = process.env['MAIN_REVALIDATE_URL'];
+  const secret = process.env['REVALIDATE_SECRET'];
+  if (
+    url === undefined ||
+    url === '' ||
+    secret === undefined ||
+    secret === ''
+  ) {
+    console.warn(
+      'MAIN_REVALIDATE_URL / REVALIDATE_SECRET が設定されていないため、mainの再検証をスキップしました',
+    );
+    return;
+  }
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${secret}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ tag: DB_CONTENT_CACHE_TAG }),
+    });
+    if (!res.ok) {
+      console.error(`mainの再検証に失敗しました: ${res.status}`);
+    }
+  } catch (error) {
+    console.error('mainの再検証に失敗しました:', error);
+  }
+}

--- a/apps/main/.env.example
+++ b/apps/main/.env.example
@@ -3,3 +3,5 @@ TURSO_AUTH_TOKEN=dummy
 NEXT_PUBLIC_GOOGLE_ANALYTICS_ID=
 GITHUB_TOKEN=
 VAPID_PUBLIC_KEY=
+# admin からの /api/revalidate 呼び出しを認可する共有 secret（未設定なら常に401）
+REVALIDATE_SECRET=

--- a/apps/main/AGENTS.md
+++ b/apps/main/AGENTS.md
@@ -45,6 +45,8 @@ Next.js の `cacheLife` は `features/*/interface` に置く。`app` のUIコン
 
 キャッシュを変更する Server Action / Route Handler は、更新対象の route に `revalidatePath` を明示する。
 
+admin の Server Action から更新されうる DB 由来のキャッシュ（talks / tags / blogs / slides の一覧・詳細）には `cacheTag('db-content')`（`@/shared/cache/cache-tags`）を付与する。admin は書き込み成功後に `/api/revalidate`（`REVALIDATE_SECRET` で認可）を叩いてこのタグを再検証する。
+
 ## TailwindCSS：ArteOdysseyカスタムトークンのみ使用
 
 ArteOdysseyのドキュメントは `apps/main/node_modules/@k8o/arte-odyssey/docs/` を参照すること。

--- a/apps/main/src/app/api/revalidate/route.test.ts
+++ b/apps/main/src/app/api/revalidate/route.test.ts
@@ -1,0 +1,139 @@
+import { revalidateTag } from 'next/cache';
+
+import { POST } from './route';
+
+vi.mock('next/cache', () => ({
+  revalidateTag: vi.fn(),
+}));
+
+const makeRequest = ({
+  authHeader,
+  body,
+}: {
+  authHeader?: string;
+  body?: string;
+}): Request =>
+  new Request('https://www.k8o.me/api/revalidate', {
+    method: 'POST',
+    headers: authHeader === undefined ? {} : { Authorization: authHeader },
+    body: body ?? null,
+  });
+
+describe('POST /api/revalidate', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.clearAllMocks();
+  });
+
+  describe('正常系', () => {
+    it('secret が一致すると revalidateTag を呼び 204 を返す', async () => {
+      vi.stubEnv('REVALIDATE_SECRET', 'super-secret');
+
+      const res = await POST(
+        makeRequest({
+          authHeader: 'Bearer super-secret',
+          body: JSON.stringify({ tag: 'db-content' }),
+        }),
+      );
+
+      expect(res.status).toBe(204);
+      expect(revalidateTag).toHaveBeenCalledWith('db-content', 'max');
+    });
+  });
+
+  describe('異常系', () => {
+    it('secret が不一致なら 401 を返し revalidateTag を呼ばない', async () => {
+      vi.stubEnv('REVALIDATE_SECRET', 'super-secret');
+
+      const res = await POST(
+        makeRequest({
+          authHeader: 'Bearer wrong',
+          body: JSON.stringify({ tag: 'db-content' }),
+        }),
+      );
+
+      expect(res.status).toBe(401);
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('Authorization ヘッダが無ければ 401 を返す', async () => {
+      vi.stubEnv('REVALIDATE_SECRET', 'super-secret');
+
+      const res = await POST(
+        makeRequest({ body: JSON.stringify({ tag: 'db-content' }) }),
+      );
+
+      expect(res.status).toBe(401);
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('REVALIDATE_SECRET 未設定なら常に 401 を返す', async () => {
+      vi.stubEnv('REVALIDATE_SECRET', undefined);
+
+      const res = await POST(
+        makeRequest({
+          authHeader: 'Bearer anything',
+          body: JSON.stringify({ tag: 'db-content' }),
+        }),
+      );
+
+      expect(res.status).toBe(401);
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('body が JSON でなければ 400 を返す', async () => {
+      vi.stubEnv('REVALIDATE_SECRET', 'super-secret');
+
+      const res = await POST(
+        makeRequest({ authHeader: 'Bearer super-secret', body: 'not-json' }),
+      );
+
+      expect(res.status).toBe(400);
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('tag が無い body は 400 を返す', async () => {
+      vi.stubEnv('REVALIDATE_SECRET', 'super-secret');
+
+      const res = await POST(
+        makeRequest({
+          authHeader: 'Bearer super-secret',
+          body: JSON.stringify({}),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('空文字の tag は 400 を返す', async () => {
+      vi.stubEnv('REVALIDATE_SECRET', 'super-secret');
+
+      const res = await POST(
+        makeRequest({
+          authHeader: 'Bearer super-secret',
+          body: JSON.stringify({ tag: '' }),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+
+    it('256文字を超える tag は 400 を返す', async () => {
+      vi.stubEnv('REVALIDATE_SECRET', 'super-secret');
+
+      const res = await POST(
+        makeRequest({
+          authHeader: 'Bearer super-secret',
+          body: JSON.stringify({ tag: 'a'.repeat(257) }),
+        }),
+      );
+
+      expect(res.status).toBe(400);
+      expect(revalidateTag).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/main/src/app/api/revalidate/route.ts
+++ b/apps/main/src/app/api/revalidate/route.ts
@@ -1,0 +1,30 @@
+import { revalidateTag } from 'next/cache';
+import * as z from 'zod/mini';
+
+import { isAuthorizedRevalidateRequest } from '@/shared/auth/verify-revalidate-request';
+
+const schema = z.object({
+  tag: z.string().check(z.minLength(1), z.maxLength(256)),
+});
+
+export async function POST(req: Request): Promise<Response> {
+  if (!isAuthorizedRevalidateRequest(req)) {
+    return new Response(null, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response(null, { status: 400 });
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return new Response(null, { status: 400 });
+  }
+
+  revalidateTag(parsed.data.tag, 'max');
+
+  return new Response(null, { status: 204 });
+}

--- a/apps/main/src/features/blog/interface/queries.ts
+++ b/apps/main/src/features/blog/interface/queries.ts
@@ -1,4 +1,4 @@
-import { cacheLife } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
 
 import {
   getBlogToc as _getBlogToc,
@@ -12,12 +12,14 @@ import {
 import { getFeatureBlogMap as _getFeatureBlogMap } from '@/features/blog/application/feature-blog-map';
 import { getBlogOgCode as _getBlogOgCode } from '@/features/blog/application/og-code';
 import { estimateReadingTimeMinutes } from '@/features/blog/application/reading-time';
+import { DB_CONTENT_CACHE_TAG } from '@/shared/cache/cache-tags';
 
 import { getMarkdown } from './markdown';
 
 export async function getBlogContents() {
   'use cache';
   cacheLife('max');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const blogs = await getBlogs();
   return Promise.all(
@@ -43,6 +45,7 @@ export async function getBlogContents() {
 export async function getBlogContent(slug: string) {
   'use cache';
   cacheLife('max');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const blog = await getBlog(slug);
   const metadata = await getBlogMetadata(slug);
@@ -78,6 +81,7 @@ export async function getBlogToc(slug: string) {
 export async function getBlogsByTags(slug: string) {
   'use cache';
   cacheLife('max');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const blog = await getBlogContent(slug);
   return _getBlogsByTags(
@@ -97,6 +101,7 @@ export async function getBlogReadingTime(slug: string): Promise<number> {
 export async function getFeatureBlogMap() {
   'use cache';
   cacheLife('max');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const featureBlogMap = await _getFeatureBlogMap();
   return featureBlogMap;

--- a/apps/main/src/features/slides/interface/queries.ts
+++ b/apps/main/src/features/slides/interface/queries.ts
@@ -1,14 +1,16 @@
-import { cacheLife } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
 
 import {
   getSlide,
   getSlideMetadata,
 } from '@/features/slides/application/slide';
 import { getSlides } from '@/features/slides/application/slides';
+import { DB_CONTENT_CACHE_TAG } from '@/shared/cache/cache-tags';
 
 export async function getSlideContents() {
   'use cache';
   cacheLife('max');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const slides = await getSlides();
   return Promise.all(
@@ -30,6 +32,7 @@ export async function getSlideContents() {
 export async function getSlideContent(slug: string) {
   'use cache';
   cacheLife('max');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const slide = await getSlide(slug);
   const metadata = await getSlideMetadata(slug);

--- a/apps/main/src/features/tags/interface/queries.ts
+++ b/apps/main/src/features/tags/interface/queries.ts
@@ -1,4 +1,6 @@
-import { cacheLife } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
+
+import { DB_CONTENT_CACHE_TAG } from '@/shared/cache/cache-tags';
 
 import { getTag as _getTag } from '../application/tag';
 import { getTags as _getTags } from '../application/tags';
@@ -6,6 +8,7 @@ import { getTags as _getTags } from '../application/tags';
 export async function getTags(page = 1) {
   'use cache';
   cacheLife('max');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const tags = await _getTags(page);
   return tags;
@@ -14,6 +17,7 @@ export async function getTags(page = 1) {
 export async function getTag(id: number) {
   'use cache';
   cacheLife('max');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const tag = await _getTag(id);
   return tag;

--- a/apps/main/src/features/talks/interface/queries.ts
+++ b/apps/main/src/features/talks/interface/queries.ts
@@ -1,10 +1,13 @@
-import { cacheLife } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
+
+import { DB_CONTENT_CACHE_TAG } from '@/shared/cache/cache-tags';
 
 import { getTalks as _getTalks } from '../application/talks';
 
 export async function getTalks() {
   'use cache';
   cacheLife('max');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const talks = await _getTalks();
   return talks;

--- a/apps/main/src/shared/auth/verify-revalidate-request.ts
+++ b/apps/main/src/shared/auth/verify-revalidate-request.ts
@@ -1,0 +1,23 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+
+// 文字列を固定長(32byte)のダイジェストに正規化する。
+// 長さの違いで timingSafeEqual が throw するのを避けつつ、
+// 入力長の差異から比較対象を推測されないようにする。
+const sha256 = (value: string): Buffer =>
+  createHash('sha256').update(value).digest();
+
+// `REVALIDATE_SECRET` 未設定時は常に不許可とし、比較はタイミング攻撃を避けるため
+// crypto.timingSafeEqual で定数時間比較する。
+export const isAuthorizedRevalidateRequest = (req: Request): boolean => {
+  const secret = process.env['REVALIDATE_SECRET'];
+  if (secret === undefined || secret === '') {
+    return false;
+  }
+
+  const authHeader = req.headers.get('Authorization');
+  if (authHeader === null) {
+    return false;
+  }
+
+  return timingSafeEqual(sha256(authHeader), sha256(`Bearer ${secret}`));
+};

--- a/apps/main/src/shared/cache/cache-tags.ts
+++ b/apps/main/src/shared/cache/cache-tags.ts
@@ -1,0 +1,3 @@
+// admin の Server Action から更新されうる DB 由来キャッシュの共通タグ。
+// admin 側は /api/revalidate 経由でこのタグを revalidateTag する。
+export const DB_CONTENT_CACHE_TAG = 'db-content';

--- a/turbo.json
+++ b/turbo.json
@@ -1,7 +1,13 @@
 {
   "$schema": "https://turborepo.com/schema.json",
   "globalEnv": ["NODE_ENV", "PORTLESS_URL", "VERCEL_ENV"],
-  "globalPassThroughEnv": ["CRON_SECRET", "GITHUB_TOKEN", "K8O_PUSH_API_KEY"],
+  "globalPassThroughEnv": [
+    "CRON_SECRET",
+    "GITHUB_TOKEN",
+    "K8O_PUSH_API_KEY",
+    "MAIN_REVALIDATE_URL",
+    "REVALIDATE_SECRET"
+  ],
   "tasks": {
     "dev": {
       "cache": false,


### PR DESCRIPTION
## 概要

DB 由来の `'use cache'` + `cacheLife('max')` クエリに `db-content` タグを付与し、admin の Server Action 成功後に main の新設 `/api/revalidate` を叩いて `revalidateTag` する経路を追加します。

## 動機

admin は別デプロイのため `revalidatePath` が main に効かず、トークの追加やブログの非公開化が main の再デプロイまで最長30日反映されませんでした（`cacheLife('max')`）。main/AGENTS.md の「'max' はビルド時に近い安定データ向け」という方針とも不整合でした。

## 詳細

- main: talks / tags / blog / slides の DB 由来キャッシュクエリに `cacheTag(DB_CONTENT_CACHE_TAG)` を付与。MDX 由来（ToC・読了時間等）はデプロイで更新されるため対象外。ネストされた `'use cache'`（feed / llms.txt / RecentBlogs）へはタグ伝播で波及
- main: `POST /api/revalidate` を新設。認可は既存の cron と同方式（Bearer + sha256 正規化 + timingSafeEqual、secret 未設定時は常に401）。`revalidateTag(tag, 'max')` を使用
- admin: 書き込み系 Server Action の成功後に `revalidateMainCache()` を呼ぶ共有ヘルパーを追加。呼び出し失敗は console.error のみでアクション自体は成功扱い
- turbo.json の `globalPassThroughEnv` と .env.example に `REVALIDATE_SECRET` / `MAIN_REVALIDATE_URL` を追加

## 気をつけるポイント

- **マージ後、Vercel の環境変数設定が必要です**: `REVALIDATE_SECRET`（main / admin 共通値）と `MAIN_REVALIDATE_URL`（admin 側、例 `https://www.k8o.me/api/revalidate`）。未設定でも console.warn してスキップするだけで壊れません
- `revalidate-main.ts` の fetch にタイムアウトを付けていません（main が無応答ハングした場合、admin のアクションが関数タイムアウトまで待つ）。フォローアップ候補
- タグ定数が main / admin に文字列リテラルで重複しています（コメントで対応を明記。helpers への共通化はフォローアップ候補）

## 影響範囲

main の talks / tags / blog / slides 表示のキャッシュ挙動、admin の書き込み系 Server Action 全般

## テスト

`/api/revalidate` の認可・入力検証分岐のユニットテスト8件。main / admin の type-check・check パス。統合チェックでフルスイート383件パス
