### PR TITLE
ci: turboキャッシュ永続化・VRTのai追加・knip修正・Renovateビルド検証

### DIFF
--- a/.github/scripts/knip-report.sh
+++ b/.github/scripts/knip-report.sh
@@ -1,20 +1,31 @@
 #!/bin/bash
 
+set -euo pipefail
+
 filter_pnpm_noise() {
-  grep -v '^ *>' | grep -v 'ELIFECYCLE'
+  grep -v '^ *>' | grep -v 'ELIFECYCLE' || true
 }
 
+stdout_file=$(mktemp)
+stderr_file=$(mktemp)
+trap 'rm -f "${stdout_file}" "${stderr_file}"' EXIT
+
+# reporterは指定順に実行される。symbols(default)はconfiguration hintsをstderrに、
+# markdownはレポート本文をstdoutに出すため、1回の実行で両方を取得できる。
+# stdout上のsymbols出力とmarkdown出力は "# Knip report" 行を境に分割する
 set +e
-markdown_output=$(pnpm knip --reporter markdown 2>&1 | filter_pnpm_noise)
-default_output=$(pnpm knip 2>&1 | filter_pnpm_noise)
+pnpm knip --reporter symbols --reporter markdown >"${stdout_file}" 2>"${stderr_file}"
 exit_code=$?
 set -e
 
 # exit code 2以上は実行エラーとして失敗させる
 if [[ "${exit_code}" -ge 2 ]]; then
-  echo "${default_output}"
+  filter_pnpm_noise <"${stdout_file}"
+  filter_pnpm_noise <"${stderr_file}"
   exit "${exit_code}"
 fi
+
+markdown_output=$(sed -n '/^# Knip report$/,$p' "${stdout_file}" | filter_pnpm_noise)
 
 # markdown reporterの出力が "# Knip report" のみなら問題なし
 stripped=$(echo "${markdown_output}" | sed '/^$/d' | sed 's/^[[:space:]]*//')
@@ -24,8 +35,8 @@ else
   has_issues=true
 fi
 
-# config-hintsの抽出
-config_hints=$(echo "${default_output}" | sed -n '/^Configuration hints/,/^$/p')
+# config-hintsの抽出（symbols reporterがstderrに出力する）
+config_hints=$(sed -n '/^Configuration hints/,/^$/p' "${stderr_file}")
 if [[ -n "${config_hints}" ]]; then
   has_config_hints=true
 else

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,6 +2,11 @@ name: 'Chromatic'
 
 on: push
 
+# 同一ブランチへの連続pushでは古い実行をキャンセルする（mainは全コミットの結果を残す）
+concurrency:
+  group: chromatic-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,11 @@ name: ci
 
 on: push
 
+# 同一ブランチへの連続pushでは古い実行をキャンセルする（mainは全コミットの結果を残す）
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
 permissions:
   contents: read
 
@@ -16,6 +21,15 @@ jobs:
           persist-credentials: false
       - name: Setup
         uses: ./.github/actions/setup
+
+      - name: Cache turbo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-${{ github.ref_name }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-
 
       - name: Run ls-lint
         run: pnpm run ls-lint
@@ -36,6 +50,15 @@ jobs:
           persist-credentials: false
       - name: Setup
         uses: ./.github/actions/setup
+
+      - name: Cache turbo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.job }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-${{ github.job }}-${{ github.ref_name }}-
+            ${{ runner.os }}-turbo-${{ github.job }}-
 
       - name: Install Playwright
         run: pnpm run install-playwright

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -10,6 +10,10 @@ concurrency:
   group: vrt-${{ github.ref }}
   cancel-in-progress: true
 
+# VRT対象アプリ（pnpm workspaceのfilter名）。アプリを追加したらここに足す
+env:
+  VRT_APPS: main admin ai
+
 permissions:
   contents: read
   pull-requests: write
@@ -31,72 +35,84 @@ jobs:
       - name: Install Playwright
         run: pnpm run install-playwright
 
-      - name: Capture story screenshots (main)
-        run: pnpm -F main run test:vrt
-
-      - name: Capture story screenshots (admin)
-        run: pnpm -F admin run test:vrt
+      - name: Capture story screenshots
+        run: |
+          for app in $VRT_APPS; do
+            pnpm -F "$app" run test:vrt
+          done
 
       # main: 撮影結果を次回のPR比較用ベースラインとして保存する
-      - name: Upload baseline (main)
+      # （.vrt は隠しディレクトリで artifact の glob から漏れるため、非隠しディレクトリへ集める）
+      - name: Collect baselines
         if: github.event_name == 'push'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: vrt-baseline-main
-          path: apps/main/.vrt/actual
-          retention-days: 30
+        run: |
+          for app in $VRT_APPS; do
+            mkdir -p "vrt-baseline/$app"
+            cp -r "apps/$app/.vrt/actual" "vrt-baseline/$app/actual"
+          done
 
-      - name: Upload baseline (admin)
+      - name: Upload baseline
         if: github.event_name == 'push'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: vrt-baseline-admin
-          path: apps/admin/.vrt/actual
+          name: vrt-baseline
+          path: vrt-baseline
           retention-days: 30
 
       # PR: mainの最新ベースラインを取得する（無いアプリは比較をスキップ）
       - name: Download baselines from main
         if: github.event_name == 'pull_request'
-        id: baseline
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
         run: |
           run_id=$(gh api "repos/$REPO/actions/workflows/vrt.yml/runs?branch=main&status=success&per_page=1" --jq '.workflow_runs[0].id // empty')
-          for app in main admin; do
-            if [ -n "$run_id" ] && gh run download "$run_id" --name "vrt-baseline-$app" --dir "apps/$app/.vrt/expected" --repo "$REPO"; then
-              echo "found_$app=true" >> "$GITHUB_OUTPUT"
+          downloaded=false
+          if [ -n "$run_id" ] && gh run download "$run_id" --name vrt-baseline --dir vrt-baseline --repo "$REPO"; then
+            downloaded=true
+          fi
+          for app in $VRT_APPS; do
+            if [ "$downloaded" = true ] && [ -d "vrt-baseline/$app/actual" ]; then
+              mkdir -p "apps/$app/.vrt"
+              cp -r "vrt-baseline/$app/actual" "apps/$app/.vrt/expected"
             else
-              echo "found_$app=false" >> "$GITHUB_OUTPUT"
+              echo "baseline not found: $app"
             fi
           done
 
-      - name: Compare against baseline (main)
-        if: github.event_name == 'pull_request' && steps.baseline.outputs.found_main == 'true'
-        id: compare-main
-        continue-on-error: true
-        working-directory: apps/main
-        run: pnpm exec svrt compare
+      - name: Compare against baselines
+        if: github.event_name == 'pull_request'
+        id: compare
+        run: |
+          failed=false
+          for app in $VRT_APPS; do
+            if [ ! -d "apps/$app/.vrt/expected" ]; then
+              echo "skip compare: $app (baseline not found)"
+              continue
+            fi
+            pnpm -F "$app" exec svrt compare || failed=true
+          done
+          echo "failed=$failed" >> "$GITHUB_OUTPUT"
 
-      - name: Compare against baseline (admin)
-        if: github.event_name == 'pull_request' && steps.baseline.outputs.found_admin == 'true'
-        id: compare-admin
-        continue-on-error: true
-        working-directory: apps/admin
-        run: pnpm exec svrt compare
+      - name: Collect reports
+        if: github.event_name == 'pull_request'
+        run: |
+          mkdir -p vrt-site
+          for app in $VRT_APPS; do
+            cp -r "apps/$app/.vrt" "vrt-site/$app"
+          done
 
       - name: Upload report
         if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: vrt-report
-          path: |
-            apps/main/.vrt
-            apps/admin/.vrt
+          path: vrt-site
           retention-days: 14
 
+      # fork PR は secrets（Cloudflareトークン）を取得できないため除外する
       - name: Publish report to Cloudflare Pages
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true
         id: pages
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -108,15 +124,13 @@ jobs:
             echo 'CLOUDFLARE_API_TOKEN が未登録のためPagesへの公開をスキップ'
             exit 0
           fi
-          mkdir -p vrt-site
-          cp -r apps/main/.vrt vrt-site/main
-          cp -r apps/admin/.vrt vrt-site/admin
           pnpm exec wrangler pages project create k8o-vrt --production-branch=main 2>/dev/null || true
           pnpm exec wrangler pages deploy vrt-site --project-name=k8o-vrt --branch="pr-$PR_NUMBER" --commit-dirty=true
           echo "base=https://pr-$PR_NUMBER.k8o-vrt.pages.dev" >> "$GITHUB_OUTPUT"
 
+      # fork PR は GITHUB_TOKEN が read-only でコメント投稿に失敗するため除外する
       - name: Comment summary on PR
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork != true
         env:
           GH_TOKEN: ${{ github.token }}
           REPO: ${{ github.repository }}
@@ -124,13 +138,15 @@ jobs:
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           PAGES_BASE: ${{ steps.pages.outputs.base }}
         run: |
-          main_url=''
-          admin_url=''
-          if [ -n "$PAGES_BASE" ]; then
-            main_url="$PAGES_BASE/main/report.html"
-            admin_url="$PAGES_BASE/admin/report.html"
-          fi
-          node .github/scripts/vrt-comment.mjs "main=apps/main/.vrt/report.json=$main_url" "admin=apps/admin/.vrt/report.json=$admin_url" > comment.md
+          args=()
+          for app in $VRT_APPS; do
+            url=''
+            if [ -n "$PAGES_BASE" ]; then
+              url="$PAGES_BASE/$app/report.html"
+            fi
+            args+=("$app=apps/$app/.vrt/report.json=$url")
+          done
+          node .github/scripts/vrt-comment.mjs "${args[@]}" > comment.md
           marker='<!-- vrt-report -->'
           comment_id=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" --paginate --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1)
           # sticky comment: 既存があれば編集（PATCH）し、無ければ新規投稿する。
@@ -144,6 +160,6 @@ jobs:
       # 差分があっても CI は落とさず、warning 注釈で可視化するだけにする。
       # 意図した変更かの判断は人間が PR コメント（sticky）と report を見て行う。
       - name: Warn when differences exist
-        if: github.event_name == 'pull_request' && (steps.compare-main.outcome == 'failure' || steps.compare-admin.outcome == 'failure')
+        if: github.event_name == 'pull_request' && steps.compare.outputs.failed == 'true'
         run: |
           echo '::warning::視覚的な差分があります。PRコメントとvrt-report artifactを確認してください。'

--- a/apps/admin/src/features/baseline/interface/queries.ts
+++ b/apps/admin/src/features/baseline/interface/queries.ts
@@ -37,5 +37,4 @@ export const getBrowserSupport = async () => {
 export type {
   BaselineSnapshotRecord,
   BaselineStatus,
-  BrowserSupportRecord,
 } from '../infrastructure/baseline-repository';

--- a/apps/main/src/features/baseline/interface/queries.ts
+++ b/apps/main/src/features/baseline/interface/queries.ts
@@ -20,4 +20,3 @@ export async function getBaselineMinVersions() {
 }
 
 export type { BaselineFeature } from '@/features/baseline/application/baseline';
-export type { BaselineMinVersions } from '@repo/helpers/browser/detect-browser';

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
   "devDependencies": {
     "@k8o/oxc-config": "0.1.3",
     "@ls-lint/ls-lint": "2.3.1",
-    "@oxlint/plugins": "1.70.0",
     "@types/node": "24.13.2",
     "@typescript/native-preview": "7.0.0-dev.20260620.1",
     "@vercel/next-browser": "0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,96 +6,6 @@ settings:
 
 catalogs:
   default:
-    '@k8o/arte-odyssey':
-      specifier: 10.6.1
-      version: 10.6.1
-    '@next/env':
-      specifier: 16.2.9
-      version: 16.2.9
-    '@next/mdx':
-      specifier: 16.2.9
-      version: 16.2.9
-    '@next/third-parties':
-      specifier: 16.2.9
-      version: 16.2.9
-    '@storybook/addon-a11y':
-      specifier: 10.4.6
-      version: 10.4.6
-    '@storybook/addon-docs':
-      specifier: 10.4.6
-      version: 10.4.6
-    '@storybook/addon-mcp':
-      specifier: 0.6.0
-      version: 0.6.0
-    '@storybook/addon-vitest':
-      specifier: 10.4.6
-      version: 10.4.6
-    '@storybook/nextjs-vite':
-      specifier: 10.4.6
-      version: 10.4.6
-    '@tailwindcss/postcss':
-      specifier: 4.3.1
-      version: 4.3.1
-    '@types/react':
-      specifier: 19.2.17
-      version: 19.2.17
-    '@types/react-dom':
-      specifier: 19.2.3
-      version: 19.2.3
-    '@vitest/browser-playwright':
-      specifier: 4.1.9
-      version: 4.1.9
-    '@vitest/coverage-v8':
-      specifier: 4.1.9
-      version: 4.1.9
-    '@vitest/ui':
-      specifier: 4.1.9
-      version: 4.1.9
-    babel-plugin-react-compiler:
-      specifier: 1.0.0
-      version: 1.0.0
-    better-auth:
-      specifier: 1.6.20
-      version: 1.6.20
-    chromatic:
-      specifier: 17.5.0
-      version: 17.5.0
-    drizzle-orm:
-      specifier: 0.45.2
-      version: 0.45.2
-    next:
-      specifier: 16.2.9
-      version: 16.2.9
-    next-themes:
-      specifier: 0.4.6
-      version: 0.4.6
-    postcss:
-      specifier: 8.5.15
-      version: 8.5.15
-    postcss-load-config:
-      specifier: 6.0.1
-      version: 6.0.1
-    react:
-      specifier: 19.2.7
-      version: 19.2.7
-    react-dom:
-      specifier: 19.2.7
-      version: 19.2.7
-    storybook:
-      specifier: 10.4.6
-      version: 10.4.6
-    storybook-addon-determinism:
-      specifier: 0.1.1
-      version: 0.1.1
-    storybook-addon-vrt:
-      specifier: 0.1.0
-      version: 0.1.0
-    tailwindcss:
-      specifier: 4.3.1
-      version: 4.3.1
-    vitest:
-      specifier: 4.1.9
-      version: 4.1.9
     wrangler:
       specifier: 4.103.0
       version: 4.103.0
@@ -113,9 +23,6 @@ importers:
       '@ls-lint/ls-lint':
         specifier: 2.3.1
         version: 2.3.1
-      '@oxlint/plugins':
-        specifier: 1.70.0
-        version: 1.70.0
       '@types/node':
         specifier: 24.13.2
         version: 24.13.2
@@ -3099,10 +3006,6 @@ packages:
 
   '@oxlint/plugins@1.68.0':
     resolution: {integrity: sha512-titLmukUt/h8ho7Svlf0xSBjoy2ccZKrXjpXpZCj+v6V4CJccC2KyP45BLSCMx8YIpifMyiDyUptM4+5sruKbQ==}
-    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-
-  '@oxlint/plugins@1.70.0':
-    resolution: {integrity: sha512-Ut6i0mPdferb+8YJFPaVAg95Fcqduk6fL3PlA4CX58OaPJOi8vvTAcm6iO40Krd5FFMWP+hAhIxlYEhvgvYA6w==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@polka/url@1.0.0-next.29':
@@ -8636,8 +8539,6 @@ snapshots:
     optional: true
 
   '@oxlint/plugins@1.68.0': {}
-
-  '@oxlint/plugins@1.70.0': {}
 
   '@polka/url@1.0.0-next.29': {}
 

--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -20,12 +20,6 @@ if [ -z "$APP_NAME" ]; then
   exit 1
 fi
 
-# renovateブランチはpreviewビルドをスキップ
-if [[ "${VERCEL_GIT_COMMIT_REF:-}" == renovate/* ]]; then
-  log "Skipping: Renovate branch (${VERCEL_GIT_COMMIT_REF})"
-  exit 0
-fi
-
 # 同一commitの再ビルド（Vercelダッシュボードからの手動Redeployやenv var変更後の再ビルド）は常に実行する
 if [ -n "${VERCEL_GIT_COMMIT_SHA:-}" ] \
   && [ -n "${VERCEL_GIT_PREVIOUS_SHA:-}" ] \

--- a/scripts/ignore-build.sh
+++ b/scripts/ignore-build.sh
@@ -20,6 +20,12 @@ if [ -z "$APP_NAME" ]; then
   exit 1
 fi
 
+# renovateブランチはpreviewビルドをスキップ
+if [[ "${VERCEL_GIT_COMMIT_REF:-}" == renovate/* ]]; then
+  log "Skipping: Renovate branch (${VERCEL_GIT_COMMIT_REF})"
+  exit 0
+fi
+
 # 同一commitの再ビルド（Vercelダッシュボードからの手動Redeployやenv var変更後の再ビルド）は常に実行する
 if [ -n "${VERCEL_GIT_COMMIT_SHA:-}" ] \
   && [ -n "${VERCEL_GIT_PREVIOUS_SHA:-}" ] \


### PR DESCRIPTION
## 概要

CI / ツーリングの改善5点です。コミット単位で分割してあります。

## 詳細

- **ci.yml**: actions/cache（SHA pin）で `.turbo` を永続化（キー: OS + job + ref + sha、restore-keys でフォールバック）。concurrency を追加（main への push は cancel しない）。chromatic.yml にも concurrency を追加
- **vrt.yml**: 対象アプリを env `VRT_APPS` に一元化して **ai を追加**（stories 5件と test:vrt が既に揃っているのに CI 対象外だった）。ベースライン artifact を per-app から単一 `vrt-baseline/<app>` 構造に変更。fork PR ではコメント投稿・Pages 公開をスキップするガードを追加
- **knip-report.sh**: パイプ経由で knip の exit code が握りつぶされ「exit 2 以上は失敗」分岐がデッドコードになっていたのを修正。knip のフル実行2回→1回に削減
- **knip の検出3件を解消**: 未使用 devDependency `@oxlint/plugins` を削除（vite-plus が自前の依存として持っており、ルートのピンは効いていない）、未使用の型 re-export 2件を削除 → `pnpm run knip` が exit 0 に
- ~~**ignore-build.sh**: renovate/* の Vercel プレビュービルドスキップを削除~~ → **Vercel ビルドコストの観点から revert 済み**（renovate/* のプレビュースキップは維持）。「Renovate PR が next build を一度も通らず merge されうる」問題は未解決の既知事項として残る（CI へのビルドジョブ追加は TURSO env が必須のため見送り）

## 気をつけるポイント

- **マージ直後、main の VRT 実行が完走するまでの間、既存 PR の VRT 比較は「ベースラインなし」でスキップされます**（自己回復します）。マージ後に main の vrt 実行が成功することを確認してください
- ai の test:vrt は CI 初実行です
- chromatic への ai 追加はプロジェクトトークンが必要なため見送りました

## 影響範囲

GitHub Actions のみ（+ knip 対応の軽微なソース削除2行）

## テスト

knip-report.sh は fake knip で4モードの end-to-end 検証、`pnpm -F ai` が `@repo/ai` にマッチすることを pnpm 11.8.0 で実証、actions/cache の SHA pin を gh api で確認、lockfile は frozen-lockfile 検証パス

