### PR TITLE
refactor(main): Reading セクション見出しを Explore に改称

### DIFF
--- a/apps/main/src/app/_components/site-entry-section/site-entry-section.stories.tsx
+++ b/apps/main/src/app/_components/site-entry-section/site-entry-section.stories.tsx
@@ -30,13 +30,13 @@ export const Tools: Story = {
   },
 };
 
-export const Reading: Story = {
+export const Explore: Story = {
   args: { kind: 'reading' },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
     await expect(
-      canvas.getByRole('heading', { name: 'Reading' }),
+      canvas.getByRole('heading', { name: 'Explore' }),
     ).toBeInTheDocument();
     const readingCount = siteEntries.filter(
       (entry) => entry.kind === 'reading',

--- a/apps/main/src/shared/site/site-entries.ts
+++ b/apps/main/src/shared/site/site-entries.ts
@@ -34,7 +34,7 @@ export const KIND_SECTION: Record<
     description: '日々の作業や遊びに使う、ちょっとした道具。',
   },
   reading: {
-    title: 'Reading',
+    title: 'Explore',
     description: '読んだり眺めたりする、書きもの・集めもの。',
   },
 };


### PR DESCRIPTION
サイト一覧のセクション見出し「Reading」と、その配下エントリ「Readings」が単数/複数違いの親子で紛らわしかったため、束ね側の見出しを **Explore** に変更した。

## 変更内容

- `KIND_SECTION.reading.title` を `'Reading'` → `'Explore'`（`apps/main/src/shared/site/site-entries.ts`）
- Storybook の story 名 `Reading` → `Explore`、見出し assertion も `'Explore'` に追随（`site-entry-section.stories.tsx`）

## 気をつけるポイント

- ユーザーに見えない内部値（`kind: 'reading'` / `icon: 'readings'` / `reading-list` 機能 / 通知 `readings_updated`）は変更していない。表示文字列のみの差し替え。
- エントリ「Readings」はセクションが `Explore` になり衝突しなくなったため、そのまま据え置き。
- story 名を変えたので story id が変わり、VRT ベースラインはこの story 分だけ次回 main 比較時に再取得扱いになる。

## テスト

- `pnpm -F main run test --project=storybook site-entry-section` → 2 stories pass