### PR TITLE
test: Web Push暗号・push配信・baseline同期・talkフォームのテストを追加

### DIFF
--- a/apps/admin/src/features/baseline/application/sync-baseline.test.ts
+++ b/apps/admin/src/features/baseline/application/sync-baseline.test.ts
@@ -1,0 +1,497 @@
+import { db } from '@repo/database';
+
+import {
+  stableStringify,
+  syncBaseline,
+  toBaselineFeature,
+} from './sync-baseline';
+
+vi.mock('@repo/database', () => ({
+  db: {
+    select: vi.fn(),
+    insert: vi.fn(),
+    transaction: vi.fn(),
+    _schema: {
+      baselineSnapshots: { featureId: 'feature_id' },
+      browserSupport: { browser: 'browser' },
+    },
+  },
+}));
+
+type FetchedFeature = {
+  feature_id: string;
+  name: string;
+  baseline: {
+    status: 'newly' | 'widely';
+    low_date: string;
+    high_date?: string;
+  };
+  browser_implementations?: Record<
+    string,
+    { version?: string; status?: string; date?: string }
+  >;
+};
+
+const apiFeature = (
+  overrides: Partial<FetchedFeature> = {},
+): FetchedFeature => ({
+  feature_id: 'grid',
+  name: 'Grid',
+  baseline: { status: 'newly', low_date: '2024-01-01' },
+  ...overrides,
+});
+
+const apiResponse = (
+  data: unknown[],
+  nextPageToken?: string,
+): { ok: boolean; json: () => Promise<unknown> } => ({
+  ok: true,
+  json: () =>
+    Promise.resolve({
+      data,
+      metadata: {
+        total: data.length,
+        ...(nextPageToken !== undefined && { next_page_token: nextPageToken }),
+      },
+    }),
+});
+
+const mockFetch = vi.fn<(input: string) => Promise<unknown>>();
+
+// fetch URL の q パラメータ(baseline_status)と page_token ごとに応答を切り替える。
+// 各 status にはページ単位の feature 配列を渡し、次ページがあれば
+// next_page_token(=次ページの添字)を返す。
+const respondByStatus = (responses: {
+  newly?: unknown[][];
+  widely?: unknown[][];
+}): void => {
+  mockFetch.mockImplementation((input: string) => {
+    const url = new URL(input);
+    const q = url.searchParams.get('q');
+    const pages =
+      (q === 'baseline_status:widely' ? responses.widely : responses.newly) ??
+      [];
+    const pageToken = url.searchParams.get('page_token');
+    const index = pageToken === null ? 0 : Number(pageToken);
+    const nextToken = index + 1 < pages.length ? String(index + 1) : undefined;
+    return Promise.resolve(apiResponse(pages[index] ?? [], nextToken));
+  });
+};
+
+const selectFromMock = vi.fn();
+const insertValuesMock = vi.fn();
+const txUpdateWhereMock = vi.fn();
+const txUpdateSetMock = vi.fn();
+const txOnConflictMock = vi.fn();
+const txInsertValuesMock = vi.fn();
+const tx = {
+  update: vi.fn(),
+  insert: vi.fn(),
+};
+
+describe('syncBaseline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockResolvedValue(apiResponse([]));
+
+    selectFromMock.mockResolvedValue([]);
+    vi.mocked(db.select).mockReturnValue({ from: selectFromMock } as never);
+    vi.mocked(db.insert).mockReturnValue({ values: insertValuesMock } as never);
+
+    txUpdateSetMock.mockReturnValue({ where: txUpdateWhereMock });
+    tx.update.mockReturnValue({ set: txUpdateSetMock });
+    txInsertValuesMock.mockReturnValue({
+      onConflictDoUpdate: txOnConflictMock,
+    });
+    tx.insert.mockReturnValue({ values: txInsertValuesMock });
+    vi.mocked(db.transaction).mockImplementation(((
+      callback: (t: typeof tx) => Promise<unknown>,
+    ) => callback(tx)) as never);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('正常系', () => {
+    it('新規 feature を insert に振り分ける', async () => {
+      respondByStatus({
+        newly: [
+          [
+            apiFeature({
+              browser_implementations: {
+                chrome: { version: '100', status: 'available' },
+              },
+            }),
+          ],
+        ],
+      });
+
+      const result = await syncBaseline();
+
+      expect(result.newFeatures).toEqual([
+        {
+          featureId: 'grid',
+          name: 'Grid',
+          status: 'newly',
+          date: '2024-01-01',
+        },
+      ]);
+      expect(result.statusChanges).toEqual([]);
+      expect(insertValuesMock).toHaveBeenCalledWith([
+        expect.objectContaining({
+          featureId: 'grid',
+          status: 'newly',
+          browserImplementations: {
+            chrome: { version: '100', status: 'available' },
+          },
+        }),
+      ]);
+      expect(tx.update).not.toHaveBeenCalled();
+    });
+
+    it('status 変化のみの feature を update に振り分ける', async () => {
+      const impl = { chrome: { version: '100', status: 'available' } };
+      selectFromMock.mockResolvedValue([
+        { featureId: 'grid', status: 'newly', browserImplementations: impl },
+      ]);
+      respondByStatus({
+        widely: [
+          [
+            apiFeature({
+              baseline: {
+                status: 'widely',
+                low_date: '2024-01-01',
+                high_date: '2026-07-01',
+              },
+              browser_implementations: impl,
+            }),
+          ],
+        ],
+      });
+
+      const result = await syncBaseline();
+
+      expect(result.newFeatures).toEqual([]);
+      expect(result.statusChanges).toEqual([
+        {
+          feature: {
+            featureId: 'grid',
+            name: 'Grid',
+            status: 'widely',
+            date: '2026-07-01',
+          },
+          previousStatus: 'newly',
+        },
+      ]);
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(tx.update).toHaveBeenCalledWith(db._schema.baselineSnapshots);
+      expect(txUpdateSetMock).toHaveBeenCalledWith(
+        expect.objectContaining({ status: 'widely', date: '2026-07-01' }),
+      );
+    });
+
+    it('browser_implementations のキー順違いだけなら差分なしとして更新しない', async () => {
+      selectFromMock.mockResolvedValue([
+        {
+          featureId: 'grid',
+          status: 'newly',
+          browserImplementations: {
+            firefox: { status: 'available', version: '90' },
+            chrome: { version: '100', status: 'available' },
+          },
+        },
+      ]);
+      respondByStatus({
+        newly: [
+          [
+            apiFeature({
+              browser_implementations: {
+                chrome: { status: 'available', version: '100' },
+                firefox: { version: '90', status: 'available' },
+              },
+            }),
+          ],
+        ],
+      });
+
+      const result = await syncBaseline();
+
+      expect(result.newFeatures).toEqual([]);
+      expect(result.statusChanges).toEqual([]);
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(tx.update).not.toHaveBeenCalled();
+    });
+
+    it('status 不変でも browser_implementations の内容が変われば update する', async () => {
+      selectFromMock.mockResolvedValue([
+        {
+          featureId: 'grid',
+          status: 'newly',
+          browserImplementations: {
+            chrome: { version: '100', status: 'available' },
+          },
+        },
+      ]);
+      respondByStatus({
+        newly: [
+          [
+            apiFeature({
+              browser_implementations: {
+                chrome: { version: '101', status: 'available' },
+              },
+            }),
+          ],
+        ],
+      });
+
+      const result = await syncBaseline();
+
+      expect(result.statusChanges).toEqual([]);
+      expect(tx.update).toHaveBeenCalledWith(db._schema.baselineSnapshots);
+      expect(txUpdateSetMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          browserImplementations: {
+            chrome: { version: '101', status: 'available' },
+          },
+        }),
+      );
+    });
+
+    it('全 feature から各ブラウザの最低対応版を browser_support へ upsert する', async () => {
+      respondByStatus({
+        newly: [
+          [
+            apiFeature({
+              feature_id: 'a',
+              browser_implementations: {
+                chrome: { version: '100', status: 'available' },
+                safari: { version: '17', status: 'available' },
+              },
+            }),
+          ],
+        ],
+        widely: [
+          [
+            apiFeature({
+              feature_id: 'b',
+              baseline: {
+                status: 'widely',
+                low_date: '2020-01-01',
+                high_date: '2023-01-01',
+              },
+              browser_implementations: {
+                chrome: { version: '111', status: 'available' },
+              },
+            }),
+          ],
+        ],
+      });
+
+      await syncBaseline();
+
+      expect(tx.insert).toHaveBeenCalledWith(db._schema.browserSupport);
+      expect(txInsertValuesMock).toHaveBeenCalledWith(
+        expect.objectContaining({ browser: 'chrome', version: '111' }),
+      );
+      expect(txInsertValuesMock).toHaveBeenCalledWith(
+        expect.objectContaining({ browser: 'safari', version: '17' }),
+      );
+      expect(txOnConflictMock).toHaveBeenCalledWith(
+        expect.objectContaining({ target: db._schema.browserSupport.browser }),
+      );
+    });
+
+    it('minVersions が算出できないときは browser_support を書き込まない', async () => {
+      // API 異常応答相当: browser_implementations が欠落した feature のみ
+      respondByStatus({ newly: [[apiFeature({ feature_id: 'a' })]] });
+      selectFromMock.mockResolvedValue([
+        { featureId: 'a', status: 'newly', browserImplementations: undefined },
+      ]);
+
+      await syncBaseline();
+
+      expect(tx.insert).not.toHaveBeenCalled();
+      expect(db.transaction).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異常系', () => {
+    it('API が HTTP エラーを返したら例外を投げる', async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+      await expect(syncBaseline()).rejects.toThrow('API error: 500');
+    });
+
+    it('data が配列でない応答を型ガードで拒否する', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: 'broken', metadata: { total: 0 } }),
+      });
+
+      await expect(syncBaseline()).rejects.toThrow(
+        /Invalid webstatus API response shape/u,
+      );
+    });
+
+    it('feature_id が無い feature を含む応答を拒否する', async () => {
+      mockFetch.mockResolvedValue(
+        apiResponse([
+          {
+            name: 'Grid',
+            baseline: { status: 'newly', low_date: '2024-01-01' },
+          },
+        ]),
+      );
+
+      await expect(syncBaseline()).rejects.toThrow(
+        /Invalid webstatus API response shape/u,
+      );
+    });
+
+    it('baseline.status が不正な feature を含む応答を拒否する', async () => {
+      mockFetch.mockResolvedValue(
+        apiResponse([
+          apiFeature({
+            baseline: {
+              status: 'limited' as never,
+              low_date: '2024-01-01',
+            },
+          }),
+        ]),
+      );
+
+      await expect(syncBaseline()).rejects.toThrow(
+        /Invalid webstatus API response shape/u,
+      );
+    });
+
+    it('metadata.total が数値でない応答を拒否する', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ data: [], metadata: { total: 'many' } }),
+      });
+
+      await expect(syncBaseline()).rejects.toThrow(
+        /Invalid webstatus API response shape/u,
+      );
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('next_page_token が続く限り取得し全ページの feature を結合する', async () => {
+      respondByStatus({
+        newly: [
+          [apiFeature({ feature_id: 'a', name: 'A' })],
+          [apiFeature({ feature_id: 'b', name: 'B' })],
+        ],
+      });
+
+      const result = await syncBaseline();
+
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(result.newFeatures.map((f) => f.featureId)).toEqual(['a', 'b']);
+    });
+
+    it('next_page_token が尽きなくても MAX_PAGES で打ち切る', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockFetch.mockResolvedValue(apiResponse([], 'next'));
+
+      const result = await syncBaseline();
+
+      // newly / widely それぞれ 50 ページで打ち切られる
+      expect(mockFetch).toHaveBeenCalledTimes(100);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('最大ページ数(50)に達しました'),
+      );
+      expect(result.newFeatures).toEqual([]);
+
+      warnSpy.mockRestore();
+    });
+  });
+});
+
+describe('toBaselineFeature', () => {
+  describe('正常系', () => {
+    it('widely かつ high_date があれば date に high_date を使う', () => {
+      const feature = toBaselineFeature({
+        feature_id: 'grid',
+        name: 'Grid',
+        baseline: {
+          status: 'widely',
+          low_date: '2020-01-01',
+          high_date: '2023-01-01',
+        },
+      });
+
+      expect(feature).toEqual({
+        featureId: 'grid',
+        name: 'Grid',
+        status: 'widely',
+        date: '2023-01-01',
+      });
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('widely でも high_date が無ければ low_date を使う', () => {
+      const feature = toBaselineFeature({
+        feature_id: 'grid',
+        name: 'Grid',
+        baseline: { status: 'widely', low_date: '2020-01-01' },
+      });
+
+      expect(feature.date).toBe('2020-01-01');
+    });
+
+    it('newly は high_date があっても low_date を使う', () => {
+      const feature = toBaselineFeature({
+        feature_id: 'grid',
+        name: 'Grid',
+        baseline: {
+          status: 'newly',
+          low_date: '2024-01-01',
+          high_date: '2026-07-01',
+        },
+      });
+
+      expect(feature.date).toBe('2024-01-01');
+    });
+  });
+});
+
+describe('stableStringify', () => {
+  describe('正常系', () => {
+    it('キー順が異なる同内容のオブジェクトを同じ文字列にする', () => {
+      const a = { chrome: { version: '100' }, firefox: { version: '90' } };
+      const b = { firefox: { version: '90' }, chrome: { version: '100' } };
+
+      expect(stableStringify(a)).toBe(stableStringify(b));
+    });
+
+    it('ネストしたオブジェクトのキー順も正規化する', () => {
+      const a = { chrome: { version: '100', status: 'available' } };
+      const b = { chrome: { status: 'available', version: '100' } };
+
+      expect(stableStringify(a)).toBe(stableStringify(b));
+    });
+
+    it('内容が異なるオブジェクトは異なる文字列になる', () => {
+      expect(stableStringify({ chrome: { version: '100' } })).not.toBe(
+        stableStringify({ chrome: { version: '101' } }),
+      );
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('配列の順序は保持する', () => {
+      expect(stableStringify([1, 2, 3])).toBe('[1,2,3]');
+      expect(stableStringify([1, 2, 3])).not.toBe(stableStringify([3, 2, 1]));
+    });
+
+    it('null をそのまま文字列化する', () => {
+      expect(stableStringify(null)).toBe('null');
+    });
+  });
+});

--- a/apps/admin/src/features/baseline/application/sync-baseline.ts
+++ b/apps/admin/src/features/baseline/application/sync-baseline.ts
@@ -140,7 +140,7 @@ const fetchAllFeatures = async (
   return features;
 };
 
-const toBaselineFeature = (feature: ApiFeature): BaselineFeature => ({
+export const toBaselineFeature = (feature: ApiFeature): BaselineFeature => ({
   featureId: feature.feature_id,
   name: feature.name,
   status: feature.baseline.status,
@@ -161,7 +161,7 @@ type SnapshotRow = {
 
 // browser_implementations の差分検知はキー順に依存しないよう正規化して比較する。
 // DB 由来(JSON.parse)と webstatus API レスポンスでキー順が異なり得るため。
-const stableStringify = (value: unknown): string =>
+export const stableStringify = (value: unknown): string =>
   JSON.stringify(value, (_key, v: unknown) =>
     v !== null && typeof v === 'object' && !Array.isArray(v)
       ? Object.fromEntries(

--- a/apps/admin/src/features/push-notification/infrastructure/push-notification.test.ts
+++ b/apps/admin/src/features/push-notification/infrastructure/push-notification.test.ts
@@ -1,0 +1,297 @@
+import { db } from '@repo/database';
+
+import { sendManualPush, sendPushNotification } from './push-notification';
+import { sendWebPush, WebPushError } from './web-push';
+
+vi.mock('./web-push', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('./web-push');
+  return { ...actual, sendWebPush: vi.fn() };
+});
+
+vi.mock('@repo/database', () => ({
+  db: {
+    query: {
+      pushSubscriptions: {
+        findMany: vi.fn(),
+      },
+    },
+    insert: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    _schema: {
+      pushLogs: { id: 'id', dedupeKey: 'dedupe_key' },
+      pushSubscriptions: { endpoint: 'endpoint' },
+    },
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((column: unknown, value: unknown) => ({ column, value })),
+  inArray: vi.fn((column: unknown, values: unknown) => ({ column, values })),
+}));
+
+const FCM_ENDPOINT = 'https://fcm.googleapis.com/fcm/send/abc';
+const MOZILLA_ENDPOINT = 'https://updates.push.services.mozilla.com/wpush/v2/x';
+const APPLE_ENDPOINT = 'https://web.push.apple.com/xyz';
+
+const subscription = (
+  endpoint: string,
+): { endpoint: string; p256dh: string; auth: string } => ({
+  endpoint,
+  p256dh: 'p256dh-key',
+  auth: 'auth-secret',
+});
+
+const notificationParams = {
+  kind: 'readings_updated' as const,
+  title: '新着記事',
+  body: '記事が追加されました',
+  url: 'https://k8o.me/readings',
+  dedupeKey: 'readings:2026-07-02',
+};
+
+const insertValuesMock = vi.fn();
+const insertReturningMock = vi.fn();
+const updateSetMock = vi.fn();
+const updateWhereMock = vi.fn();
+const deleteWhereMock = vi.fn();
+
+describe('sendPushNotification', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('VAPID_PUBLIC_KEY', 'vapid-public');
+    vi.stubEnv('VAPID_PRIVATE_KEY', 'vapid-private');
+    vi.stubEnv('VAPID_SUBJECT', 'mailto:admin@example.com');
+
+    insertReturningMock.mockResolvedValue([{ id: 10 }]);
+    insertValuesMock.mockReturnValue({
+      onConflictDoNothing: vi
+        .fn()
+        .mockReturnValue({ returning: insertReturningMock }),
+    });
+    vi.mocked(db.insert).mockReturnValue({ values: insertValuesMock } as never);
+
+    updateSetMock.mockReturnValue({ where: updateWhereMock });
+    vi.mocked(db.update).mockReturnValue({ set: updateSetMock } as never);
+
+    vi.mocked(db.delete).mockReturnValue({ where: deleteWhereMock } as never);
+
+    vi.mocked(db.query.pushSubscriptions.findMany).mockResolvedValue([]);
+    vi.mocked(sendWebPush).mockResolvedValue(new Response());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('正常系', () => {
+    it('claim に成功したら全購読へ送信し succeeded/failed を記録する', async () => {
+      vi.mocked(db.query.pushSubscriptions.findMany).mockResolvedValue([
+        subscription(FCM_ENDPOINT),
+        subscription(MOZILLA_ENDPOINT),
+      ] as never);
+
+      await sendPushNotification(notificationParams);
+
+      expect(insertValuesMock).toHaveBeenCalledWith({
+        kind: 'readings_updated',
+        title: '新着記事',
+        body: '記事が追加されました',
+        url: 'https://k8o.me/readings',
+        dedupeKey: 'readings:2026-07-02',
+        succeeded: 0,
+        failed: 0,
+      });
+      expect(sendWebPush).toHaveBeenCalledTimes(2);
+      expect(sendWebPush).toHaveBeenCalledWith(
+        {
+          endpoint: FCM_ENDPOINT,
+          keys: { p256dh: 'p256dh-key', auth: 'auth-secret' },
+        },
+        JSON.stringify({
+          title: '新着記事',
+          body: '記事が追加されました',
+          url: 'https://k8o.me/readings',
+        }),
+        {
+          vapidPublicKey: 'vapid-public',
+          vapidPrivateKey: 'vapid-private',
+          vapidSubject: 'mailto:admin@example.com',
+        },
+      );
+      expect(updateSetMock).toHaveBeenCalledWith({ succeeded: 2, failed: 0 });
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('送信失敗した購読は failed として集計する', async () => {
+      vi.mocked(db.query.pushSubscriptions.findMany).mockResolvedValue([
+        subscription(FCM_ENDPOINT),
+        subscription(MOZILLA_ENDPOINT),
+      ] as never);
+      vi.mocked(sendWebPush)
+        .mockRejectedValueOnce(new WebPushError(500, 'Server error'))
+        .mockResolvedValueOnce(new Response());
+
+      await sendPushNotification(notificationParams);
+
+      expect(updateSetMock).toHaveBeenCalledWith({ succeeded: 1, failed: 1 });
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+
+    it('404/410 を返した endpoint の購読レコードだけ削除する', async () => {
+      vi.mocked(db.query.pushSubscriptions.findMany).mockResolvedValue([
+        subscription(FCM_ENDPOINT),
+        subscription(MOZILLA_ENDPOINT),
+        subscription(APPLE_ENDPOINT),
+      ] as never);
+      vi.mocked(sendWebPush)
+        .mockRejectedValueOnce(new WebPushError(410, 'Gone'))
+        .mockRejectedValueOnce(new WebPushError(404, 'Not Found'))
+        .mockResolvedValueOnce(new Response());
+
+      await sendPushNotification(notificationParams);
+
+      expect(updateSetMock).toHaveBeenCalledWith({ succeeded: 1, failed: 2 });
+      expect(db.delete).toHaveBeenCalledTimes(1);
+      expect(deleteWhereMock).toHaveBeenCalledWith({
+        column: db._schema.pushSubscriptions.endpoint,
+        values: [FCM_ENDPOINT, MOZILLA_ENDPOINT],
+      });
+    });
+
+    it('WebPushError 以外のエラーは failed に数えるが購読は削除しない', async () => {
+      vi.mocked(db.query.pushSubscriptions.findMany).mockResolvedValue([
+        subscription(FCM_ENDPOINT),
+      ] as never);
+      vi.mocked(sendWebPush).mockRejectedValue(new Error('network error'));
+
+      await sendPushNotification(notificationParams);
+
+      expect(updateSetMock).toHaveBeenCalledWith({ succeeded: 0, failed: 1 });
+      expect(db.delete).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('dedupe', () => {
+    it('既に claim 済み(dedupeKey 重複)なら送信しない', async () => {
+      insertReturningMock.mockResolvedValue([]);
+
+      await sendPushNotification(notificationParams);
+
+      expect(db.query.pushSubscriptions.findMany).not.toHaveBeenCalled();
+      expect(sendWebPush).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('異常系', () => {
+    it('VAPID 環境変数が未設定なら警告して何もしない', async () => {
+      vi.stubEnv('VAPID_PRIVATE_KEY', '');
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      await sendPushNotification(notificationParams);
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        'VAPID 環境変数が設定されていません',
+      );
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(sendWebPush).not.toHaveBeenCalled();
+
+      warnSpy.mockRestore();
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('allowlist 外の endpoint には送信せず集計にも含めない', async () => {
+      vi.mocked(db.query.pushSubscriptions.findMany).mockResolvedValue([
+        subscription('https://evil.example.com/push'),
+        subscription(FCM_ENDPOINT),
+      ] as never);
+
+      await sendPushNotification(notificationParams);
+
+      expect(sendWebPush).toHaveBeenCalledTimes(1);
+      expect(sendWebPush).toHaveBeenCalledWith(
+        expect.objectContaining({ endpoint: FCM_ENDPOINT }),
+        expect.any(String),
+        expect.any(Object),
+      );
+      expect(updateSetMock).toHaveBeenCalledWith({ succeeded: 1, failed: 0 });
+    });
+
+    it('購読が1件も無ければ succeeded/failed を 0 で記録する', async () => {
+      await sendPushNotification(notificationParams);
+
+      expect(sendWebPush).not.toHaveBeenCalled();
+      expect(updateSetMock).toHaveBeenCalledWith({ succeeded: 0, failed: 0 });
+    });
+  });
+});
+
+describe('sendManualPush', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('VAPID_PUBLIC_KEY', 'vapid-public');
+    vi.stubEnv('VAPID_PRIVATE_KEY', 'vapid-private');
+    vi.stubEnv('VAPID_SUBJECT', 'mailto:admin@example.com');
+
+    vi.mocked(db.delete).mockReturnValue({ where: deleteWhereMock } as never);
+    vi.mocked(db.query.pushSubscriptions.findMany).mockResolvedValue([]);
+    vi.mocked(sendWebPush).mockResolvedValue(new Response());
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('正常系', () => {
+    it('集計を返し push_logs には記録しない', async () => {
+      vi.mocked(db.query.pushSubscriptions.findMany).mockResolvedValue([
+        subscription(FCM_ENDPOINT),
+        subscription(MOZILLA_ENDPOINT),
+      ] as never);
+      vi.mocked(sendWebPush)
+        .mockResolvedValueOnce(new Response())
+        .mockRejectedValueOnce(new WebPushError(500, 'Server error'));
+
+      const result = await sendManualPush({
+        title: '手動通知',
+        body: 'テスト',
+        url: 'https://k8o.me',
+      });
+
+      expect(result).toEqual({ succeeded: 1, failed: 1 });
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
+    });
+
+    it('410 を返した endpoint の購読レコードを削除する', async () => {
+      vi.mocked(db.query.pushSubscriptions.findMany).mockResolvedValue([
+        subscription(FCM_ENDPOINT),
+      ] as never);
+      vi.mocked(sendWebPush).mockRejectedValue(new WebPushError(410, 'Gone'));
+
+      const result = await sendManualPush({
+        title: '手動通知',
+        body: 'テスト',
+        url: 'https://k8o.me',
+      });
+
+      expect(result).toEqual({ succeeded: 0, failed: 1 });
+      expect(deleteWhereMock).toHaveBeenCalledWith({
+        column: db._schema.pushSubscriptions.endpoint,
+        values: [FCM_ENDPOINT],
+      });
+    });
+  });
+
+  describe('異常系', () => {
+    it('VAPID 環境変数が未設定なら例外を投げる', async () => {
+      vi.stubEnv('VAPID_SUBJECT', '');
+
+      await expect(
+        sendManualPush({ title: 't', body: 'b', url: 'https://k8o.me' }),
+      ).rejects.toThrow('VAPID 環境変数が設定されていません');
+    });
+  });
+});

--- a/apps/admin/src/features/push-notification/infrastructure/web-push.test.ts
+++ b/apps/admin/src/features/push-notification/infrastructure/web-push.test.ts
@@ -1,0 +1,517 @@
+import { Buffer } from 'node:buffer';
+
+import {
+  base64UrlDecode,
+  base64UrlEncode,
+  base64UrlEncodeBytes,
+  buildEncryptedBody,
+  sendWebPush,
+  WebPushError,
+} from './web-push';
+
+// RFC 8291 Appendix A / Section 5 のテストベクタ
+const RFC8291_AS_PUBLIC =
+  'BP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A8';
+const RFC8291_AS_PRIVATE = 'yfWPiYE-n46HLnH0KqZOF1fJJU3MYrct3AELtAQ-oRw';
+const RFC8291_UA_PUBLIC =
+  'BCVxsr7N_eNgVRqvHtD0zTZsEc6-VV-JvLexhqUzORcxaOzi6-AYWXvTBHm4bjyPjs7Vd8pZGH6SRpkNtoIAiw4';
+const RFC8291_SALT = 'DGv6ra1nlYgDCS1FRnbzlw';
+const RFC8291_AUTH_SECRET = 'BTBZMqHH6r4Tts7J_aSIgg';
+const RFC8291_PLAINTEXT = 'When I grow up, I want to be a watermelon';
+const RFC8291_ENCRYPTED_MESSAGE =
+  'DGv6ra1nlYgDCS1FRnbzlwAAEABBBP4z9KsN6nGRTbVYI_c7VJSPQTBtkgcy27mlmlMoZIIgDll6e3vCYLocInmYWAmS6TlzAC8wEqKK6PBru3jl7A_yl95bQpu6cVPTpK4Mqgkf1CXztLVBSt2Ks3oZwbuwXPXLWyouBWLVWGNWQexSgSxsj_Qulcy4a-fN';
+
+const fromB64Url = (value: string): Uint8Array<ArrayBuffer> =>
+  new Uint8Array(Buffer.from(value, 'base64url'));
+
+const toB64Url = (bytes: Uint8Array): string =>
+  Buffer.from(bytes).toString('base64url');
+
+const utf8 = (str: string): Uint8Array<ArrayBuffer> =>
+  new Uint8Array(new TextEncoder().encode(str));
+
+const concatBytes = (
+  ...arrays: Array<Uint8Array<ArrayBuffer>>
+): Uint8Array<ArrayBuffer> => {
+  const result = new Uint8Array(
+    arrays.reduce((sum, arr) => sum + arr.length, 0),
+  );
+  let offset = 0;
+  for (const arr of arrays) {
+    result.set(arr, offset);
+    offset += arr.length;
+  }
+  return result;
+};
+
+const ensureKeyPair = (key: CryptoKey | CryptoKeyPair): CryptoKeyPair => {
+  if ('privateKey' in key && 'publicKey' in key) {
+    return key;
+  }
+  throw new Error('CryptoKeyPair を期待しています');
+};
+
+type ClientKeys = {
+  keyPair: CryptoKeyPair;
+  publicKeyRaw: Uint8Array<ArrayBuffer>;
+  authSecret: Uint8Array<ArrayBuffer>;
+  subscriptionKeys: { p256dh: string; auth: string };
+};
+
+const generateClientKeys = async (): Promise<ClientKeys> => {
+  const keyPair = ensureKeyPair(
+    await crypto.subtle.generateKey(
+      { name: 'ECDH', namedCurve: 'P-256' },
+      true,
+      ['deriveBits'],
+    ),
+  );
+  const publicKeyRaw = new Uint8Array(
+    await crypto.subtle.exportKey('raw', keyPair.publicKey),
+  );
+  const authSecret = crypto.getRandomValues(new Uint8Array(16));
+  return {
+    keyPair,
+    publicKeyRaw,
+    authSecret,
+    subscriptionKeys: {
+      p256dh: toB64Url(publicKeyRaw),
+      auth: toB64Url(authSecret),
+    },
+  };
+};
+
+type VapidKeys = {
+  publicKey: string;
+  privateKey: string;
+  verifyKey: CryptoKey;
+};
+
+const generateVapidKeys = async (): Promise<VapidKeys> => {
+  const keyPair = ensureKeyPair(
+    await crypto.subtle.generateKey(
+      { name: 'ECDSA', namedCurve: 'P-256' },
+      true,
+      ['sign', 'verify'],
+    ),
+  );
+  const publicKeyRaw = new Uint8Array(
+    await crypto.subtle.exportKey('raw', keyPair.publicKey),
+  );
+  const jwk = await crypto.subtle.exportKey('jwk', keyPair.privateKey);
+  if (jwk.d === undefined) {
+    throw new Error('JWK の d が取得できません');
+  }
+  return {
+    publicKey: toB64Url(publicKeyRaw),
+    privateKey: jwk.d,
+    verifyKey: keyPair.publicKey,
+  };
+};
+
+// テスト側は WebCrypto ネイティブの HKDF を使い、実装側(HMAC 手組み)と独立させる
+const hkdfDerive = async (
+  salt: Uint8Array<ArrayBuffer>,
+  ikm: Uint8Array<ArrayBuffer>,
+  info: Uint8Array<ArrayBuffer>,
+  bits: number,
+): Promise<Uint8Array<ArrayBuffer>> => {
+  const key = await crypto.subtle.importKey('raw', ikm, 'HKDF', false, [
+    'deriveBits',
+  ]);
+  return new Uint8Array(
+    await crypto.subtle.deriveBits(
+      { name: 'HKDF', hash: 'SHA-256', salt, info },
+      key,
+      bits,
+    ),
+  );
+};
+
+// RFC 8291 の受信側手順で aes128gcm ボディを復号する
+const decryptBody = async (
+  body: Uint8Array<ArrayBuffer>,
+  client: ClientKeys,
+): Promise<string> => {
+  const salt = body.slice(0, 16);
+  const asPublicRaw = body.slice(21, 86);
+  const ciphertext = body.slice(86);
+
+  const asPublicKey = await crypto.subtle.importKey(
+    'raw',
+    asPublicRaw,
+    { name: 'ECDH', namedCurve: 'P-256' },
+    false,
+    [],
+  );
+  const sharedSecret = new Uint8Array(
+    await crypto.subtle.deriveBits(
+      { name: 'ECDH', public: asPublicKey },
+      client.keyPair.privateKey,
+      256,
+    ),
+  );
+
+  const info = concatBytes(
+    utf8('WebPush: info\0'),
+    client.publicKeyRaw,
+    asPublicRaw,
+  );
+  const ikm = await hkdfDerive(client.authSecret, sharedSecret, info, 256);
+  const cek = await hkdfDerive(
+    salt,
+    ikm,
+    utf8('Content-Encoding: aes128gcm\0'),
+    128,
+  );
+  const nonce = await hkdfDerive(
+    salt,
+    ikm,
+    utf8('Content-Encoding: nonce\0'),
+    96,
+  );
+
+  const key = await crypto.subtle.importKey(
+    'raw',
+    cek,
+    { name: 'AES-GCM' },
+    false,
+    ['decrypt'],
+  );
+  const padded = new Uint8Array(
+    await crypto.subtle.decrypt(
+      { name: 'AES-GCM', iv: nonce },
+      key,
+      ciphertext,
+    ),
+  );
+
+  expect(padded.at(-1)).toBe(2);
+  return new TextDecoder().decode(padded.slice(0, -1));
+};
+
+type VapidAuthorization = {
+  key: string;
+  headerB64: string;
+  payloadB64: string;
+  signatureB64: string;
+};
+
+const parseVapidAuthorization = (
+  header: string | undefined,
+): VapidAuthorization => {
+  const match = /^vapid t=(?<token>[^,]+), k=(?<key>.+)$/u.exec(header ?? '');
+  const key = match?.groups?.['key'];
+  const [headerB64, payloadB64, signatureB64] = (
+    match?.groups?.['token'] ?? ''
+  ).split('.');
+  if (
+    key === undefined ||
+    headerB64 === undefined ||
+    payloadB64 === undefined ||
+    signatureB64 === undefined
+  ) {
+    throw new Error('Authorization ヘッダが VAPID 形式ではありません');
+  }
+  return { key, headerB64, payloadB64, signatureB64 };
+};
+
+const mockFetch = vi.fn() as ReturnType<typeof vi.fn>;
+
+type CapturedRequest = {
+  url: string;
+  headers: Record<string, string>;
+  body: Uint8Array<ArrayBuffer>;
+  init: RequestInit;
+};
+
+const capturedRequest = (): CapturedRequest => {
+  const call = mockFetch.mock.calls.at(0) as
+    | [string, RequestInit & { body: Uint8Array<ArrayBuffer> }]
+    | undefined;
+  if (call === undefined) {
+    throw new Error('fetch が呼ばれていません');
+  }
+  return {
+    url: call[0],
+    headers: call[1].headers as Record<string, string>,
+    body: call[1].body,
+    init: call[1],
+  };
+};
+
+describe('base64UrlDecode', () => {
+  describe('正常系', () => {
+    it('base64url 文字列をバイト列に復号する', () => {
+      expect(base64UrlDecode('AQID')).toEqual(Uint8Array.from([1, 2, 3]));
+    });
+
+    it('URL セーフ文字(-/_)を + と / として扱う', () => {
+      expect(base64UrlDecode('-_8')).toEqual(Uint8Array.from([251, 255]));
+    });
+
+    it('パディング無しの文字列を復号する', () => {
+      expect(base64UrlDecode('YQ')).toEqual(Uint8Array.from([97]));
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('空文字列は空のバイト列になる', () => {
+      expect(base64UrlDecode('')).toEqual(new Uint8Array(0));
+    });
+
+    it('encode したバイト列を decode すると元に戻る', () => {
+      const bytes = Uint8Array.from([0, 1, 62, 63, 127, 128, 254, 255]);
+      expect(base64UrlDecode(base64UrlEncodeBytes(bytes))).toEqual(bytes);
+    });
+  });
+});
+
+describe('base64UrlEncode / base64UrlEncodeBytes', () => {
+  describe('正常系', () => {
+    it('文字列を URL セーフな base64 に符号化する', () => {
+      expect(base64UrlEncode('>>>')).toBe('Pj4-');
+    });
+
+    it('パディングの = を出力しない', () => {
+      expect(base64UrlEncode('a')).toBe('YQ');
+    });
+
+    it('バイト列の符号化結果が Node の base64url と一致する', () => {
+      const bytes = Uint8Array.from([251, 255, 0, 62]);
+      expect(base64UrlEncodeBytes(bytes)).toBe(toB64Url(bytes));
+    });
+  });
+});
+
+describe('buildEncryptedBody', () => {
+  describe('正常系', () => {
+    it('salt / rs / idlen / 公開鍵 / 暗号文の順に連結する', () => {
+      const salt = Uint8Array.from({ length: 16 }, (_, i) => i);
+      const publicKey = new Uint8Array(65).fill(0xaa);
+      const encrypted = Uint8Array.from([9, 8, 7]);
+
+      const body = buildEncryptedBody(publicKey, { encrypted, salt });
+
+      expect(body).toHaveLength(16 + 4 + 1 + 65 + 3);
+      expect(body.slice(0, 16)).toEqual(salt);
+      // rs は 4096 のビッグエンディアン
+      expect(body.slice(16, 20)).toEqual(Uint8Array.from([0, 0, 16, 0]));
+      // idlen は P-256 公開鍵長の 65
+      expect(body[20]).toBe(65);
+      expect(body.slice(21, 86)).toEqual(publicKey);
+      expect(body.slice(86)).toEqual(encrypted);
+    });
+  });
+});
+
+describe('sendWebPush', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 201,
+      text: () => Promise.resolve(''),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('正常系', () => {
+    it('送信ボディを RFC 8291 の受信手順で復号すると元の payload に一致する', async () => {
+      const client = await generateClientKeys();
+      const vapid = await generateVapidKeys();
+      const payload = JSON.stringify({
+        title: '新着記事',
+        body: 'テスト通知です',
+      });
+
+      await sendWebPush(
+        {
+          endpoint: 'https://push.example.net/push/abc',
+          keys: client.subscriptionKeys,
+        },
+        payload,
+        {
+          vapidPublicKey: vapid.publicKey,
+          vapidPrivateKey: vapid.privateKey,
+          vapidSubject: 'mailto:admin@example.com',
+        },
+      );
+
+      const { body } = capturedRequest();
+      await expect(decryptBody(body, client)).resolves.toBe(payload);
+    });
+
+    it('aes128gcm のヘッダを付けて endpoint に POST する', async () => {
+      const client = await generateClientKeys();
+      const vapid = await generateVapidKeys();
+
+      await sendWebPush(
+        {
+          endpoint: 'https://push.example.net/push/abc',
+          keys: client.subscriptionKeys,
+        },
+        'hello',
+        {
+          vapidPublicKey: vapid.publicKey,
+          vapidPrivateKey: vapid.privateKey,
+          vapidSubject: 'mailto:admin@example.com',
+        },
+      );
+
+      const { url, headers, body, init } = capturedRequest();
+      expect(url).toBe('https://push.example.net/push/abc');
+      expect(init.method).toBe('POST');
+      expect(init.redirect).toBe('manual');
+      expect(headers['Content-Type']).toBe('application/octet-stream');
+      expect(headers['Content-Encoding']).toBe('aes128gcm');
+      expect(headers['TTL']).toBe('86400');
+      // RFC 8188 ヘッダ: rs=4096(BE) と idlen=65
+      expect(body.slice(16, 20)).toEqual(Uint8Array.from([0, 0, 16, 0]));
+      expect(body[20]).toBe(65);
+    });
+
+    it('VAPID の JWT が公開鍵で検証でき aud/exp/sub が正しい', async () => {
+      const client = await generateClientKeys();
+      const vapid = await generateVapidKeys();
+
+      await sendWebPush(
+        {
+          endpoint: 'https://fcm.googleapis.com/fcm/send/xyz',
+          keys: client.subscriptionKeys,
+        },
+        'hello',
+        {
+          vapidPublicKey: vapid.publicKey,
+          vapidPrivateKey: vapid.privateKey,
+          vapidSubject: 'mailto:admin@example.com',
+        },
+      );
+
+      const { headers } = capturedRequest();
+      expect(headers['Crypto-Key']).toBe(`p256ecdsa=${vapid.publicKey}`);
+
+      const { key, headerB64, payloadB64, signatureB64 } =
+        parseVapidAuthorization(headers['Authorization']);
+      expect(key).toBe(vapid.publicKey);
+
+      const header: unknown = JSON.parse(
+        new TextDecoder().decode(fromB64Url(headerB64)),
+      );
+      expect(header).toEqual({ typ: 'JWT', alg: 'ES256' });
+
+      const claims = JSON.parse(
+        new TextDecoder().decode(fromB64Url(payloadB64)),
+      ) as { aud: string; exp: number; sub: string };
+      expect(claims.aud).toBe('https://fcm.googleapis.com');
+      expect(claims.sub).toBe('mailto:admin@example.com');
+      const nowSec = Math.floor(Date.now() / 1000);
+      expect(claims.exp).toBeGreaterThan(nowSec);
+      expect(claims.exp).toBeLessThanOrEqual(nowSec + 12 * 60 * 60);
+
+      const valid = await crypto.subtle.verify(
+        { name: 'ECDSA', hash: 'SHA-256' },
+        vapid.verifyKey,
+        fromB64Url(signatureB64),
+        utf8(`${headerB64}.${payloadB64}`),
+      );
+      expect(valid).toBe(true);
+    });
+
+    it('RFC 8291 Appendix A のテストベクタと同じ暗号文を生成する', async () => {
+      const realSubtle = crypto.subtle;
+      const asPublicRaw = fromB64Url(RFC8291_AS_PUBLIC);
+      const asJwk = {
+        kty: 'EC',
+        crv: 'P-256',
+        x: toB64Url(asPublicRaw.slice(1, 33)),
+        y: toB64Url(asPublicRaw.slice(33, 65)),
+      };
+      const asPrivateKey = await realSubtle.importKey(
+        'jwk',
+        { ...asJwk, d: RFC8291_AS_PRIVATE },
+        { name: 'ECDH', namedCurve: 'P-256' },
+        false,
+        ['deriveBits'],
+      );
+      const asPublicKey = await realSubtle.importKey(
+        'jwk',
+        asJwk,
+        { name: 'ECDH', namedCurve: 'P-256' },
+        true,
+        [],
+      );
+
+      // 鍵ペアと salt を RFC のテストベクタに固定する
+      vi.stubGlobal('crypto', {
+        getRandomValues: <T extends ArrayBufferView>(array: T): T => {
+          new Uint8Array(array.buffer, array.byteOffset, array.byteLength).set(
+            fromB64Url(RFC8291_SALT),
+          );
+          return array;
+        },
+        subtle: {
+          generateKey: () =>
+            Promise.resolve({
+              privateKey: asPrivateKey,
+              publicKey: asPublicKey,
+            }),
+          importKey: realSubtle.importKey.bind(realSubtle),
+          deriveBits: realSubtle.deriveBits.bind(realSubtle),
+          exportKey: realSubtle.exportKey.bind(realSubtle),
+          encrypt: realSubtle.encrypt.bind(realSubtle),
+          sign: realSubtle.sign.bind(realSubtle),
+        },
+      });
+
+      await sendWebPush(
+        {
+          endpoint:
+            'https://push.example.net/push/JzLQ3raZJfFBR0aqvOMsLrt54w4rJUsV',
+          keys: { p256dh: RFC8291_UA_PUBLIC, auth: RFC8291_AUTH_SECRET },
+        },
+        RFC8291_PLAINTEXT,
+        {
+          vapidPublicKey: RFC8291_AS_PUBLIC,
+          vapidPrivateKey: RFC8291_AS_PRIVATE,
+          vapidSubject: 'mailto:admin@example.com',
+        },
+      );
+
+      const { body } = capturedRequest();
+      expect(toB64Url(body)).toBe(RFC8291_ENCRYPTED_MESSAGE);
+    });
+  });
+
+  describe('異常系', () => {
+    it('push サービスがエラー応答を返したら status 付きの WebPushError を投げる', async () => {
+      const client = await generateClientKeys();
+      const vapid = await generateVapidKeys();
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 410,
+        text: () => Promise.resolve('Gone'),
+      });
+
+      const promise = sendWebPush(
+        {
+          endpoint: 'https://push.example.net/push/abc',
+          keys: client.subscriptionKeys,
+        },
+        'hello',
+        {
+          vapidPublicKey: vapid.publicKey,
+          vapidPrivateKey: vapid.privateKey,
+          vapidSubject: 'mailto:admin@example.com',
+        },
+      );
+
+      await expect(promise).rejects.toThrow(WebPushError);
+      await expect(promise).rejects.toMatchObject({ status: 410 });
+    });
+  });
+});

--- a/apps/admin/src/features/push-notification/infrastructure/web-push.test.ts
+++ b/apps/admin/src/features/push-notification/infrastructure/web-push.test.ts
@@ -128,6 +128,9 @@ const hkdfDerive = async (
   );
 };
 
+// RFC 8188: 最終レコード末尾に置くパディングデリミタ
+const RECORD_PADDING_DELIMITER = 2;
+
 // RFC 8291 の受信側手順で aes128gcm ボディを復号する
 const decryptBody = async (
   body: Uint8Array<ArrayBuffer>,
@@ -186,7 +189,12 @@ const decryptBody = async (
     ),
   );
 
-  expect(padded.at(-1)).toBe(2);
+  const delimiter = padded.at(-1);
+  if (delimiter !== RECORD_PADDING_DELIMITER) {
+    throw new Error(
+      `復号結果の末尾が RFC 8188 のパディングデリミタ(${RECORD_PADDING_DELIMITER})ではありません: ${String(delimiter)}`,
+    );
+  }
   return new TextDecoder().decode(padded.slice(0, -1));
 };
 

--- a/apps/admin/src/features/push-notification/infrastructure/web-push.ts
+++ b/apps/admin/src/features/push-notification/infrastructure/web-push.ts
@@ -175,7 +175,7 @@ async function encryptPayload(
   return new Uint8Array(encrypted);
 }
 
-function buildEncryptedBody(
+export function buildEncryptedBody(
   localPublicKey: Uint8Array<ArrayBuffer>,
   {
     encrypted,
@@ -276,21 +276,21 @@ async function hkdf(
   return okm.slice(0, length);
 }
 
-function base64UrlDecode(str: string): Uint8Array<ArrayBuffer> {
+export function base64UrlDecode(str: string): Uint8Array<ArrayBuffer> {
   const base64 = str.replaceAll('-', '+').replaceAll('_', '/');
   const padding = '='.repeat((4 - (base64.length % 4)) % 4);
   const binary = atob(base64 + padding);
   return Uint8Array.from(binary, (c) => c.codePointAt(0) ?? 0);
 }
 
-function base64UrlEncode(str: string): string {
+export function base64UrlEncode(str: string): string {
   return btoa(str)
     .replaceAll('+', '-')
     .replaceAll('/', '_')
     .replaceAll('=', '');
 }
 
-function base64UrlEncodeBytes(bytes: Uint8Array<ArrayBuffer>): string {
+export function base64UrlEncodeBytes(bytes: Uint8Array<ArrayBuffer>): string {
   const binary = String.fromCodePoint(...bytes);
   return btoa(binary)
     .replaceAll('+', '-')

--- a/apps/admin/src/features/talks/interface/talk-form-validation.test.ts
+++ b/apps/admin/src/features/talks/interface/talk-form-validation.test.ts
@@ -1,0 +1,133 @@
+import { parseTalkFormData } from './talk-form-validation';
+
+const buildFormData = (
+  overrides: Partial<Record<string, string>> = {},
+): FormData => {
+  const fields: Record<string, string> = {
+    title: 'React のトーク',
+    eventName: 'K8o Conference',
+    eventDate: '2026-07-01',
+    eventLocation: '東京',
+    eventUrl: 'https://example.com/event',
+    slideUrl: 'https://example.com/slide',
+    blogId: '1',
+    ...overrides,
+  };
+  const formData = new FormData();
+  for (const [key, value] of Object.entries(fields)) {
+    formData.set(key, value);
+  }
+  return formData;
+};
+
+describe('parseTalkFormData', () => {
+  describe('正常系', () => {
+    it('全項目が正しければ TalkInput を返す', () => {
+      const result = parseTalkFormData(buildFormData());
+
+      expect(result).toEqual({
+        ok: true,
+        data: {
+          title: 'React のトーク',
+          eventName: 'K8o Conference',
+          eventDate: '2026-07-01',
+          eventLocation: '東京',
+          eventUrl: 'https://example.com/event',
+          slideUrl: 'https://example.com/slide',
+          blogId: 1,
+        },
+      });
+    });
+
+    it('任意項目の eventLocation が空なら null にする', () => {
+      const result = parseTalkFormData(buildFormData({ eventLocation: '' }));
+
+      expect(result).toMatchObject({
+        ok: true,
+        data: { eventLocation: null },
+      });
+    });
+  });
+
+  describe('異常系', () => {
+    it.each([
+      ['title'],
+      ['eventName'],
+      ['eventDate'],
+      ['eventUrl'],
+      ['slideUrl'],
+    ])('必須項目 %s が空ならエラーを返す', (field) => {
+      const result = parseTalkFormData(buildFormData({ [field]: '' }));
+
+      expect(result).toEqual({
+        ok: false,
+        error: 'タイトル・イベント名・日付・イベントURL・スライドURLは必須です',
+      });
+    });
+
+    it('フィールドが未設定でも必須エラーを返す', () => {
+      const result = parseTalkFormData(new FormData());
+
+      expect(result).toEqual({
+        ok: false,
+        error: 'タイトル・イベント名・日付・イベントURL・スライドURLは必須です',
+      });
+    });
+
+    it('eventDate が YYYY-MM-DD 形式でなければエラーを返す', () => {
+      const result = parseTalkFormData(
+        buildFormData({ eventDate: '2026/07/01' }),
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: '開催日は YYYY-MM-DD 形式で入力してください',
+      });
+    });
+
+    it.each([['0'], ['-1'], ['1.5'], ['abc'], ['']])(
+      'blogId が正の整数でない値(%s)ならエラーを返す',
+      (blogId) => {
+        const result = parseTalkFormData(buildFormData({ blogId }));
+
+        expect(result).toEqual({
+          ok: false,
+          error: '紐づけるブログを選択してください',
+        });
+      },
+    );
+
+    it('eventUrl が URL としてパースできなければエラーを返す', () => {
+      const result = parseTalkFormData(
+        buildFormData({ eventUrl: 'not-a-url' }),
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: '有効なURLを入力してください',
+      });
+    });
+
+    it('slideUrl が URL としてパースできなければエラーを返す', () => {
+      const result = parseTalkFormData(
+        buildFormData({ slideUrl: 'example.com/slide' }),
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: '有効なURLを入力してください',
+      });
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('blogId の前後の空白は数値として許容される', () => {
+      const result = parseTalkFormData(buildFormData({ blogId: ' 2 ' }));
+
+      expect(result).toMatchObject({
+        ok: true,
+        data: { blogId: 2 },
+      });
+    });
+  });
+});


### PR DESCRIPTION
## 概要

テストがゼロだった重要ロジック4箇所にテストを追加します。プロダクションコードの変更はテストから参照するための export 追加のみです。

## 動機

監査でリスクの高い未テスト箇所として特定されたため。特に web-push.ts は RFC 8291/8292（ECDH + HKDF + AES-128-GCM + VAPID ES256）を WebCrypto で手書きした312行の暗号実装で、1バイトのずれで全プッシュ通知が静かに壊れます。

## 詳細

- web-push: **RFC 8291 Appendix A の公式テストベクタと暗号文がバイト単位で一致することを検証**（crypto を stub して固定鍵・salt を注入。プロダクション側の構造変更なし）。ラウンドトリップテストの復号側は WebCrypto ネイティブの HKDF を使い実装と独立させて自作自演を回避。VAPID JWT はヘッダ・クレーム構造と ES256 署名を公開鍵で検証
- push-notification: claim-first dedupe（claim 済みなら送信しない）、404/410 応答の endpoint だけ購読削除されること、成功/失敗の集計
- sync-baseline: insert/update の振り分け、キー順非依存の差分検知（stableStringify）、minVersions が空のとき browser_support を書き込まないこと、MAX_PAGES 打ち切り、型ガードの異常応答拒否
- parseTalkFormData の網羅テスト（正常系 / 必須欠落 / 不正値 / 空→null 変換）

テストベクタ検証の結果、既存実装にバグは発見されませんでした（正しさが公開ベクタで裏付けられました）。

## 影響範囲

テストのみ（web-push.ts / sync-baseline.ts への export 追加を除きプロダクション挙動の変更なし）

## テスト

新規102件を含む admin features テスト全パス。check・type-check パス
