### PR TITLE
fix(main): かどまるラボの openGraph.url を実ルートに修正

### DIFF
--- a/apps/main/src/app/radius-maker/layout.tsx
+++ b/apps/main/src/app/radius-maker/layout.tsx
@@ -7,7 +7,7 @@ export const metadata = {
   openGraph: {
     title: 'かどまるラボ',
     description: 'border-radiusを視覚的に操作してCSSを生成します。',
-    url: 'https://k8o.me/rounded-maker',
+    url: 'https://k8o.me/radius-maker',
     siteName: 'k8o',
     locale: 'ja',
     type: 'website',


### PR DESCRIPTION
## 変更内容

かどまるラボ（`apps/main/src/app/radius-maker/layout.tsx`）の `openGraph.url` が旧パスの `https://k8o.me/rounded-maker` のままになっていたため、実際のルートに合わせて `https://k8o.me/radius-maker` に修正しました。

## 背景

実ルートは `/radius-maker` ですが、OGPメタデータのURLだけが古いパスを指しており、SNSシェア時のcanonical URLが誤っていました。

## 確認

- `pnpm run check`: 0 errors（既存warningのみ）
- `pnpm run type-check`: 全タスク成功