### PR TITLE
ci(ai-bake): sign re-bake commits via createCommitOnBranch

### DIFF
--- a/.github/workflows/ai-bake.yml
+++ b/.github/workflows/ai-bake.yml
@@ -62,7 +62,6 @@ jobs:
         if: steps.drift.outputs.stale == 'true'
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
           BRANCH: ${{ github.event.pull_request.head.ref }}
           REPO: ${{ github.repository }}
           POINTER: apps/ai/src/features/preview/infrastructure/template-snapshot.ts
@@ -71,10 +70,23 @@ jobs:
             echo "snapshot は最新（差分なし）。コミットしません。"
             exit 0
           fi
-          bot_user="${APP_SLUG}[bot]"
-          bot_id=$(gh api "/users/${bot_user}" --jq .id)
-          git config user.name "$bot_user"
-          git config user.email "${bot_id}+${bot_user}@users.noreply.github.com"
-          git add "$POINTER"
-          git commit -m "chore(ai): re-bake sandbox snapshot"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "HEAD:${BRANCH}"
+          # GitHub API(createCommitOnBranch)経由でコミットすると App 署名が付き verified になる。
+          # ローカル git commit だと unsigned になり、Vercel の verified-commits 制約でデプロイが CANCELED される。
+          head_oid=$(git rev-parse HEAD)
+          jq -n \
+            --arg repo "$REPO" \
+            --arg branch "$BRANCH" \
+            --arg oid "$head_oid" \
+            --arg path "$POINTER" \
+            --arg contents "$(base64 -w0 "$POINTER")" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: $branch },
+                  message: { headline: "chore(ai): re-bake sandbox snapshot" },
+                  expectedHeadOid: $oid,
+                  fileChanges: { additions: [{ path: $path, contents: $contents }] }
+                }
+              }
+            }' | gh api graphql --input -


### PR DESCRIPTION
## 背景

Renovate の `apps/ai/sandbox-template/**` を含む PR で `AI Sandbox Bake` ワークフローが走ると、`k8o-bot` が `template-snapshot.ts` を再 bake してコミットする。

このコミットがローカル `git commit`（未署名）だったため、Vercel の **verified-commits 制約**に引っかかり、デプロイが `CANCELED`（= PR のステータスが FAILURE）になっていた。

例: #1931 の HEAD `chore(ai): re-bake sandbox snapshot` は `verified: false / unsigned`。

## 変更

`ai-bake.yml` のコミット処理を、ローカル `git commit` + `git push` から GitHub GraphQL API `createCommitOnBranch` 経由に変更。App トークンで叩くと GitHub が自動署名するため verified コミットになり、Vercel に弾かれなくなる。

- 変更ファイルを base64 化して `fileChanges.additions` で送信
- `expectedHeadOid` に現在の HEAD を渡し、想定外の並行 push があれば mutation が失敗して気付ける
- 不要になった `APP_SLUG` / 手動 author 設定を削除（author は App = `k8o-bot[bot]` として自動付与）

## 確認

- YAML 構文 OK
- 生成 JSON が `CreateCommitOnBranchInput` スキーマに一致、base64 往復も一致