### PR TITLE
feat(reading-list): ソース絞り込みを検索付きマルチセレクト化・期間フィルタ削除

### DIFF
--- a/apps/main/src/app/reading-list/_components/filter-bar/filter-bar.stories.tsx
+++ b/apps/main/src/app/reading-list/_components/filter-bar/filter-bar.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { expect, within } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
 import { FilterBar } from './filter-bar';
 
@@ -17,13 +17,11 @@ const meta: Meta<typeof FilterBar> = {
       { id: 5, title: 'CSS Tricks', articleCount: 6 },
     ],
     query: '',
-    dateRange: 'all',
     sortOrder: 'newest',
     sourceIds: [],
     onQueryChange: noop,
-    onDateChange: noop,
     onSortChange: noop,
-    onSourceToggle: noop,
+    onSourceChange: noop,
   },
 };
 
@@ -36,12 +34,39 @@ export const Primary: Story = {
     await expect(
       canvas.getByRole('textbox', { name: '検索' }),
     ).toBeInTheDocument();
-    await expect(canvas.getByText('ソース')).toBeInTheDocument();
-    await expect(
-      canvas.getByRole('combobox', { name: '期間' }),
-    ).toBeInTheDocument();
     await expect(
       canvas.getByRole('combobox', { name: '並び順' }),
     ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('combobox', { name: 'ソース' }),
+    ).toBeInTheDocument();
+  },
+};
+
+// 正常系: 選択済みソースが削除可能なチップとして表示される
+export const WithSelectedSources: Story = {
+  args: {
+    sourceIds: [1, 3],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('web.dev (24)')).toBeInTheDocument();
+    await expect(canvas.getByText('Chrome Developers (8)')).toBeInTheDocument();
+  },
+};
+
+// 正常系: 入力して候補から選ぶと、その id が onSourceChange に渡る
+export const SelectByTyping: Story = {
+  args: {
+    onSourceChange: fn<(ids: number[]) => void>(),
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    const combobox = canvas.getByRole('combobox', { name: 'ソース' });
+    await userEvent.click(combobox);
+    await userEvent.type(combobox, 'Zenn');
+    const option = await canvas.findByRole('option', { name: 'Zenn (15)' });
+    await userEvent.click(option);
+    await expect(args.onSourceChange).toHaveBeenCalledWith([2]);
   },
 };

--- a/apps/main/src/app/reading-list/_components/filter-bar/filter-bar.tsx
+++ b/apps/main/src/app/reading-list/_components/filter-bar/filter-bar.tsx
@@ -1,19 +1,16 @@
 'use client';
 
 import {
-  Checkbox,
+  Autocomplete,
   FormControl,
   Heading,
   Select,
   Separator,
   TextField,
 } from '@k8o/arte-odyssey';
-import { type FC, useMemo } from 'react';
+import type { FC } from 'react';
 
 import {
-  DATE_RANGE_OPTIONS,
-  type DateRange,
-  isDateRange,
   isSortOrder,
   SORT_OPTIONS,
   type SortOrder,
@@ -29,26 +26,29 @@ type Props = {
   sources: readonly Source[];
   query: string;
   onQueryChange: (value: string) => void;
-  dateRange: DateRange;
-  onDateChange: (value: DateRange) => void;
   sortOrder: SortOrder;
   onSortChange: (value: SortOrder) => void;
   sourceIds: number[];
-  onSourceToggle: (id: number) => void;
+  onSourceChange: (ids: number[]) => void;
 };
 
 export const FilterBar: FC<Props> = ({
   sources,
   query,
   onQueryChange,
-  dateRange,
-  onDateChange,
   sortOrder,
   onSortChange,
   sourceIds,
-  onSourceToggle,
+  onSourceChange,
 }) => {
-  const selectedSet = useMemo(() => new Set(sourceIds), [sourceIds]);
+  const sourceOptions = sources
+    .filter(
+      (source) => source.articleCount > 0 || sourceIds.includes(source.id),
+    )
+    .map((source) => ({
+      value: String(source.id),
+      label: `${source.title} (${source.articleCount})`,
+    }));
 
   return (
     <div className="flex flex-col gap-5">
@@ -63,21 +63,6 @@ export const FilterBar: FC<Props> = ({
             }}
             placeholder="記事を検索..."
             value={query}
-          />
-        )}
-      />
-      <FormControl
-        label="期間"
-        renderInput={({ 'aria-labelledby': _, ...props }) => (
-          <Select
-            {...props}
-            onChange={(e) => {
-              if (isDateRange(e.target.value)) {
-                onDateChange(e.target.value);
-              }
-            }}
-            options={DATE_RANGE_OPTIONS}
-            value={dateRange}
           />
         )}
       />
@@ -97,26 +82,20 @@ export const FilterBar: FC<Props> = ({
         )}
       />
       <Separator color="subtle" />
-      <fieldset className="flex flex-col gap-2">
-        <legend className="text-fg-mute mb-1 text-xs font-medium">
-          ソース
-        </legend>
-        <ul className="flex max-h-80 flex-col gap-1 overflow-y-auto overscroll-contain">
-          {sources
-            .filter((source) => source.articleCount > 0)
-            .map((source) => (
-              <li key={source.id}>
-                <Checkbox
-                  label={`${source.title} (${source.articleCount})`}
-                  onChange={() => {
-                    onSourceToggle(source.id);
-                  }}
-                  value={selectedSet.has(source.id)}
-                />
-              </li>
-            ))}
-        </ul>
-      </fieldset>
+      <FormControl
+        helpText="複数のソースを選択できます"
+        label="ソース"
+        renderInput={(props) => (
+          <Autocomplete
+            {...props}
+            onChange={(values) => {
+              onSourceChange(values.map(Number));
+            }}
+            options={sourceOptions}
+            value={sourceIds.map(String)}
+          />
+        )}
+      />
     </div>
   );
 };

--- a/apps/main/src/app/reading-list/_components/reading-list-content/reading-list-content.tsx
+++ b/apps/main/src/app/reading-list/_components/reading-list-content/reading-list-content.tsx
@@ -10,7 +10,7 @@ import {
 import { useQueryStates } from 'nuqs';
 import { type FC, type ReactNode, useCallback, useMemo, useState } from 'react';
 
-import type { DateRange, SortOrder } from '../../_utils/constants';
+import type { SortOrder } from '../../_utils/constants';
 import { readingListParsers } from '../../_utils/search-params';
 import { FilterBar } from '../filter-bar';
 
@@ -33,29 +33,12 @@ type Props = {
   cards: Readonly<Record<number, ReactNode>>;
 };
 
-const getDateThreshold = (range: DateRange): Date => {
-  const now = new Date();
-  switch (range) {
-    case 'today':
-      return new Date(now.getFullYear(), now.getMonth(), now.getDate());
-    case 'week':
-      return new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-    case 'month':
-      return new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-    case 'all':
-      return new Date(0);
-    default:
-      return new Date(0);
-  }
-};
-
 export const ReadingListContent: FC<Props> = ({ articles, sources, cards }) => {
   const [params, setParams] = useQueryStates(readingListParsers);
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
 
   const query = params.q;
   const sourceIds = params.source;
-  const dateRange = params.date;
   const sortOrder = params.sort;
 
   const handleQueryChange = useCallback(
@@ -65,19 +48,9 @@ export const ReadingListContent: FC<Props> = ({ articles, sources, cards }) => {
     [setParams],
   );
 
-  const handleSourceToggle = useCallback(
-    (id: number) => {
-      const next = sourceIds.includes(id)
-        ? sourceIds.filter((sid) => sid !== id)
-        : [...sourceIds, id];
-      void setParams({ source: next.length > 0 ? next : null });
-    },
-    [sourceIds, setParams],
-  );
-
-  const handleDateChange = useCallback(
-    (value: DateRange) => {
-      void setParams({ date: value === 'all' ? null : value });
+  const handleSourceChange = useCallback(
+    (ids: number[]) => {
+      void setParams({ source: ids.length > 0 ? ids : null });
     },
     [setParams],
   );
@@ -89,8 +62,6 @@ export const ReadingListContent: FC<Props> = ({ articles, sources, cards }) => {
     [setParams],
   );
 
-  const dateThreshold = useMemo(() => getDateThreshold(dateRange), [dateRange]);
-
   const filteredArticles = useMemo(() => {
     const lowerQuery = query.toLowerCase();
     const filtered = articles.filter((article) => {
@@ -98,12 +69,6 @@ export const ReadingListContent: FC<Props> = ({ articles, sources, cards }) => {
         return false;
       }
       if (sourceIds.length > 0 && !sourceIds.includes(article.sourceId)) {
-        return false;
-      }
-      if (
-        dateRange !== 'all' &&
-        new Date(article.publishedAt) < dateThreshold
-      ) {
         return false;
       }
       return true;
@@ -114,14 +79,12 @@ export const ReadingListContent: FC<Props> = ({ articles, sources, cards }) => {
         new Date(b.publishedAt).getTime() - new Date(a.publishedAt).getTime();
       return sortOrder === 'oldest' ? -diff : diff;
     });
-  }, [articles, query, sourceIds, dateRange, dateThreshold, sortOrder]);
+  }, [articles, query, sourceIds, sortOrder]);
 
   const filterBarProps = {
-    dateRange,
-    onDateChange: handleDateChange,
     onQueryChange: handleQueryChange,
     onSortChange: handleSortChange,
-    onSourceToggle: handleSourceToggle,
+    onSourceChange: handleSourceChange,
     query,
     sortOrder,
     sourceIds,

--- a/apps/main/src/app/reading-list/_utils/constants.ts
+++ b/apps/main/src/app/reading-list/_utils/constants.ts
@@ -1,21 +1,3 @@
-const DATE_RANGE_DEFINITIONS = [
-  { value: 'all', label: 'すべての期間（3ヶ月）' },
-  { value: 'today', label: '今日の記事' },
-  { value: 'week', label: '1週間以内' },
-  { value: 'month', label: '1ヶ月以内' },
-] as const;
-
-export type DateRange = (typeof DATE_RANGE_DEFINITIONS)[number]['value'];
-
-export const DATE_RANGE_OPTIONS = DATE_RANGE_DEFINITIONS;
-
-export const DATE_RANGE_VALUES = DATE_RANGE_DEFINITIONS.map((o) => o.value);
-
-const DATE_RANGE_SET = new Set<string>(DATE_RANGE_VALUES);
-
-export const isDateRange = (value: string): value is DateRange =>
-  DATE_RANGE_SET.has(value);
-
 export const SORT_OPTIONS = [
   { value: 'newest', label: '新しい順' },
   { value: 'oldest', label: '古い順' },

--- a/apps/main/src/app/reading-list/_utils/search-params.ts
+++ b/apps/main/src/app/reading-list/_utils/search-params.ts
@@ -5,11 +5,10 @@ import {
   parseAsStringLiteral,
 } from 'nuqs/server';
 
-import { DATE_RANGE_VALUES, SORT_VALUES } from './constants';
+import { SORT_VALUES } from './constants';
 
 export const readingListParsers = {
   q: parseAsString.withDefault(''),
   source: parseAsArrayOf(parseAsInteger).withDefault([]),
-  date: parseAsStringLiteral(DATE_RANGE_VALUES).withDefault('all'),
   sort: parseAsStringLiteral(SORT_VALUES).withDefault('newest'),
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,96 @@ settings:
 
 catalogs:
   default:
+    '@k8o/arte-odyssey':
+      specifier: 10.6.3
+      version: 10.6.3
+    '@next/env':
+      specifier: 16.2.9
+      version: 16.2.9
+    '@next/mdx':
+      specifier: 16.2.9
+      version: 16.2.9
+    '@next/third-parties':
+      specifier: 16.2.9
+      version: 16.2.9
+    '@storybook/addon-a11y':
+      specifier: 10.4.6
+      version: 10.4.6
+    '@storybook/addon-docs':
+      specifier: 10.4.6
+      version: 10.4.6
+    '@storybook/addon-mcp':
+      specifier: 0.6.0
+      version: 0.6.0
+    '@storybook/addon-vitest':
+      specifier: 10.4.6
+      version: 10.4.6
+    '@storybook/nextjs-vite':
+      specifier: 10.4.6
+      version: 10.4.6
+    '@tailwindcss/postcss':
+      specifier: 4.3.1
+      version: 4.3.1
+    '@types/react':
+      specifier: 19.2.17
+      version: 19.2.17
+    '@types/react-dom':
+      specifier: 19.2.3
+      version: 19.2.3
+    '@vitest/browser-playwright':
+      specifier: 4.1.9
+      version: 4.1.9
+    '@vitest/coverage-v8':
+      specifier: 4.1.9
+      version: 4.1.9
+    '@vitest/ui':
+      specifier: 4.1.9
+      version: 4.1.9
+    babel-plugin-react-compiler:
+      specifier: 1.0.0
+      version: 1.0.0
+    better-auth:
+      specifier: 1.6.20
+      version: 1.6.20
+    chromatic:
+      specifier: 17.5.0
+      version: 17.5.0
+    drizzle-orm:
+      specifier: 0.45.2
+      version: 0.45.2
+    next:
+      specifier: 16.2.9
+      version: 16.2.9
+    next-themes:
+      specifier: 0.4.6
+      version: 0.4.6
+    postcss:
+      specifier: 8.5.15
+      version: 8.5.15
+    postcss-load-config:
+      specifier: 6.0.1
+      version: 6.0.1
+    react:
+      specifier: 19.2.7
+      version: 19.2.7
+    react-dom:
+      specifier: 19.2.7
+      version: 19.2.7
+    storybook:
+      specifier: 10.4.6
+      version: 10.4.6
+    storybook-addon-determinism:
+      specifier: 0.1.1
+      version: 0.1.1
+    storybook-addon-vrt:
+      specifier: 0.1.0
+      version: 0.1.0
+    tailwindcss:
+      specifier: 4.3.1
+      version: 4.3.1
+    vitest:
+      specifier: 4.1.9
+      version: 4.1.9
     wrangler:
       specifier: 4.103.0
       version: 4.103.0
@@ -64,7 +154,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.6.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.6.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -176,7 +266,7 @@ importers:
         version: 3.0.210(react@19.2.7)(zod@4.4.3)
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.6.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.6.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
       '@repo/code-highlight':
         specifier: workspace:*
         version: link:../../packages/code-highlight
@@ -288,7 +378,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.6.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.6.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
       '@mdx-js/loader':
         specifier: 3.1.1
         version: 3.1.1
@@ -1537,8 +1627,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@k8o/arte-odyssey@10.6.1':
-    resolution: {integrity: sha512-fiC9oHHYx0i5/evNDWcH/SHiFyt1fO+bWNwAJ4b+MiBX7V8aq6fC8O+vj2zQVbF6PK4S+reypjvOGxYv99vxyQ==}
+  '@k8o/arte-odyssey@10.6.3':
+    resolution: {integrity: sha512-QqdHZ4vX2jsgRviKOz+SVgHGXsmzYK2gLxDGg96MEGZeCR/mWV+vumvU7XYlD0In0XVFOtYZFtyEgT/tpca36g==}
     peerDependencies:
       '@json-render/core': '>=0.19.0'
       '@json-render/react': '>=0.19.0'
@@ -4185,8 +4275,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.38:
-    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
+  baseline-browser-mapping@2.10.32:
+    resolution: {integrity: sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -7524,7 +7614,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@k8o/arte-odyssey@10.6.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)':
+  '@k8o/arte-odyssey@10.6.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -9426,7 +9516,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.38: {}
+  baseline-browser-mapping@2.10.32: {}
 
   baseline-status@1.1.1:
     dependencies:
@@ -9492,7 +9582,7 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.38
+      baseline-browser-mapping: 2.10.32
       caniuse-lite: 1.0.30001793
       electron-to-chromium: 1.5.361
       node-releases: 2.0.46
@@ -11055,7 +11145,7 @@ snapshots:
     dependencies:
       '@next/env': 16.2.9
       '@swc/helpers': 0.5.15
-      baseline-browser-mapping: 2.10.38
+      baseline-browser-mapping: 2.10.32
       caniuse-lite: 1.0.30001793
       postcss: 8.4.31
       react: 19.2.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ allowBuilds:
 blockExoticSubdeps: true
 
 catalog:
-  '@k8o/arte-odyssey': 10.6.1
+  '@k8o/arte-odyssey': 10.6.3
   '@next/env': 16.2.9
   '@next/mdx': 16.2.9
   '@next/third-parties': 16.2.9


### PR DESCRIPTION
## 概要

Readings（reading-list）のソース絞り込みを、縦スクロールするチェックボックス一覧から**検索付きのマルチセレクト**に刷新した。併せて実益の薄い「期間」フィルタを削除し、`@k8o/arte-odyssey` を 10.6.3 に更新した。

## 動機

- ソースが増えると、チェックボックスの縦スクロール一覧では目的のソースを探しづらかった。
- 「期間」フィルタは、対象データが直近90日に限られ、既定の並び順（新しい順）で新着が上に来るため実益が薄かった。

## 詳細

- **ソース絞り込み**: ArteOdyssey の `Autocomplete` に置き換え。入力で検索・複数選択でき、選択済みは削除可能なチップで表示する。
- **期間フィルタ削除**: 期間の `Select` と関連する状態・URLクエリ（`date`）・定数（`DATE_RANGE_*`）を除去。絞り込みは 検索 / 並び順 / ソース の3本に整理。
- **依存更新**: `@k8o/arte-odyssey` を 10.6.3 に更新。狭いサイドバーで選択チップやクリアボタンがはみ出す問題は、FormControl の `<fieldset>` と Autocomplete のチップ行への `min-w-0` 付与（10.6.2 / 10.6.3）で**上流側が恒久修正**しており、k8o 側の暫定 CSS は入れていない。

## 気をつけるポイント

- URLクエリから `date` を削除（`q` / `source` / `sort` は維持）。
- `FilterBar` の props 変更: `onSourceToggle(id)` → `onSourceChange(ids[])`、`dateRange` / `onDateChange` を削除。

## 影響範囲

- `/reading-list`（Readings）ページの絞り込みサイドバー、およびモバイルの絞り込み Drawer。

## テスト

- `type-check` / lint OK。filter-bar の Storybook テスト 3件（Primary / 選択チップ表示 / 入力→候補選択で `onSourceChange`）green。
- dev サーバーの実機で、選択チップ・クリアボタンが枠内に収まることを 10.6.3（暫定なし）で確認。
