### PR TITLE
feat(main): Baseline一覧のフィルタ改善（直近1週間の基準修正 + URL反映）

### DIFF
--- a/apps/main/src/app/baseline/_components/baseline-feature-list.stories.tsx
+++ b/apps/main/src/app/baseline/_components/baseline-feature-list.stories.tsx
@@ -7,59 +7,52 @@ import type { BlogLink } from '@/features/blog/interface/queries';
 import { BaselineFeatureList } from './baseline-feature-list';
 
 const now = Date.now();
-const toIso = (offsetMs: number): string =>
-  new Date(now - offsetMs).toISOString();
 const DAY_MS = 24 * 60 * 60 * 1000;
+const toDate = (offsetMs: number): string =>
+  new Date(now - offsetMs).toISOString().slice(0, 10);
 
 const FEATURES: BaselineFeature[] = [
   {
     featureId: 'popover',
     name: 'Popover API',
     status: 'widely',
-    date: '2026-01-27',
-    updatedAt: toIso(2 * DAY_MS),
+    date: toDate(2 * DAY_MS),
   },
   {
     featureId: 'view-transitions',
     name: 'View transitions',
     status: 'widely',
-    date: '2026-01-14',
-    updatedAt: toIso(30 * DAY_MS),
+    date: toDate(10 * DAY_MS),
   },
   {
     featureId: 'font-family-math',
     name: 'Math font family',
     status: 'newly',
-    date: '2026-03-24',
-    updatedAt: toIso(3 * DAY_MS),
+    date: toDate(3 * DAY_MS),
   },
   {
     featureId: 'iterator-concat',
     name: 'Iterator.concat()',
     status: 'newly',
-    date: '2026-03-24',
-    updatedAt: toIso(30 * DAY_MS),
+    date: toDate(10 * DAY_MS),
   },
   {
     featureId: 'scope',
     name: '@scope',
     status: 'widely',
     date: '2025-09-27',
-    updatedAt: toIso(60 * DAY_MS),
   },
   {
     featureId: 'promise-try',
     name: 'Promise.try()',
     status: 'newly',
     date: '2025-07-02',
-    updatedAt: toIso(90 * DAY_MS),
   },
   {
     featureId: 'highlight',
     name: 'Custom highlight',
     status: 'newly',
     date: '2025-03-12',
-    updatedAt: toIso(180 * DAY_MS),
   },
 ];
 

--- a/apps/main/src/app/baseline/_components/baseline-feature-list.stories.tsx
+++ b/apps/main/src/app/baseline/_components/baseline-feature-list.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { expect, userEvent, within } from 'storybook/test';
 
 import type { BaselineFeature } from '@/features/baseline/interface/queries';
@@ -76,8 +77,16 @@ const meta: Meta<typeof BaselineFeatureList> = {
   args: {
     features: FEATURES,
     blogMap: BLOG_MAP,
-    currentYear: '2026',
+    currentYear: toDate(0).slice(0, 4),
+    nowMs: now,
   },
+  decorators: [
+    (Story) => (
+      <NuqsTestingAdapter>
+        <Story />
+      </NuqsTestingAdapter>
+    ),
+  ],
 };
 
 export default meta;

--- a/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
+++ b/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
@@ -54,7 +54,7 @@ const FeatureList: FC<{
     );
     if (recentOnly) {
       result = result.filter(
-        (f) => new Date(f.updatedAt).getTime() >= recentThresholdMs,
+        (f) => new Date(f.date).getTime() >= recentThresholdMs,
       );
     }
     if (query) {
@@ -164,8 +164,7 @@ export const BaselineFeatureList: FC<{
         (feature.status === 'newly' && visibility.newly) ||
         (feature.status === 'widely' && visibility.widely);
       const matchesRecent =
-        !recentOnly ||
-        new Date(feature.updatedAt).getTime() >= recentThresholdMs;
+        !recentOnly || new Date(feature.date).getTime() >= recentThresholdMs;
       const matchesQuery =
         !query ||
         feature.name.toLowerCase().includes(lowerQuery) ||

--- a/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
+++ b/apps/main/src/app/baseline/_components/baseline-feature-list.tsx
@@ -10,10 +10,13 @@ import {
 import { formatDate } from '@repo/helpers/date/format';
 import type { Route } from 'next';
 import Link from 'next/link';
-import { type FC, useMemo, useState } from 'react';
+import { useQueryStates } from 'nuqs';
+import { type FC, useMemo } from 'react';
 
 import type { BaselineFeature } from '@/features/baseline/interface/queries';
 import type { BlogLink } from '@/features/blog/interface/queries';
+
+import { baselineListParsers } from '../_utils/search-params';
 
 type StatusVisibility = {
   newly: boolean;
@@ -124,21 +127,15 @@ export const BaselineFeatureList: FC<{
   features: BaselineFeature[];
   blogMap: Record<string, BlogLink>;
   currentYear: string;
-}> = ({ features, blogMap, currentYear }) => {
-  const [visibility, setVisibility] = useState<StatusVisibility>({
-    newly: true,
-    widely: true,
-  });
-  const [query, setQuery] = useState('');
-  const [recentOnly, setRecentOnly] = useState(false);
-  const [recentThresholdMs, setRecentThresholdMs] = useState(0);
-
-  const toggleRecentOnly = () => {
-    if (!recentOnly) {
-      setRecentThresholdMs(Date.now() - SEVEN_DAYS_MS);
-    }
-    setRecentOnly((prev) => !prev);
-  };
+  nowMs: number;
+}> = ({ features, blogMap, currentYear, nowMs }) => {
+  const [params, setParams] = useQueryStates(baselineListParsers);
+  const { q: query, newly, widely, recent: recentOnly } = params;
+  const visibility = useMemo<StatusVisibility>(
+    () => ({ newly, widely }),
+    [newly, widely],
+  );
+  const recentThresholdMs = nowMs - SEVEN_DAYS_MS;
 
   const availableYears = useMemo(() => getAvailableYears(features), [features]);
 
@@ -191,7 +188,7 @@ export const BaselineFeatureList: FC<{
               <TextField
                 {...props}
                 onChange={(e) => {
-                  setQuery(e.target.value);
+                  void setParams({ q: e.target.value || null });
                 }}
                 placeholder="機能名で検索..."
                 value={query}
@@ -204,27 +201,23 @@ export const BaselineFeatureList: FC<{
             <Checkbox
               label="Newly Available"
               onChange={() => {
-                setVisibility((prev) => ({
-                  ...prev,
-                  newly: !prev.newly,
-                }));
+                void setParams({ newly: !newly });
               }}
-              value={visibility.newly}
+              value={newly}
             />
             <Checkbox
               label="Widely Available"
               onChange={() => {
-                setVisibility((prev) => ({
-                  ...prev,
-                  widely: !prev.widely,
-                }));
+                void setParams({ widely: !widely });
               }}
-              value={visibility.widely}
+              value={widely}
             />
           </div>
           <Checkbox
             label="直近1週間の更新のみ"
-            onChange={toggleRecentOnly}
+            onChange={() => {
+              void setParams({ recent: !recentOnly });
+            }}
             value={recentOnly}
           />
         </div>
@@ -232,8 +225,15 @@ export const BaselineFeatureList: FC<{
 
       {defaultYear !== undefined && (
         <Tabs.Root
-          defaultSelectedId={defaultYear}
           ids={availableYears as [string, ...string[]]}
+          onChange={(id) => {
+            void setParams({ year: id === defaultYear ? null : id });
+          }}
+          selectedId={
+            params.year !== null && availableYears.includes(params.year)
+              ? params.year
+              : defaultYear
+          }
         >
           <Tabs.List label="年を選択">
             {availableYears.map((year) => {

--- a/apps/main/src/app/baseline/_components/index.ts
+++ b/apps/main/src/app/baseline/_components/index.ts
@@ -1,1 +1,2 @@
 export { BaselineFeatureList } from './baseline-feature-list';
+export { BaselineFeatureListSkeleton } from './skeleton';

--- a/apps/main/src/app/baseline/_components/skeleton.tsx
+++ b/apps/main/src/app/baseline/_components/skeleton.tsx
@@ -1,0 +1,30 @@
+import type { FC } from 'react';
+
+const ROW_KEYS = ['a', 'b', 'c', 'd', 'e'] as const;
+
+export const BaselineFeatureListSkeleton: FC = () => (
+  <section className="bg-bg-raised flex flex-col gap-6 rounded-xl p-5 sm:p-6">
+    <div className="flex flex-col gap-4">
+      <div className="bg-bg-mute h-9 w-full animate-pulse rounded-md sm:max-w-64" />
+      <div className="flex flex-wrap items-center gap-x-8 gap-y-4">
+        <div className="bg-bg-mute h-5 w-32 animate-pulse rounded-md" />
+        <div className="bg-bg-mute h-5 w-32 animate-pulse rounded-md" />
+        <div className="bg-bg-mute h-5 w-40 animate-pulse rounded-md" />
+      </div>
+    </div>
+    <div className="flex flex-col gap-4">
+      <div className="bg-bg-mute h-8 w-48 animate-pulse rounded-md" />
+      <ul className="flex flex-col gap-2.5">
+        {ROW_KEYS.map((key) => (
+          <li className="flex items-center gap-4 px-1 py-2.5" key={key}>
+            <div className="bg-bg-mute h-5 w-14 animate-pulse rounded-full" />
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+              <div className="bg-bg-mute h-4 w-1/2 animate-pulse rounded-md" />
+              <div className="bg-bg-mute h-3 w-1/3 animate-pulse rounded-md" />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
+);

--- a/apps/main/src/app/baseline/_utils/search-params.ts
+++ b/apps/main/src/app/baseline/_utils/search-params.ts
@@ -1,0 +1,9 @@
+import { parseAsBoolean, parseAsString } from 'nuqs/server';
+
+export const baselineListParsers = {
+  q: parseAsString.withDefault(''),
+  newly: parseAsBoolean.withDefault(true),
+  widely: parseAsBoolean.withDefault(true),
+  recent: parseAsBoolean.withDefault(false),
+  year: parseAsString,
+};

--- a/apps/main/src/app/baseline/page.tsx
+++ b/apps/main/src/app/baseline/page.tsx
@@ -1,12 +1,16 @@
 import { Anchor } from '@k8o/arte-odyssey';
+import { Suspense } from 'react';
 
 import { getBaselineFeatures } from '@/features/baseline/interface/queries';
 import { getFeatureBlogMap } from '@/features/blog/interface/queries';
 
-import { BaselineFeatureList } from './_components';
+import {
+  BaselineFeatureList,
+  BaselineFeatureListSkeleton,
+} from './_components';
 
 export default async function BaselinePage() {
-  const [features, blogMap] = await Promise.all([
+  const [{ features, nowMs }, blogMap] = await Promise.all([
     getBaselineFeatures(),
     getFeatureBlogMap(),
   ]);
@@ -15,11 +19,16 @@ export default async function BaselinePage() {
 
   return (
     <div className="flex flex-col gap-6">
-      <BaselineFeatureList
-        blogMap={blogMap}
-        currentYear={latestYear}
-        features={features}
-      />
+      {/* nuqs が searchParams（動的データ）を読むため、静的プリレンダリング時は
+          Suspense 境界が必要。境界内はリクエスト時にレンダリングされる。 */}
+      <Suspense fallback={<BaselineFeatureListSkeleton />}>
+        <BaselineFeatureList
+          blogMap={blogMap}
+          currentYear={latestYear}
+          features={features}
+          nowMs={nowMs}
+        />
+      </Suspense>
       <p className="text-fg-mute text-xs">
         Source:{' '}
         <Anchor href="https://webstatus.dev" openInNewTab>

--- a/apps/main/src/features/baseline/application/baseline.ts
+++ b/apps/main/src/features/baseline/application/baseline.ts
@@ -5,7 +5,6 @@ export type BaselineFeature = {
   name: string;
   status: 'newly' | 'widely';
   date: string;
-  updatedAt: string;
 };
 
 export async function getBaselineFeatures(): Promise<BaselineFeature[]> {
@@ -17,7 +16,6 @@ export async function getBaselineFeatures(): Promise<BaselineFeature[]> {
       name: s.name,
       status: s.status,
       date: s.date,
-      updatedAt: s.updatedAt,
     }))
     .toSorted((a, b) => b.date.localeCompare(a.date));
 }

--- a/apps/main/src/features/baseline/interface/queries.ts
+++ b/apps/main/src/features/baseline/interface/queries.ts
@@ -8,7 +8,10 @@ export async function getBaselineFeatures() {
   cacheLife('minutes');
 
   const features = await _getBaselineFeatures();
-  return features;
+  // 「直近1週間」フィルタの基準時刻。component render では Date.now() を呼べない
+  // （React Compiler の purity ルール / 静的プリレンダリングの現在時刻制約）ため、
+  // キャッシュ境界内で解決して features と一緒に返す。鮮度は cacheLife('minutes') 相当。
+  return { features, nowMs: Date.now() };
 }
 
 export async function getBaselineMinVersions() {


### PR DESCRIPTION
## 概要

`/baseline` 一覧の「直近1週間の更新のみ」フィルタの不具合を修正し、あわせて一覧のフィルタ状態（検索 / Newly / Widely / 直近1週間 / 選択中の年タブ）を URL のクエリパラメータに反映するようにした。

## 動機

- 「直近1週間」フィルタが `updatedAt`（DB 行の同期書き込み時刻）を基準にしており、実際の Baseline の新着を反映できていなかった。初回同期で全機能が一斉に `updatedAt` 更新されるため、テーブル投入直後は全件が「直近」に該当し、以降はほぼ該当なしになる。
- フィルタ状態が URL に残らず、リロードや共有で失われていた。

## 詳細

**fix: 直近1週間フィルタの基準を修正**
- 判定を各機能の Baseline 日付 `date`（newly は `low_date`、widely は `high_date`）基準に変更。`date` は年タブの区分にも使う値で、直近該当分が必ず現在年に入るためデフォルトタブとも整合する。
- main 側で未使用になった `updatedAt` を `BaselineFeature` 型と取得マッピングから除去（**DB カラムは残置**）。

**feat: フィルタ状態を URL に反映**
- 既存パターンに合わせ nuqs（`useQueryStates`）で `q` / `newly` / `widely` / `recent` / `year` を URL 同期。パーサは `_utils/search-params.ts` に定義（デフォルト値のときは URL から省略）。
- 年タブは `Tabs` を制御モード（`selectedId` / `onChange`）にして反映。
- 例: `/baseline?q=popover&widely=false&recent=true&year=2025`

## 気をつけるポイント

- **基準時刻はサーバー側の非 component 関数 `getNowMs()` で解決して prop 渡し**にしている。クライアント／サーバーいずれの component render でも `Date.now()` は React Compiler の purity ルールで禁止されるため。ページは `cacheLife('minutes')` 依存で再検証されるので、7日フィルタには十分な鮮度。
- DB の `updated_at` カラムと同期ジョブ（admin）は**無変更**。今回は読み取りロジックの変更のみ。
- 元実装はトグル時に時刻取得だったが、今回はページ読み込み時刻が基準になる（長時間開きっぱなしのセッションでは基準が読み込み時点に固定されるが、7日窓には実用上問題なし）。

## 影響範囲

- `/baseline` ページのみ。DB スキーマ・マイグレーション・admin・同期ジョブへの変更なし。

## テスト

- `pnpm -F main run type-check` ✓
- Story テスト 386 件パス ✓（`NuqsTestingAdapter` 配下でフィルタ操作を検証）
- `pnpm run check` 0 errors ✓