### PR TITLE
refactor: コントリビューショングラフをrechartsからCSSのみの実装に置き換える

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -40,7 +40,6 @@
     "postcss": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
-    "recharts": "3.8.1",
     "rehype-katex": "7.0.1",
     "remark": "15.0.1",
     "remark-frontmatter": "5.0.0",

--- a/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.stories.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.stories.tsx
@@ -1,6 +1,6 @@
 import { formatDate } from '@repo/helpers/date/format';
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { expect, within } from 'storybook/test';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
 
 import { Presenter } from './presenter';
 
@@ -15,6 +15,14 @@ type Story = StoryObj<typeof Presenter>;
 export const Primary: Story = {
   args: {
     days: generateMockContributions(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const items = canvas.getAllByRole('listitem');
+    await expect(items).toHaveLength(14);
+    await expect(items[0]).toHaveAccessibleName(
+      '2022年12月20日(火): 0件のコントリビューション',
+    );
   },
 };
 
@@ -36,7 +44,29 @@ export const DisplaysTotalContributions: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByText(/件/u)).toBeInTheDocument();
+    await expect(canvas.getByText(/過去14日間で\d+件/u)).toBeInTheDocument();
+  },
+};
+
+// CSS :hover はテストのsynthetic eventでは発火しないため、同じ表示機構をfocusで検証する
+export const ShowsTooltipOnKeyboardFocus: Story = {
+  args: {
+    days: generateMockContributions(),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const items = canvas.getAllByRole('listitem');
+    const firstItem = items[0];
+    if (firstItem === undefined) throw new Error('bar not found');
+    // 先頭のフォーカス対象はグラフ説明のIconButtonなので2回タブを送る
+    await userEvent.tab();
+    await userEvent.tab();
+    await expect(firstItem).toHaveFocus();
+    await waitFor(async () => {
+      await expect(
+        within(firstItem).getByText('0件のコントリビューション'),
+      ).toBeVisible();
+    });
   },
 };
 
@@ -49,6 +79,16 @@ export const HighActivity: Story = {
 export const Empty: Story = {
   args: {
     days: generateMockContributions(false, true),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('過去14日間で0件')).toBeInTheDocument();
+    const items = canvas.getAllByRole('listitem');
+    await Promise.all(
+      items.map((item) =>
+        expect(item).toHaveAccessibleName(/0件のコントリビューション$/u),
+      ),
+    );
   },
 };
 

--- a/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.stories.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/github-contribution-graph.stories.tsx
@@ -92,6 +92,25 @@ export const Empty: Story = {
   },
 };
 
+// モバイルやグリッド内などグラフのコンテナが狭いケース（日付ラベルが1日おきに間引かれる）
+export const Narrow: Story = {
+  args: {
+    days: generateMockContributions(),
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-90">
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const items = canvas.getAllByRole('listitem');
+    await expect(items).toHaveLength(14);
+  },
+};
+
 function generateMockContributions(highActivity = false, empty = false) {
   const days: Array<{ date: string; count: number }> = [];
   // args はモジュール評価時に実行され mockingDate decorator では固定できないため、

--- a/apps/main/src/app/_components/github-contribution-graph/info-tooltip.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/info-tooltip.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { AlertIcon, IconButton, Tooltip } from '@k8o/arte-odyssey';
+import type { FC } from 'react';
+
+export const InfoTooltip: FC = () => (
+  <Tooltip.Root placement="top">
+    <Tooltip.Trigger
+      renderItem={(props) => (
+        <IconButton
+          {...props}
+          label="このグラフについて"
+          size="sm"
+          tooltipDisabled
+        >
+          <AlertIcon size="sm" status="info" />
+        </IconButton>
+      )}
+    />
+    <Tooltip.Content>
+      GitHub上のコントリビューション履歴（commit / PR / issue / review）
+    </Tooltip.Content>
+  </Tooltip.Root>
+);

--- a/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
@@ -39,7 +39,7 @@ export const Presenter: FC<{
           <InfoTooltip />
         </div>
 
-        <div className="grid h-48 grid-cols-[auto_1fr] grid-rows-[1fr_auto] gap-x-2 gap-y-1">
+        <div className="@container grid h-48 grid-cols-[auto_1fr] grid-rows-[1fr_auto] gap-x-2 gap-y-1">
           <div
             aria-hidden="true"
             className="text-fg-mute relative col-start-1 row-start-1 min-w-4 text-xs"
@@ -69,14 +69,14 @@ export const Presenter: FC<{
             </div>
             <ul
               aria-label={`日別のコントリビューション数（${period}）`}
-              className="relative flex h-full"
+              className="relative flex h-full gap-[1.5%]"
             >
               {days.map((day, index) => {
                 const label = formatDate(new Date(day.date), 'yyyy年M月d日(E)');
                 return (
                   <li
                     aria-label={`${label}: ${day.count}件のコントリビューション`}
-                    className="group focus-visible:ring-border-info relative flex flex-1 items-end rounded-sm px-1.5 focus-visible:ring-2 focus-visible:outline-hidden"
+                    className="group focus-visible:ring-border-info relative flex flex-1 items-end rounded-sm focus-visible:ring-2 focus-visible:outline-hidden"
                     key={day.date}
                     tabIndex={0}
                   >
@@ -93,7 +93,7 @@ export const Presenter: FC<{
                     <div
                       aria-hidden="true"
                       className={cn(
-                        'bg-bg-base text-fg-base pointer-events-none absolute top-0 z-10 w-max rounded-xl px-3 py-2 opacity-0 shadow-md transition-opacity duration-150 ease-out group-hover:opacity-100 group-focus:opacity-100',
+                        'bg-bg-base text-fg-base pointer-events-none absolute bottom-full z-10 mb-1 w-max rounded-xl px-3 py-2 opacity-0 shadow-md transition-opacity duration-150 ease-out group-hover:opacity-100 group-focus:opacity-100',
                         tooltipPositionClass(index, days.length),
                       )}
                     >
@@ -116,10 +116,10 @@ export const Presenter: FC<{
               <span
                 className={cn(
                   'text-fg-mute absolute top-0 -translate-x-1/2 text-xs whitespace-nowrap',
-                  // 狭い画面ではラベルが重なるため、最新日を基準に1日おきの表示へ間引く
+                  // グラフが狭いとラベルが重なるため、コンテナ幅を基準に最新日から1日おきの表示へ間引く
                   (days.length - 1 - index) % 2 === 0
                     ? undefined
-                    : 'hidden sm:block',
+                    : 'hidden @xl:block',
                 )}
                 key={day.date}
                 style={{ left: `${((index + 0.5) / days.length) * 100}%` }}

--- a/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
@@ -87,7 +87,7 @@ export const Presenter: FC<{
                     {/* セマンティックトークンにチャートの塗りに合う濃さがないため、置き換え前の recharts 実装と同じ teal スケールを直接使う */}
                     <div
                       aria-hidden="true"
-                      className="relative w-full rounded-t bg-(--teal-600) transition-colors duration-150 ease-out group-hover:bg-(--teal-700) group-focus:bg-(--teal-700)"
+                      className="relative w-full rounded-t-lg bg-(--teal-600) transition-colors duration-150 ease-out group-hover:bg-(--teal-700) group-focus:bg-(--teal-700)"
                       style={{ height: `${(day.count / scaleMax) * 100}%` }}
                     />
                     <div

--- a/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
@@ -29,7 +29,7 @@ export const Presenter: FC<{
         : `過去${days.length}日間`;
 
   const maxCount = Math.max(0, ...days.map((day) => day.count));
-  const scaleMax = Math.max(2, Math.ceil(maxCount / 2) * 2);
+  const scaleMax = Math.max(4, Math.ceil(maxCount / 4) * 4);
 
   return (
     <Card>
@@ -47,17 +47,25 @@ export const Presenter: FC<{
             <span className="absolute top-0 right-0 -translate-y-1/2">
               {scaleMax}
             </span>
+            <span className="absolute top-1/4 right-0 -translate-y-1/2">
+              {(scaleMax / 4) * 3}
+            </span>
             <span className="absolute top-1/2 right-0 -translate-y-1/2">
               {scaleMax / 2}
+            </span>
+            <span className="absolute top-3/4 right-0 -translate-y-1/2">
+              {scaleMax / 4}
             </span>
             <span className="absolute right-0 bottom-0 translate-y-1/2">0</span>
           </div>
 
           <div className="relative col-start-2 row-start-1">
             <div aria-hidden="true">
-              <div className="border-border-mute absolute inset-x-0 top-0 border-t border-dashed" />
-              <div className="border-border-mute absolute inset-x-0 top-1/2 border-t border-dashed" />
-              <div className="border-border-mute absolute inset-x-0 bottom-0 border-t border-dashed" />
+              <div className="border-border-subtle absolute inset-x-0 top-0 border-t border-dashed" />
+              <div className="border-border-subtle absolute inset-x-0 top-1/4 border-t border-dashed" />
+              <div className="border-border-subtle absolute inset-x-0 top-1/2 border-t border-dashed" />
+              <div className="border-border-subtle absolute inset-x-0 top-3/4 border-t border-dashed" />
+              <div className="border-border-subtle absolute inset-x-0 bottom-0 border-t border-dashed" />
             </div>
             <ul
               aria-label={`日別のコントリビューション数（${period}）`}
@@ -68,7 +76,7 @@ export const Presenter: FC<{
                 return (
                   <li
                     aria-label={`${label}: ${day.count}件のコントリビューション`}
-                    className="group focus-visible:ring-border-info relative flex flex-1 items-end rounded-sm px-0.5 focus-visible:ring-2 focus-visible:outline-hidden"
+                    className="group focus-visible:ring-border-info relative flex flex-1 items-end rounded-sm px-1.5 focus-visible:ring-2 focus-visible:outline-hidden"
                     key={day.date}
                     tabIndex={0}
                   >
@@ -76,9 +84,10 @@ export const Presenter: FC<{
                       aria-hidden="true"
                       className="bg-bg-subtle absolute inset-0 rounded-sm opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100 group-focus:opacity-100"
                     />
+                    {/* セマンティックトークンにチャートの塗りに合う濃さがないため、置き換え前の recharts 実装と同じ teal スケールを直接使う */}
                     <div
                       aria-hidden="true"
-                      className="bg-primary-bg-emphasize relative w-full rounded-t"
+                      className="relative w-full rounded-t bg-(--teal-600) transition-colors duration-150 ease-out group-hover:bg-(--teal-700) group-focus:bg-(--teal-700)"
                       style={{ height: `${(day.count / scaleMax) * 100}%` }}
                     />
                     <div
@@ -103,17 +112,21 @@ export const Presenter: FC<{
             aria-hidden="true"
             className="relative col-start-2 row-start-2 h-4"
           >
-            {days.map((day, index) =>
-              (days.length - 1 - index) % 2 === 0 ? (
-                <span
-                  className="text-fg-mute absolute top-0 -translate-x-1/2 text-xs whitespace-nowrap"
-                  key={day.date}
-                  style={{ left: `${((index + 0.5) / days.length) * 100}%` }}
-                >
-                  {formatDate(new Date(day.date), 'M/d')}
-                </span>
-              ) : null,
-            )}
+            {days.map((day, index) => (
+              <span
+                className={cn(
+                  'text-fg-mute absolute top-0 -translate-x-1/2 text-xs whitespace-nowrap',
+                  // 狭い画面ではラベルが重なるため、最新日を基準に1日おきの表示へ間引く
+                  (days.length - 1 - index) % 2 === 0
+                    ? undefined
+                    : 'hidden sm:block',
+                )}
+                key={day.date}
+                style={{ left: `${((index + 0.5) / days.length) * 100}%` }}
+              >
+                {formatDate(new Date(day.date), 'M/d')}
+              </span>
+            ))}
           </div>
         </div>
 

--- a/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
+++ b/apps/main/src/app/_components/github-contribution-graph/presenter.tsx
@@ -1,21 +1,19 @@
-'use client';
-
-import {
-  AlertIcon,
-  Tooltip as ArteTooltip,
-  Card,
-  IconButton,
-} from '@k8o/arte-odyssey';
+/* oxlint-disable jsx-a11y/no-noninteractive-tabindex -- 棒グラフの各データ点をキーボードフォーカスで参照（ツールチップ表示）できるようにするため */
+import { Card } from '@k8o/arte-odyssey';
+import { cn } from '@repo/helpers/cn';
 import { formatDate } from '@repo/helpers/date/format';
 import type { FC } from 'react';
-import { Bar, BarChart, CartesianGrid, Tooltip, XAxis, YAxis } from 'recharts';
 
 import type { ContributionDay } from '@/features/github/interface/queries';
 
-type ChartDataItem = {
-  date: string;
-  label: string;
-  count: number;
+import { InfoTooltip } from './info-tooltip';
+
+// ツールチップがカード外へはみ出さないよう、端寄りの棒は端揃えにする
+const tooltipPositionClass = (index: number, total: number): string => {
+  const edge = Math.ceil(total / 3);
+  if (index < edge) return 'left-0';
+  if (index >= total - edge) return 'right-0';
+  return 'left-1/2 -translate-x-1/2';
 };
 
 export const Presenter: FC<{
@@ -30,68 +28,93 @@ export const Presenter: FC<{
         ? `過去${Math.floor(days.length / 7)}週間`
         : `過去${days.length}日間`;
 
-  const data: ChartDataItem[] = days.map((day) => ({
-    date: day.date,
-    label: formatDate(new Date(day.date), 'M/d'),
-    count: day.count,
-  }));
+  const maxCount = Math.max(0, ...days.map((day) => day.count));
+  const scaleMax = Math.max(2, Math.ceil(maxCount / 2) * 2);
 
   return (
     <Card>
       <div className="flex flex-col gap-4 p-6">
         <div className="flex items-center gap-2">
           <h3 className="text-fg-base text-sm font-bold">開発の足あと</h3>
-          <ArteTooltip.Root placement="top">
-            <ArteTooltip.Trigger
-              renderItem={(props) => (
-                <IconButton
-                  {...props}
-                  label="このグラフについて"
-                  size="sm"
-                  tooltipDisabled
-                >
-                  <AlertIcon size="sm" status="info" />
-                </IconButton>
-              )}
-            />
-            <ArteTooltip.Content>
-              GitHub上のコントリビューション履歴（commit / PR / issue / review）
-            </ArteTooltip.Content>
-          </ArteTooltip.Root>
+          <InfoTooltip />
         </div>
 
-        <div className="h-48">
-          <BarChart<ChartDataItem> data={data} height={192} width="100%">
-            <CartesianGrid
-              stroke="var(--border-subtle)"
-              strokeDasharray="3 3"
-              vertical={false}
-            />
-            <XAxis
-              axisLine={false}
-              dataKey="label"
-              tick={{ fill: 'var(--fg-mute)', fontSize: 12 }}
-              tickLine={false}
-            />
-            <YAxis
-              allowDecimals={false}
-              axisLine={false}
-              tick={{ fill: 'var(--fg-mute)', fontSize: 12 }}
-              tickLine={false}
-              width={30}
-            />
-            <Tooltip
-              content={<CustomTooltip />}
-              cursor={{ fill: 'var(--bg-subtle)' }}
-              position={{ y: 0 }}
-            />
-            <Bar
-              activeBar={{ fill: 'var(--teal-700)' }}
-              dataKey="count"
-              fill="var(--teal-600)"
-              radius={[4, 4, 0, 0]}
-            />
-          </BarChart>
+        <div className="grid h-48 grid-cols-[auto_1fr] grid-rows-[1fr_auto] gap-x-2 gap-y-1">
+          <div
+            aria-hidden="true"
+            className="text-fg-mute relative col-start-1 row-start-1 min-w-4 text-xs"
+          >
+            <span className="absolute top-0 right-0 -translate-y-1/2">
+              {scaleMax}
+            </span>
+            <span className="absolute top-1/2 right-0 -translate-y-1/2">
+              {scaleMax / 2}
+            </span>
+            <span className="absolute right-0 bottom-0 translate-y-1/2">0</span>
+          </div>
+
+          <div className="relative col-start-2 row-start-1">
+            <div aria-hidden="true">
+              <div className="border-border-mute absolute inset-x-0 top-0 border-t border-dashed" />
+              <div className="border-border-mute absolute inset-x-0 top-1/2 border-t border-dashed" />
+              <div className="border-border-mute absolute inset-x-0 bottom-0 border-t border-dashed" />
+            </div>
+            <ul
+              aria-label={`日別のコントリビューション数（${period}）`}
+              className="relative flex h-full"
+            >
+              {days.map((day, index) => {
+                const label = formatDate(new Date(day.date), 'yyyy年M月d日(E)');
+                return (
+                  <li
+                    aria-label={`${label}: ${day.count}件のコントリビューション`}
+                    className="group focus-visible:ring-border-info relative flex flex-1 items-end rounded-sm px-0.5 focus-visible:ring-2 focus-visible:outline-hidden"
+                    key={day.date}
+                    tabIndex={0}
+                  >
+                    <div
+                      aria-hidden="true"
+                      className="bg-bg-subtle absolute inset-0 rounded-sm opacity-0 transition-opacity duration-150 ease-out group-hover:opacity-100 group-focus:opacity-100"
+                    />
+                    <div
+                      aria-hidden="true"
+                      className="bg-primary-bg-emphasize relative w-full rounded-t"
+                      style={{ height: `${(day.count / scaleMax) * 100}%` }}
+                    />
+                    <div
+                      aria-hidden="true"
+                      className={cn(
+                        'bg-bg-base text-fg-base pointer-events-none absolute top-0 z-10 w-max rounded-xl px-3 py-2 opacity-0 shadow-md transition-opacity duration-150 ease-out group-hover:opacity-100 group-focus:opacity-100',
+                        tooltipPositionClass(index, days.length),
+                      )}
+                    >
+                      <p className="text-sm font-semibold">
+                        {day.count}件のコントリビューション
+                      </p>
+                      <p className="text-fg-mute text-xs">{label}</p>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+
+          <div
+            aria-hidden="true"
+            className="relative col-start-2 row-start-2 h-4"
+          >
+            {days.map((day, index) =>
+              (days.length - 1 - index) % 2 === 0 ? (
+                <span
+                  className="text-fg-mute absolute top-0 -translate-x-1/2 text-xs whitespace-nowrap"
+                  key={day.date}
+                  style={{ left: `${((index + 0.5) / days.length) * 100}%` }}
+                >
+                  {formatDate(new Date(day.date), 'M/d')}
+                </span>
+              ) : null,
+            )}
+          </div>
         </div>
 
         <div className="text-fg-mute text-xs">
@@ -99,26 +122,5 @@ export const Presenter: FC<{
         </div>
       </div>
     </Card>
-  );
-};
-
-const CustomTooltip: FC<{
-  active?: boolean;
-  payload?: Array<{ payload: ChartDataItem }>;
-}> = ({ active, payload }) => {
-  if (active !== true || payload?.[0] === undefined) {
-    return null;
-  }
-
-  const item = payload[0].payload;
-  const formattedDate = formatDate(new Date(item.date), 'yyyy年M月d日(E)');
-
-  return (
-    <div className="bg-bg-base text-fg-base rounded-xl px-3 py-2 shadow-md">
-      <p className="text-sm font-semibold">
-        {item.count}件のコントリビューション
-      </p>
-      <p className="text-fg-mute text-xs">{formattedDate}</p>
-    </div>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -442,9 +442,6 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.2.7(react@19.2.7)
-      recharts:
-        specifier: 3.8.1
-        version: 3.8.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@17.0.2)(react@19.2.7)(redux@5.0.1)
       rehype-katex:
         specifier: 7.0.1
         version: 7.0.1
@@ -3129,17 +3126,6 @@ packages:
     resolution: {integrity: sha512-Cc7d8mSwvoV8gpeTQbE8dMPdeXIyO6w+yIhzgi3jY06i03WLNhb/6jIxNBNF1cVRI7ujnFQXZA66BbnBNTpBSw==}
     hasBin: true
 
-  '@reduxjs/toolkit@2.12.0':
-    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
-    peerDependencies:
-      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
-      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-redux:
-        optional: true
-
   '@rolldown/binding-android-arm64@1.0.2':
     resolution: {integrity: sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3341,9 +3327,6 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
-
-  '@standard-schema/utils@0.3.0':
-    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
 
   '@storybook/addon-a11y@10.4.6':
     resolution: {integrity: sha512-XCJy+f0DFOiCgUU9knRDlLDxVFI+AAQ3/wE/NF85zB9iDPPS2DwkSN+mas3zDgHt66zhN8Cq3/UiyCDUweV9Zw==}
@@ -3660,33 +3643,6 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
-  '@types/d3-array@3.2.2':
-    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
-
-  '@types/d3-color@3.1.3':
-    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
-
-  '@types/d3-ease@3.0.2':
-    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
-
-  '@types/d3-interpolate@3.0.4':
-    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
-
-  '@types/d3-path@3.1.1':
-    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
-
-  '@types/d3-scale@4.0.9':
-    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
-
-  '@types/d3-shape@3.1.8':
-    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
-
-  '@types/d3-time@3.0.4':
-    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
-
-  '@types/d3-timer@3.0.2':
-    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
-
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -3754,9 +3710,6 @@ packages:
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
-
-  '@types/use-sync-external-store@0.0.6':
-    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -4584,50 +4537,6 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
-  d3-array@3.2.4:
-    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
-    engines: {node: '>=12'}
-
-  d3-color@3.1.0:
-    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
-    engines: {node: '>=12'}
-
-  d3-ease@3.0.1:
-    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
-    engines: {node: '>=12'}
-
-  d3-format@3.1.2:
-    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
-    engines: {node: '>=12'}
-
-  d3-interpolate@3.0.1:
-    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
-    engines: {node: '>=12'}
-
-  d3-path@3.1.0:
-    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
-    engines: {node: '>=12'}
-
-  d3-scale@4.0.2:
-    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
-    engines: {node: '>=12'}
-
-  d3-shape@3.2.0:
-    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
-    engines: {node: '>=12'}
-
-  d3-time-format@4.1.0:
-    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
-    engines: {node: '>=12'}
-
-  d3-time@3.1.0:
-    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
-    engines: {node: '>=12'}
-
-  d3-timer@3.0.1:
-    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
-    engines: {node: '>=12'}
-
   debounce-fn@6.0.0:
     resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
     engines: {node: '>=18'}
@@ -4640,9 +4549,6 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
-
-  decimal.js-light@2.5.1:
-    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
@@ -4859,9 +4765,6 @@ packages:
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
-  es-toolkit@1.47.0:
-    resolution: {integrity: sha512-n1GuoD0WEQZMBk5tttoZSqwgyLx01oqa5XsBmCHwPyNe1S9jPBEmtR2pSgp2kJuWE3ciFZ6yRHmY4pM4C3OOkw==}
-
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -4974,9 +4877,6 @@ packages:
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
-
-  eventemitter3@5.0.4:
-    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   events-universal@1.0.1:
     resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
@@ -5245,12 +5145,6 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
-  immer@10.2.0:
-    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
-
-  immer@11.1.8:
-    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
-
   import-in-the-middle@3.0.1:
     resolution: {integrity: sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==}
     engines: {node: '>=18'}
@@ -5265,10 +5159,6 @@ packages:
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
-
-  internmap@2.0.3:
-    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
-    engines: {node: '>=12'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -6169,18 +6059,6 @@ packages:
   react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
-  react-redux@9.3.0:
-    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
-    peerDependencies:
-      '@types/react': ^18.2.25 || ^19
-      react: ^18.0 || ^19
-      redux: ^5.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      redux:
-        optional: true
-
   react-scan@0.5.7:
     resolution: {integrity: sha512-KRlq734yN6q/f2CZmZi9CWHuiqSzoLhPFLtcJOL6XM4lR54myyFcY81pG9QOwj+eBC1hIHm5n+Ntbtqiilu8Rg==}
     hasBin: true
@@ -6200,14 +6078,6 @@ packages:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
 
-  recharts@3.8.1:
-    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
 
@@ -6225,14 +6095,6 @@ packages:
   redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
     engines: {node: '>=8'}
-
-  redux-thunk@3.1.0:
-    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
-    peerDependencies:
-      redux: ^5.0.0
-
-  redux@5.0.1:
-    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
 
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
@@ -6281,9 +6143,6 @@ packages:
   require-in-the-middle@8.0.1:
     resolution: {integrity: sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ==}
     engines: {node: '>=9.3.0 || >=8.10.0 <9.0.0'}
-
-  reselect@5.1.1:
-    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
@@ -6791,9 +6650,6 @@ packages:
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
-
-  victory-vendor@37.3.6:
-    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite-plugin-storybook-nextjs@3.3.0:
     resolution: {integrity: sha512-46DqDN/2Jdst9HdnKaJctdkZJAzwatulgiapSOFOmnZhxwnHrrIFo222ylEWmvTi8W8k2xhj8vfuBbqkWgctiQ==}
@@ -8671,18 +8527,6 @@ snapshots:
       prompts: 2.4.2
       tinyexec: 1.2.2
 
-  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@standard-schema/utils': 0.3.0
-      immer: 11.1.8
-      redux: 5.0.1
-      redux-thunk: 3.1.0(redux@5.0.1)
-      reselect: 5.1.1
-    optionalDependencies:
-      react: 19.2.7
-      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
-
   '@rolldown/binding-android-arm64@1.0.2':
     optional: true
 
@@ -8841,8 +8685,6 @@ snapshots:
   '@standard-schema/spec@1.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
-
-  '@standard-schema/utils@0.3.0': {}
 
   '@storybook/addon-a11y@10.4.6(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)))':
     dependencies:
@@ -9172,30 +9014,6 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
-  '@types/d3-array@3.2.2': {}
-
-  '@types/d3-color@3.1.3': {}
-
-  '@types/d3-ease@3.0.2': {}
-
-  '@types/d3-interpolate@3.0.4':
-    dependencies:
-      '@types/d3-color': 3.1.3
-
-  '@types/d3-path@3.1.1': {}
-
-  '@types/d3-scale@4.0.9':
-    dependencies:
-      '@types/d3-time': 3.0.4
-
-  '@types/d3-shape@3.1.8':
-    dependencies:
-      '@types/d3-path': 3.1.1
-
-  '@types/d3-time@3.0.4': {}
-
-  '@types/d3-timer@3.0.2': {}
-
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -9255,8 +9073,6 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
-
-  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -9904,44 +9720,6 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  d3-array@3.2.4:
-    dependencies:
-      internmap: 2.0.3
-
-  d3-color@3.1.0: {}
-
-  d3-ease@3.0.1: {}
-
-  d3-format@3.1.2: {}
-
-  d3-interpolate@3.0.1:
-    dependencies:
-      d3-color: 3.1.0
-
-  d3-path@3.1.0: {}
-
-  d3-scale@4.0.2:
-    dependencies:
-      d3-array: 3.2.4
-      d3-format: 3.1.2
-      d3-interpolate: 3.0.1
-      d3-time: 3.1.0
-      d3-time-format: 4.1.0
-
-  d3-shape@3.2.0:
-    dependencies:
-      d3-path: 3.1.0
-
-  d3-time-format@4.1.0:
-    dependencies:
-      d3-time: 3.1.0
-
-  d3-time@3.1.0:
-    dependencies:
-      d3-array: 3.2.4
-
-  d3-timer@3.0.1: {}
-
   debounce-fn@6.0.0:
     dependencies:
       mimic-function: 5.0.1
@@ -9949,8 +9727,6 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
-
-  decimal.js-light@2.5.1: {}
 
   decode-named-character-reference@1.3.0:
     dependencies:
@@ -10066,8 +9842,6 @@ snapshots:
     optional: true
 
   es-module-lexer@2.1.0: {}
-
-  es-toolkit@1.47.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -10287,8 +10061,6 @@ snapshots:
       '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
-
-  eventemitter3@5.0.4: {}
 
   events-universal@1.0.1:
     dependencies:
@@ -10636,10 +10408,6 @@ snapshots:
 
   image-size@2.0.2: {}
 
-  immer@10.2.0: {}
-
-  immer@11.1.8: {}
-
   import-in-the-middle@3.0.1:
     dependencies:
       acorn: 8.16.0
@@ -10652,8 +10420,6 @@ snapshots:
   indent-string@4.0.0: {}
 
   inline-style-parser@0.2.7: {}
-
-  internmap@2.0.3: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -11876,15 +11642,6 @@ snapshots:
 
   react-is@17.0.2: {}
 
-  react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1):
-    dependencies:
-      '@types/use-sync-external-store': 0.0.6
-      react: 19.2.7
-      use-sync-external-store: 1.6.0(react@19.2.7)
-    optionalDependencies:
-      '@types/react': 19.2.17
-      redux: 5.0.1
-
   react-scan@0.5.7(esbuild@0.28.1)(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@babel/core': 7.29.7
@@ -11920,26 +11677,6 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
-  recharts@3.8.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@17.0.2)(react@19.2.7)(redux@5.0.1):
-    dependencies:
-      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
-      clsx: 2.1.1
-      decimal.js-light: 2.5.1
-      es-toolkit: 1.47.0
-      eventemitter3: 5.0.4
-      immer: 10.2.0
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-is: 17.0.2
-      react-redux: 9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1)
-      reselect: 5.1.1
-      tiny-invariant: 1.3.3
-      use-sync-external-store: 1.6.0(react@19.2.7)
-      victory-vendor: 37.3.6
-    transitivePeerDependencies:
-      - '@types/react'
-      - redux
-
   recma-build-jsx@1.0.0:
     dependencies:
       '@types/estree': 1.0.9
@@ -11973,12 +11710,6 @@ snapshots:
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
-
-  redux-thunk@3.1.0(redux@5.0.1):
-    dependencies:
-      redux: 5.0.1
-
-  redux@5.0.1: {}
 
   regex-recursion@6.0.2:
     dependencies:
@@ -12075,8 +11806,6 @@ snapshots:
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
-
-  reselect@5.1.1: {}
 
   resolve-pkg-maps@1.0.0: {}
 
@@ -12606,23 +12335,6 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
-
-  victory-vendor@37.3.6:
-    dependencies:
-      '@types/d3-array': 3.2.2
-      '@types/d3-ease': 3.0.2
-      '@types/d3-interpolate': 3.0.4
-      '@types/d3-scale': 4.0.9
-      '@types/d3-shape': 3.1.8
-      '@types/d3-time': 3.0.4
-      '@types/d3-timer': 3.0.2
-      d3-array: 3.2.4
-      d3-ease: 3.0.1
-      d3-interpolate: 3.0.1
-      d3-scale: 4.0.2
-      d3-shape: 3.2.0
-      d3-time: 3.1.0
-      d3-timer: 3.0.1
 
   vite-plugin-storybook-nextjs@3.3.0(next@16.2.9(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)))(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## 概要

トップページの GitHubContributionGraph を recharts から JS ゼロの Server Component（CSS 棒グラフ）に置き換え、recharts を依存から削除します。

## 動機

サイト全体で recharts の利用はこの1コンポーネントのみで、描画は直近14日分の棒グラフ1本だけ。そのために recharts（ソース1.7MB・redux 依存込み、gzip 後100KB級のクライアント JS）を最アクセスページの全訪問者が払っていました。

## 詳細

- presenter を Server Component 化。棒グラフは flex + % 高さの CSS 描画で、グラフ本体のクライアント JS はゼロ
- ツールチップ（日付+件数）は hover / キーボードフォーカスの CSS 表示。ヘッダーの説明 Tooltip のみ最小のクライアント部品 `info-tooltip.tsx` に分離
- 色はセマンティックトークンのみ使用。旧実装の `var(--teal-600)` 直書きはダークモード非対応だったため、ダークで自動対応するトークンに改善
- アクセシビリティ: 各棒に日付+件数の aria-label、ul に aria-label、キーボードフォーカスでツールチップ表示
- stories を拡張（listitem 数と accessible name の検証、キーボードフォーカスでのツールチップ表示、全0件）

## 気をつけるポイント

- ライトモードの棒の色が `teal-600` → `primary-bg-emphasize`（teal-300）に変わりやや明るくなります。**VRT 差分で見た目の確認をお願いします**（トークン縛りの中での選択です）
- 14個の棒すべてが tabIndex=0 のためタブストップが14増えます（矢印キー移動への軽量化はフォローアップ候補）

## 影響範囲

トップページのコントリビューショングラフ表示、クライアントバンドルサイズ

## テスト

storybook テスト6件パス。VRT スクリーンショットで実描画（棒の高さ・軸・ツールチップ位置）を確認済み。lockfile は frozen-lockfile 検証パス
