### PR TITLE
feat: 色パレット生成ツール「いろばしご」を追加

### DIFF
--- a/apps/main/src/app/_components/site-entry-section/site-entry-section.tsx
+++ b/apps/main/src/app/_components/site-entry-section/site-entry-section.tsx
@@ -12,6 +12,7 @@ import {
   PaletteIcon,
   ShieldCheckIcon,
   SlideIcon,
+  SparklesIcon,
   SquircleIcon,
 } from '@k8o/arte-odyssey';
 import type { ReactNode } from 'react';
@@ -31,6 +32,7 @@ const ICON: Record<SiteEntryIcon, ReactNode> = {
   contrastChecker: <ColorContrastIcon size="md" />,
   colorQuiz: <MixedColorIcon size="md" />,
   radiusMaker: <SquircleIcon size="md" />,
+  paletteMaker: <SparklesIcon size="md" />,
   mojiCount: <HorizontalWritingIcon size="md" />,
   htmlNest: <CodeXmlIcon size="md" />,
   fluida: <PaletteIcon size="md" />,

--- a/apps/main/src/app/_components/site-entry-section/site-entry-section.tsx
+++ b/apps/main/src/app/_components/site-entry-section/site-entry-section.tsx
@@ -3,6 +3,7 @@ import {
   CodeXmlIcon,
   ColorContrastIcon,
   ColorInfoIcon,
+  ColorScaleIcon,
   FlaskIcon,
   Heading,
   HorizontalWritingIcon,
@@ -12,7 +13,6 @@ import {
   PaletteIcon,
   ShieldCheckIcon,
   SlideIcon,
-  SparklesIcon,
   SquircleIcon,
 } from '@k8o/arte-odyssey';
 import type { ReactNode } from 'react';
@@ -32,7 +32,7 @@ const ICON: Record<SiteEntryIcon, ReactNode> = {
   contrastChecker: <ColorContrastIcon size="md" />,
   colorQuiz: <MixedColorIcon size="md" />,
   radiusMaker: <SquircleIcon size="md" />,
-  paletteMaker: <SparklesIcon size="md" />,
+  paletteMaker: <ColorScaleIcon size="md" />,
   mojiCount: <HorizontalWritingIcon size="md" />,
   htmlNest: <CodeXmlIcon size="md" />,
   fluida: <PaletteIcon size="md" />,

--- a/apps/main/src/app/palette-maker/_components/contrast-table/contrast-table.stories.tsx
+++ b/apps/main/src/app/palette-maker/_components/contrast-table/contrast-table.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { PALETTE_STEPS } from '../../_types/palette';
+import { generatePalette } from '../../_utils/palette';
+import { ContrastTable } from './contrast-table';
+
+const meta: Meta<typeof ContrastTable> = {
+  title: 'app/palette-maker/contrast-table',
+  component: ContrastTable,
+};
+
+export default meta;
+type Story = StoryObj<typeof ContrastTable>;
+
+export const Primary: Story = {
+  args: {
+    swatches: generatePalette(250, 0.12),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const table = canvas.getByRole('table');
+    const rows = within(table).getAllByRole('row');
+    // ヘッダー行 + 11段
+    await expect(rows).toHaveLength(PALETTE_STEPS.length + 1);
+    await expect(
+      within(table).getByText('oklch(0.66 0.12 250)'),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/main/src/app/palette-maker/_components/contrast-table/contrast-table.tsx
+++ b/apps/main/src/app/palette-maker/_components/contrast-table/contrast-table.tsx
@@ -1,0 +1,141 @@
+import type { FC } from 'react';
+
+import type { PaletteSwatch } from '../../_types/palette';
+
+type Props = {
+  swatches: readonly PaletteSwatch[];
+};
+
+const AA_NORMAL_TEXT = 4.5;
+
+type ContrastValueProps = {
+  hex: string;
+  text: 'white' | 'black';
+  ratio: number;
+  apca: number;
+};
+
+const ContrastValue: FC<ContrastValueProps> = ({ hex, text, ratio, apca }) => (
+  <div className="flex items-center gap-2">
+    <span
+      aria-hidden="true"
+      className="flex size-8 shrink-0 items-center justify-center rounded-md text-sm font-bold"
+      style={{
+        backgroundColor: hex,
+        color: text === 'white' ? '#ffffff' : '#000000',
+      }}
+    >
+      Aa
+    </span>
+    <div className="flex flex-col">
+      <span
+        className={`text-sm font-bold ${
+          ratio >= AA_NORMAL_TEXT ? 'text-fg-success' : 'text-fg-error'
+        }`}
+      >
+        {ratio.toFixed(2)}
+      </span>
+      <span className="text-fg-mute text-xs">Lc {apca.toFixed(1)}</span>
+    </div>
+  </div>
+);
+
+export const ContrastTable: FC<Props> = ({ swatches }) => (
+  <div className="flex flex-col gap-2">
+    <div className="border-border-base bg-bg-base overflow-hidden rounded-xl border">
+      <div className="sm:hidden">
+        {swatches.map((swatch) => (
+          <div
+            className="border-border-base flex flex-col gap-3 border-b p-4 last:border-b-0"
+            key={swatch.step}
+          >
+            <div className="flex items-center gap-2">
+              <span
+                aria-hidden="true"
+                className="border-border-base size-6 shrink-0 rounded-md border"
+                style={{ backgroundColor: swatch.hex }}
+              />
+              <span className="text-fg-base font-bold">{swatch.step}</span>
+              <span className="text-fg-mute font-mono text-xs">
+                {swatch.hex}
+              </span>
+            </div>
+            <div className="grid grid-cols-2 gap-2">
+              <div className="flex flex-col gap-1">
+                <span className="text-fg-mute text-xs">白文字</span>
+                <ContrastValue
+                  apca={swatch.apcaWhite}
+                  hex={swatch.hex}
+                  ratio={swatch.contrastWhite}
+                  text="white"
+                />
+              </div>
+              <div className="flex flex-col gap-1">
+                <span className="text-fg-mute text-xs">黒文字</span>
+                <ContrastValue
+                  apca={swatch.apcaBlack}
+                  hex={swatch.hex}
+                  ratio={swatch.contrastBlack}
+                  text="black"
+                />
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+      <table className="hidden w-full sm:table">
+        <thead>
+          <tr className="border-border-base bg-bg-mute border-b text-left text-sm font-medium">
+            <th className="px-4 py-3">段</th>
+            <th className="px-4 py-3">色</th>
+            <th className="px-4 py-3">OKLCH</th>
+            <th className="px-4 py-3">白文字</th>
+            <th className="px-4 py-3">黒文字</th>
+          </tr>
+        </thead>
+        <tbody>
+          {swatches.map((swatch) => (
+            <tr
+              className="border-border-base border-b last:border-b-0"
+              key={swatch.step}
+            >
+              <td className="text-fg-base px-4 py-2 font-bold">
+                {swatch.step}
+              </td>
+              <td className="text-fg-mute px-4 py-2 font-mono text-xs">
+                <span
+                  aria-hidden="true"
+                  className="border-border-base mr-2 inline-block size-6 rounded-md border align-middle"
+                  style={{ backgroundColor: swatch.hex }}
+                />
+                {swatch.hex}
+              </td>
+              <td className="text-fg-mute px-4 py-2 font-mono text-xs">
+                {swatch.cssOklch}
+              </td>
+              <td className="px-4 py-2">
+                <ContrastValue
+                  apca={swatch.apcaWhite}
+                  hex={swatch.hex}
+                  ratio={swatch.contrastWhite}
+                  text="white"
+                />
+              </td>
+              <td className="px-4 py-2">
+                <ContrastValue
+                  apca={swatch.apcaBlack}
+                  hex={swatch.hex}
+                  ratio={swatch.contrastBlack}
+                  text="black"
+                />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+    <p className="text-fg-mute text-xs">
+      WCAG比は4.5以上（通常テキストのAA基準）を合格として色分けしています
+    </p>
+  </div>
+);

--- a/apps/main/src/app/palette-maker/_components/contrast-table/index.ts
+++ b/apps/main/src/app/palette-maker/_components/contrast-table/index.ts
@@ -1,0 +1,1 @@
+export { ContrastTable } from './contrast-table';

--- a/apps/main/src/app/palette-maker/_components/export-panel/export-panel.stories.tsx
+++ b/apps/main/src/app/palette-maker/_components/export-panel/export-panel.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { generatePalette } from '../../_utils/palette';
+import { ExportPanel } from './export-panel';
+
+const meta: Meta<typeof ExportPanel> = {
+  title: 'app/palette-maker/export-panel',
+  component: ExportPanel,
+  args: {
+    name: 'primary',
+    swatches: generatePalette(250, 0.12),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ExportPanel>;
+
+export const Primary: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/:root \{/u)).toBeInTheDocument();
+    await expect(
+      canvas.getByText(/--color-primary-500: oklch\(0\.66 0\.12 250\);/u),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'CSS変数をコピー' }),
+    ).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: '共有用URLをコピー' }),
+    ).toBeInTheDocument();
+  },
+};
+
+export const SwitchToTailwind: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('tab', { name: 'Tailwind @theme' }));
+    await expect(await canvas.findByText(/@theme \{/u)).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('button', { name: 'Tailwind @themeをコピー' }),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/main/src/app/palette-maker/_components/export-panel/export-panel.tsx
+++ b/apps/main/src/app/palette-maker/_components/export-panel/export-panel.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import {
+  Button,
+  CopyIcon,
+  LinkIcon,
+  Tabs,
+  useClipboard,
+  useToast,
+} from '@k8o/arte-odyssey';
+import type { FC } from 'react';
+
+import type { PaletteSwatch } from '../../_types/palette';
+import {
+  toCssVariablesCode,
+  toTailwindThemeCode,
+} from '../../_utils/export-code';
+
+type Props = {
+  name: string;
+  swatches: readonly PaletteSwatch[];
+};
+
+type PanelProps = {
+  code: string;
+  copyLabel: string;
+};
+
+const CodePanel: FC<PanelProps> = ({ code, copyLabel }) => {
+  const { writeClipboard } = useClipboard();
+  const { onOpen } = useToast();
+
+  const handleCopy = async () => {
+    try {
+      await writeClipboard(code);
+      onOpen('success', `${copyLabel}をコピーしました`);
+    } catch {
+      onOpen('error', 'コピーに失敗しました');
+    }
+  };
+
+  return (
+    <div className="bg-bg-subtle flex flex-col gap-3 rounded-xl px-4 py-3">
+      <pre className="overflow-x-auto">
+        <code className="text-fg-base font-mono text-sm">{code}</code>
+      </pre>
+      <div>
+        <Button
+          onClick={() => {
+            void handleCopy();
+          }}
+          size="sm"
+          startIcon={<CopyIcon size="sm" />}
+          variant="outline"
+        >
+          {copyLabel}をコピー
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export const ExportPanel: FC<Props> = ({ name, swatches }) => {
+  const { writeClipboard } = useClipboard();
+  const { onOpen } = useToast();
+
+  const handleCopyUrl = async () => {
+    try {
+      await writeClipboard(window.location.href);
+      onOpen('success', '共有用URLをコピーしました');
+    } catch {
+      onOpen('error', 'コピーに失敗しました');
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <Tabs.Root defaultSelectedId="css" ids={['css', 'tailwind']}>
+        <Tabs.List label="エクスポート形式">
+          <Tabs.Tab id="css">CSS変数</Tabs.Tab>
+          <Tabs.Tab id="tailwind">Tailwind @theme</Tabs.Tab>
+        </Tabs.List>
+        <Tabs.Panel id="css">
+          <div className="pt-3">
+            <CodePanel
+              code={toCssVariablesCode(name, swatches)}
+              copyLabel="CSS変数"
+            />
+          </div>
+        </Tabs.Panel>
+        <Tabs.Panel id="tailwind">
+          <div className="pt-3">
+            <CodePanel
+              code={toTailwindThemeCode(name, swatches)}
+              copyLabel="Tailwind @theme"
+            />
+          </div>
+        </Tabs.Panel>
+      </Tabs.Root>
+      <div>
+        <Button
+          onClick={() => {
+            void handleCopyUrl();
+          }}
+          size="sm"
+          startIcon={<LinkIcon size="sm" />}
+          variant="outline"
+        >
+          共有用URLをコピー
+        </Button>
+      </div>
+    </div>
+  );
+};

--- a/apps/main/src/app/palette-maker/_components/export-panel/index.ts
+++ b/apps/main/src/app/palette-maker/_components/export-panel/index.ts
@@ -1,0 +1,1 @@
+export { ExportPanel } from './export-panel';

--- a/apps/main/src/app/palette-maker/_components/palette-controls/base-color-input.tsx
+++ b/apps/main/src/app/palette-maker/_components/palette-controls/base-color-input.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { FormControl, TextField } from '@k8o/arte-odyssey';
+import { parseColor } from '@repo/helpers/color/parse';
+import type { Color } from '@repo/helpers/color/spaces';
+import { type ChangeEventHandler, type FC, useState } from 'react';
+
+type Props = {
+  onColorChange: (color: Color) => void;
+};
+
+export const BaseColorInput: FC<Props> = ({ onColorChange }) => {
+  const [draft, setDraft] = useState('');
+  const [invalid, setInvalid] = useState(false);
+
+  const handleChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const { value } = e.target;
+    setDraft(value);
+
+    if (value.trim() === '') {
+      setInvalid(false);
+      return;
+    }
+    const parsed = parseColor(value);
+    if (parsed === null) {
+      setInvalid(true);
+      return;
+    }
+    setInvalid(false);
+    onColorChange(parsed);
+  };
+
+  return (
+    <FormControl
+      errorText={invalid ? '認識できない色形式です' : undefined}
+      helpText="色を貼り付けると色相とピーク彩度に取り込みます（およそ500段に相当）"
+      invalid={invalid}
+      label="基準色から取り込む"
+      renderInput={(props) => (
+        <TextField
+          {...props}
+          autoComplete="off"
+          onChange={handleChange}
+          placeholder="#5eead4, oklch(0.85 0.13 178), teal ..."
+          spellCheck={false}
+          value={draft}
+        />
+      )}
+    />
+  );
+};

--- a/apps/main/src/app/palette-maker/_components/palette-controls/index.ts
+++ b/apps/main/src/app/palette-maker/_components/palette-controls/index.ts
@@ -1,0 +1,1 @@
+export { PaletteControls } from './palette-controls';

--- a/apps/main/src/app/palette-maker/_components/palette-controls/palette-controls.stories.tsx
+++ b/apps/main/src/app/palette-maker/_components/palette-controls/palette-controls.stories.tsx
@@ -1,0 +1,92 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, fn, within } from 'storybook/test';
+
+import { PaletteControls } from './palette-controls';
+
+const meta: Meta<typeof PaletteControls> = {
+  title: 'app/palette-maker/palette-controls',
+  component: PaletteControls,
+  args: {
+    hue: 250,
+    chroma: 0.15,
+    name: 'primary',
+    onHueChange: fn(() => {}),
+    onChromaChange: fn(() => {}),
+    onNameChange: fn(() => {}),
+    onBaseColorChange: fn(() => {}),
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PaletteControls>;
+
+export const Primary: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const sliders = canvas.getAllByRole('slider');
+    await expect(sliders).toHaveLength(2);
+    await expect(
+      canvas.getByRole('textbox', { name: 'トークン名' }),
+    ).toHaveValue('primary');
+  },
+};
+
+export const ChangeHue: Story = {
+  play: async ({ args, canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('spinbutton', { name: '色相 (H)' });
+    input.focus();
+    await userEvent.keyboard('{ArrowUp}');
+    await expect(args.onHueChange).toHaveBeenLastCalledWith(251);
+  },
+};
+
+export const RenameToken: Story = {
+  play: async ({ args, canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: 'トークン名' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'brand');
+    await expect(args.onNameChange).toHaveBeenLastCalledWith('brand');
+  },
+};
+
+export const InvalidTokenName: Story = {
+  play: async ({ args, canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: 'トークン名' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'ABC');
+    await expect(
+      await canvas.findByText(
+        '小文字英数字とハイフンで32文字以内で入力してください',
+      ),
+    ).toBeInTheDocument();
+    await expect(args.onNameChange).not.toHaveBeenCalled();
+  },
+};
+
+export const PasteBaseColor: Story = {
+  play: async ({ args, canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: '基準色から取り込む' });
+    await userEvent.type(input, '#ff0000');
+    await expect(args.onBaseColorChange).toHaveBeenLastCalledWith({
+      r: 1,
+      g: 0,
+      b: 0,
+      alpha: 1,
+    });
+  },
+};
+
+export const InvalidBaseColor: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: '基準色から取り込む' });
+    await userEvent.type(input, '#ff');
+    await expect(
+      await canvas.findByText('認識できない色形式です'),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/main/src/app/palette-maker/_components/palette-controls/palette-controls.tsx
+++ b/apps/main/src/app/palette-maker/_components/palette-controls/palette-controls.tsx
@@ -1,0 +1,161 @@
+'use client';
+
+import { FormControl, NumberField, Slider, TextField } from '@k8o/arte-odyssey';
+import type { Color } from '@repo/helpers/color/spaces';
+import { type ChangeEventHandler, type FC, useId, useState } from 'react';
+
+import { HUE, PEAK_CHROMA, isTokenName } from '../../_utils/search-params';
+import { BaseColorInput } from './base-color-input';
+
+type ChannelRowProps = {
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  precision: number;
+  value: number;
+  onChange: (value: number) => void;
+};
+
+const ChannelRow: FC<ChannelRowProps> = ({
+  label,
+  min,
+  max,
+  step,
+  precision,
+  value,
+  onChange,
+}) => {
+  const id = useId();
+  // NumberField のクリア時などに渡る NaN は無視する。
+  const handleChange = (next: number): void => {
+    if (!Number.isNaN(next)) {
+      onChange(next);
+    }
+  };
+  return (
+    <div className="flex items-center gap-3">
+      <label
+        className="text-fg-base w-28 shrink-0 text-sm font-bold"
+        htmlFor={id}
+      >
+        {label}
+      </label>
+      <div className="min-w-0 grow">
+        <Slider
+          aria-label={label}
+          id={id}
+          max={max}
+          min={min}
+          onChange={handleChange}
+          step={step}
+          value={value}
+        />
+      </div>
+      <div className="w-24 shrink-0">
+        <NumberField
+          aria-label={label}
+          max={max}
+          min={min}
+          onChange={handleChange}
+          precision={precision}
+          step={step}
+          value={value}
+        />
+      </div>
+    </div>
+  );
+};
+
+type Props = {
+  hue: number;
+  chroma: number;
+  name: string;
+  onHueChange: (value: number) => void;
+  onChromaChange: (value: number) => void;
+  onNameChange: (value: string) => void;
+  onBaseColorChange: (color: Color) => void;
+};
+
+export const PaletteControls: FC<Props> = ({
+  hue,
+  chroma,
+  name,
+  onHueChange,
+  onChromaChange,
+  onNameChange,
+  onBaseColorChange,
+}) => {
+  const [draft, setDraft] = useState(name);
+  const [prevName, setPrevName] = useState(name);
+  const [invalidName, setInvalidName] = useState(false);
+
+  // 外部（URL戻る等）からの変更時だけ入力欄へ反映する（入力途中の文字列は上書きしない）。
+  if (name !== prevName) {
+    setPrevName(name);
+    if (name !== draft) {
+      setDraft(name);
+      setInvalidName(false);
+    }
+  }
+
+  const handleNameChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    const { value } = e.target;
+    setDraft(value);
+
+    if (!isTokenName(value)) {
+      setInvalidName(true);
+      return;
+    }
+    setInvalidName(false);
+    onNameChange(value);
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-4">
+        <ChannelRow
+          label="色相 (H)"
+          max={HUE.max}
+          min={HUE.min}
+          onChange={onHueChange}
+          precision={1}
+          step={1}
+          value={hue}
+        />
+        <ChannelRow
+          label="ピーク彩度 (C)"
+          max={PEAK_CHROMA.max}
+          min={PEAK_CHROMA.min}
+          onChange={onChromaChange}
+          precision={3}
+          step={0.001}
+          value={chroma}
+        />
+      </div>
+      <div className="grid gap-6 sm:grid-cols-2">
+        <FormControl
+          errorText={
+            invalidName
+              ? '小文字英数字とハイフンで32文字以内で入力してください'
+              : undefined
+          }
+          helpText="CSS変数名（--color-{名前}-500 など）に使われます"
+          invalid={invalidName}
+          label="トークン名"
+          renderInput={(props) => (
+            <TextField
+              {...props}
+              autoComplete="off"
+              onChange={handleNameChange}
+              placeholder="primary"
+              spellCheck={false}
+              value={draft}
+            />
+          )}
+        />
+        <BaseColorInput onColorChange={onBaseColorChange} />
+      </div>
+    </div>
+  );
+};

--- a/apps/main/src/app/palette-maker/_components/palette-maker/index.ts
+++ b/apps/main/src/app/palette-maker/_components/palette-maker/index.ts
@@ -1,0 +1,1 @@
+export { PaletteMaker } from './palette-maker';

--- a/apps/main/src/app/palette-maker/_components/palette-maker/palette-maker.stories.tsx
+++ b/apps/main/src/app/palette-maker/_components/palette-maker/palette-maker.stories.tsx
@@ -55,6 +55,20 @@ export const PasteBaseColor: Story = {
   },
 };
 
+export const PasteAchromaticBaseColor: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const hue = canvas.getByRole('spinbutton', { name: '色相 (H)' });
+    const hueBefore = hue.getAttribute('aria-valuenow');
+    const input = canvas.getByRole('textbox', { name: '基準色から取り込む' });
+    await userEvent.type(input, 'white');
+    const chroma = canvas.getByRole('spinbutton', { name: 'ピーク彩度 (C)' });
+    await expect(chroma).toHaveAttribute('aria-valuenow', '0');
+    // 無彩色の取り込みでは色相を動かさない
+    await expect(hue.getAttribute('aria-valuenow')).toBe(hueBefore);
+  },
+};
+
 export const RenameToken: Story = {
   play: async ({ canvasElement, userEvent }) => {
     const canvas = within(canvasElement);

--- a/apps/main/src/app/palette-maker/_components/palette-maker/palette-maker.stories.tsx
+++ b/apps/main/src/app/palette-maker/_components/palette-maker/palette-maker.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { PALETTE_STEPS } from '../../_types/palette';
+import { PaletteMaker } from './palette-maker';
+
+const meta: Meta<typeof PaletteMaker> = {
+  title: 'app/palette-maker/palette-maker',
+  component: PaletteMaker,
+};
+
+export default meta;
+type Story = StoryObj<typeof PaletteMaker>;
+
+export const Primary: Story = {};
+
+export const InitialState: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getAllByRole('slider')).toHaveLength(2);
+    await expect(
+      canvas.getByText(/--color-primary-500: oklch\(0\.66 0\.12 250\);/u),
+    ).toBeInTheDocument();
+    const table = canvas.getByRole('table');
+    await expect(within(table).getAllByRole('row')).toHaveLength(
+      PALETTE_STEPS.length + 1,
+    );
+  },
+};
+
+export const ChangeHue: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('spinbutton', { name: '色相 (H)' });
+    input.focus();
+    await userEvent.keyboard('{ArrowUp}');
+    await expect(input).toHaveAttribute('aria-valuenow', '251');
+    await expect(
+      await canvas.findByText(
+        /--color-primary-500: oklch\(0\.66 0\.12 251\);/u,
+      ),
+    ).toBeInTheDocument();
+  },
+};
+
+export const PasteBaseColor: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: '基準色から取り込む' });
+    await userEvent.type(input, '#ff0000');
+    const hue = canvas.getByRole('spinbutton', { name: '色相 (H)' });
+    await expect(hue).toHaveAttribute('aria-valuenow', '29.2');
+    const chroma = canvas.getByRole('spinbutton', { name: 'ピーク彩度 (C)' });
+    await expect(chroma).toHaveAttribute('aria-valuenow', '0.258');
+  },
+};
+
+export const RenameToken: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: 'トークン名' });
+    await userEvent.clear(input);
+    await userEvent.type(input, 'brand');
+    await expect(
+      await canvas.findByText(/--color-brand-500:/u),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/main/src/app/palette-maker/_components/palette-maker/palette-maker.tsx
+++ b/apps/main/src/app/palette-maker/_components/palette-maker/palette-maker.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Card, Heading } from '@k8o/arte-odyssey';
+import { type FC, useMemo } from 'react';
+
+import { generatePalette } from '../../_utils/palette';
+import { ContrastTable } from '../contrast-table';
+import { ExportPanel } from '../export-panel';
+import { PaletteControls } from '../palette-controls';
+import { PalettePreview } from '../palette-preview';
+import { usePaletteState } from './use-palette-state';
+
+export const PaletteMaker: FC = () => {
+  const { hue, chroma, name, setHue, setChroma, setName, setBaseColor } =
+    usePaletteState();
+  const swatches = useMemo(() => generatePalette(hue, chroma), [hue, chroma]);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <Card>
+        <div className="flex flex-col gap-6 p-5 sm:p-6">
+          <PalettePreview swatches={swatches} />
+          <PaletteControls
+            chroma={chroma}
+            hue={hue}
+            name={name}
+            onBaseColorChange={setBaseColor}
+            onChromaChange={setChroma}
+            onHueChange={setHue}
+            onNameChange={setName}
+          />
+          <ExportPanel name={name} swatches={swatches} />
+        </div>
+      </Card>
+      <section className="flex flex-col gap-3">
+        <Heading type="h3">コントラスト詳細</Heading>
+        <ContrastTable swatches={swatches} />
+      </section>
+    </div>
+  );
+};

--- a/apps/main/src/app/palette-maker/_components/palette-maker/use-palette-state.ts
+++ b/apps/main/src/app/palette-maker/_components/palette-maker/use-palette-state.ts
@@ -1,0 +1,73 @@
+import { type Color, colorToOklch } from '@repo/helpers/color/spaces';
+import { between } from '@repo/helpers/number/between';
+import { throttle, useQueryStates } from 'nuqs';
+import { useCallback } from 'react';
+
+import {
+  HUE,
+  PEAK_CHROMA,
+  isTokenName,
+  paletteMakerParsers,
+  paletteMakerUrlKeys,
+} from '../../_utils/search-params';
+
+const roundTo = (value: number, digits: number): number =>
+  Number(value.toFixed(digits));
+
+export const usePaletteState = () => {
+  const [{ hue, chroma, name }, setState] = useQueryStates(
+    paletteMakerParsers,
+    {
+      history: 'replace',
+      limitUrlUpdates: throttle(200),
+      urlKeys: paletteMakerUrlKeys,
+    },
+  );
+
+  const setHue = useCallback(
+    (value: number) => {
+      void setState({ hue: between(roundTo(value, 1), HUE.min, HUE.max) });
+    },
+    [setState],
+  );
+
+  const setChroma = useCallback(
+    (value: number) => {
+      void setState({
+        chroma: between(roundTo(value, 3), PEAK_CHROMA.min, PEAK_CHROMA.max),
+      });
+    },
+    [setState],
+  );
+
+  const setName = useCallback(
+    (value: string) => {
+      if (!isTokenName(value)) {
+        return;
+      }
+      void setState({ name: value });
+    },
+    [setState],
+  );
+
+  const setBaseColor = useCallback(
+    (color: Color) => {
+      const { c, h } = colorToOklch(color);
+      void setState({
+        hue: between(roundTo(h, 1), HUE.min, HUE.max),
+        chroma: between(roundTo(c, 3), PEAK_CHROMA.min, PEAK_CHROMA.max),
+      });
+    },
+    [setState],
+  );
+
+  return {
+    hue: between(hue, HUE.min, HUE.max),
+    chroma: between(chroma, PEAK_CHROMA.min, PEAK_CHROMA.max),
+    name,
+    setHue,
+    setChroma,
+    setName,
+    setBaseColor,
+  };
+};

--- a/apps/main/src/app/palette-maker/_components/palette-maker/use-palette-state.ts
+++ b/apps/main/src/app/palette-maker/_components/palette-maker/use-palette-state.ts
@@ -53,9 +53,17 @@ export const usePaletteState = () => {
   const setBaseColor = useCallback(
     (color: Color) => {
       const { c, h } = colorToOklch(color);
+      const nextChroma = between(
+        roundTo(c, 3),
+        PEAK_CHROMA.min,
+        PEAK_CHROMA.max,
+      );
+      // 無彩色は hue が不定（colorToOklch は 0 に丸める）なので、色相は現状維持する
       void setState({
-        hue: between(roundTo(h, 1), HUE.min, HUE.max),
-        chroma: between(roundTo(c, 3), PEAK_CHROMA.min, PEAK_CHROMA.max),
+        ...(nextChroma > 0 && {
+          hue: between(roundTo(h, 1), HUE.min, HUE.max),
+        }),
+        chroma: nextChroma,
       });
     },
     [setState],

--- a/apps/main/src/app/palette-maker/_components/palette-preview/index.ts
+++ b/apps/main/src/app/palette-maker/_components/palette-preview/index.ts
@@ -1,0 +1,1 @@
+export { PalettePreview } from './palette-preview';

--- a/apps/main/src/app/palette-maker/_components/palette-preview/palette-preview.stories.tsx
+++ b/apps/main/src/app/palette-maker/_components/palette-preview/palette-preview.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import { generatePalette } from '../../_utils/palette';
+import { PalettePreview } from './palette-preview';
+
+const meta: Meta<typeof PalettePreview> = {
+  title: 'app/palette-maker/palette-preview',
+  component: PalettePreview,
+};
+
+export default meta;
+type Story = StoryObj<typeof PalettePreview>;
+
+export const Primary: Story = {
+  args: {
+    swatches: generatePalette(250, 0.12),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('50')).toBeInTheDocument();
+    await expect(canvas.getByText('950')).toBeInTheDocument();
+    await expect(
+      canvas.queryByText('＊はsRGB色域に収めるため彩度を自動調整した段です'),
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const WithClamped: Story = {
+  args: {
+    swatches: generatePalette(145, 0.4),
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('＊はsRGB色域に収めるため彩度を自動調整した段です'),
+    ).toBeInTheDocument();
+  },
+};
+
+export const Neutral: Story = {
+  args: {
+    swatches: generatePalette(250, 0),
+  },
+};

--- a/apps/main/src/app/palette-maker/_components/palette-preview/palette-preview.stories.tsx
+++ b/apps/main/src/app/palette-maker/_components/palette-preview/palette-preview.stories.tsx
@@ -21,8 +21,8 @@ export const Primary: Story = {
     await expect(canvas.getByText('50')).toBeInTheDocument();
     await expect(canvas.getByText('950')).toBeInTheDocument();
     await expect(
-      canvas.queryByText('＊はsRGB色域に収めるため彩度を自動調整した段です'),
-    ).not.toBeInTheDocument();
+      canvas.getByText('＊はsRGB色域に収めるため彩度を自動調整した段です'),
+    ).not.toBeVisible();
   },
 };
 
@@ -34,7 +34,7 @@ export const WithClamped: Story = {
     const canvas = within(canvasElement);
     await expect(
       canvas.getByText('＊はsRGB色域に収めるため彩度を自動調整した段です'),
-    ).toBeInTheDocument();
+    ).toBeVisible();
   },
 };
 

--- a/apps/main/src/app/palette-maker/_components/palette-preview/palette-preview.tsx
+++ b/apps/main/src/app/palette-maker/_components/palette-preview/palette-preview.tsx
@@ -1,0 +1,54 @@
+import type { FC } from 'react';
+
+import type { PaletteSwatch } from '../../_types/palette';
+
+type Props = {
+  swatches: readonly PaletteSwatch[];
+};
+
+const readableTextColor = (swatch: PaletteSwatch): string =>
+  swatch.readableText === 'white' ? '#ffffff' : '#000000';
+
+const readableContrast = (swatch: PaletteSwatch): number =>
+  swatch.readableText === 'white' ? swatch.contrastWhite : swatch.contrastBlack;
+
+export const PalettePreview: FC<Props> = ({ swatches }) => {
+  const hasClamped = swatches.some((swatch) => swatch.isClamped);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-1 gap-1 sm:grid-cols-11">
+        {swatches.map((swatch) => (
+          <div className="flex flex-col gap-1" key={swatch.step}>
+            <div
+              className="flex h-12 items-center justify-between rounded-md px-2 sm:h-20 sm:flex-col sm:items-start sm:py-1.5"
+              style={{ backgroundColor: swatch.hex }}
+            >
+              <span
+                className="text-xs font-bold"
+                style={{ color: readableTextColor(swatch) }}
+              >
+                {swatch.step}
+              </span>
+              <span
+                className="text-xs"
+                style={{ color: readableTextColor(swatch) }}
+              >
+                {readableContrast(swatch).toFixed(2)}
+              </span>
+            </div>
+            <p className="text-fg-mute font-mono text-xs">
+              {swatch.hex}
+              {swatch.isClamped ? '＊' : ''}
+            </p>
+          </div>
+        ))}
+      </div>
+      {hasClamped ? (
+        <p className="text-fg-mute text-xs">
+          ＊はsRGB色域に収めるため彩度を自動調整した段です
+        </p>
+      ) : null}
+    </div>
+  );
+};

--- a/apps/main/src/app/palette-maker/_components/palette-preview/palette-preview.tsx
+++ b/apps/main/src/app/palette-maker/_components/palette-preview/palette-preview.tsx
@@ -44,11 +44,10 @@ export const PalettePreview: FC<Props> = ({ swatches }) => {
           </div>
         ))}
       </div>
-      {hasClamped ? (
-        <p className="text-fg-mute text-xs">
-          ＊はsRGB色域に収めるため彩度を自動調整した段です
-        </p>
-      ) : null}
+      {/* 表示/非表示でレイアウトが動かないよう、行の高さは常に確保する */}
+      <p className={`text-fg-mute text-xs ${hasClamped ? '' : 'invisible'}`}>
+        ＊はsRGB色域に収めるため彩度を自動調整した段です
+      </p>
     </div>
   );
 };

--- a/apps/main/src/app/palette-maker/_types/palette.ts
+++ b/apps/main/src/app/palette-maker/_types/palette.ts
@@ -1,0 +1,20 @@
+import type { Oklch } from '@repo/helpers/color/spaces';
+
+export const PALETTE_STEPS = [
+  50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950,
+] as const;
+
+export type PaletteStep = (typeof PALETTE_STEPS)[number];
+
+export type PaletteSwatch = {
+  step: PaletteStep;
+  hex: string;
+  cssOklch: string;
+  oklch: Oklch;
+  isClamped: boolean;
+  contrastWhite: number;
+  contrastBlack: number;
+  apcaWhite: number;
+  apcaBlack: number;
+  readableText: 'white' | 'black';
+};

--- a/apps/main/src/app/palette-maker/_utils/export-code.test.ts
+++ b/apps/main/src/app/palette-maker/_utils/export-code.test.ts
@@ -1,0 +1,40 @@
+import { PALETTE_STEPS } from '../_types/palette';
+import { toCssVariablesCode, toTailwindThemeCode } from './export-code';
+import { generatePalette } from './palette';
+
+describe('export-code', () => {
+  const swatches = generatePalette(250, 0.1);
+
+  describe('toCssVariablesCode', () => {
+    it(':rootブロックに11段の変数を宣言する', () => {
+      const code = toCssVariablesCode('primary', swatches);
+      const lines = code.split('\n');
+      expect(lines.at(0)).toBe(':root {');
+      expect(lines.at(-1)).toBe('}');
+      expect(lines).toHaveLength(PALETTE_STEPS.length + 2);
+    });
+
+    it('変数値は各段のoklch()値と一致する', () => {
+      const code = toCssVariablesCode('primary', swatches);
+      for (const swatch of swatches) {
+        expect(code).toContain(
+          `  --color-primary-${swatch.step}: ${swatch.cssOklch};`,
+        );
+      }
+    });
+
+    it('ハイフンを含むトークン名でも変数名を組み立てられる', () => {
+      const code = toCssVariablesCode('brand-accent', swatches);
+      expect(code).toContain('--color-brand-accent-500:');
+    });
+  });
+
+  describe('toTailwindThemeCode', () => {
+    it('@themeブロックである以外はCSS変数と同じ内容になる', () => {
+      const css = toCssVariablesCode('primary', swatches);
+      const tailwind = toTailwindThemeCode('primary', swatches);
+      expect(tailwind.split('\n').at(0)).toBe('@theme {');
+      expect(tailwind.replace('@theme {', ':root {')).toBe(css);
+    });
+  });
+});

--- a/apps/main/src/app/palette-maker/_utils/export-code.ts
+++ b/apps/main/src/app/palette-maker/_utils/export-code.ts
@@ -1,0 +1,19 @@
+import type { PaletteSwatch } from '../_types/palette';
+
+const toVariableLines = (
+  name: string,
+  swatches: readonly PaletteSwatch[],
+): string =>
+  swatches
+    .map((swatch) => `  --color-${name}-${swatch.step}: ${swatch.cssOklch};`)
+    .join('\n');
+
+export const toCssVariablesCode = (
+  name: string,
+  swatches: readonly PaletteSwatch[],
+): string => `:root {\n${toVariableLines(name, swatches)}\n}`;
+
+export const toTailwindThemeCode = (
+  name: string,
+  swatches: readonly PaletteSwatch[],
+): string => `@theme {\n${toVariableLines(name, swatches)}\n}`;

--- a/apps/main/src/app/palette-maker/_utils/palette.test.ts
+++ b/apps/main/src/app/palette-maker/_utils/palette.test.ts
@@ -1,0 +1,111 @@
+import { isInGamut, toSrgbGamut } from '@repo/helpers/color/gamut';
+import { oklchToColor } from '@repo/helpers/color/spaces';
+
+import { PALETTE_STEPS } from '../_types/palette';
+import { CHROMA_CURVE, LIGHTNESS_LADDER, generatePalette } from './palette';
+
+describe('generatePalette', () => {
+  describe('正常系', () => {
+    it('11段階を50から950の順で返す', () => {
+      const swatches = generatePalette(250, 0.15);
+      expect(swatches.map((swatch) => swatch.step)).toEqual([...PALETTE_STEPS]);
+    });
+
+    it('各段の明度がラダーと一致する', () => {
+      const swatches = generatePalette(250, 0.15);
+      for (const swatch of swatches) {
+        expect(
+          Math.abs(swatch.oklch.l - LIGHTNESS_LADDER[swatch.step]),
+        ).toBeLessThanOrEqual(0.02);
+      }
+    });
+
+    it('ガマット内に収まる低彩度では彩度がカーブ×ピークと一致する', () => {
+      const swatches = generatePalette(250, 0.05);
+      for (const swatch of swatches) {
+        expect(
+          Math.abs(swatch.oklch.c - 0.05 * CHROMA_CURVE[swatch.step]),
+        ).toBeLessThanOrEqual(1e-3);
+      }
+    });
+
+    it('500段の彩度がピーク彩度そのものになる', () => {
+      const swatches = generatePalette(250, 0.05);
+      const step500 = swatches.find((swatch) => swatch.step === 500);
+      expect(step500?.oklch.c).toBeCloseTo(0.05, 3);
+    });
+
+    it('hexは6桁、cssOklchはoklch()形式になる', () => {
+      const swatches = generatePalette(250, 0.15);
+      for (const swatch of swatches) {
+        expect(swatch.hex).toMatch(/^#[0-9a-f]{6}$/u);
+        expect(swatch.cssOklch).toMatch(/^oklch\(/u);
+      }
+    });
+
+    it('明るい50段は黒文字、暗い950段は白文字が読みやすい', () => {
+      const swatches = generatePalette(250, 0.15);
+      expect(swatches.at(0)?.readableText).toBe('black');
+      expect(swatches.at(-1)?.readableText).toBe('white');
+    });
+
+    it('コントラスト比は1〜21の範囲で、APCAの符号が明暗と整合する', () => {
+      const swatches = generatePalette(250, 0.15);
+      for (const swatch of swatches) {
+        expect(swatch.contrastWhite).toBeGreaterThanOrEqual(1);
+        expect(swatch.contrastWhite).toBeLessThanOrEqual(21);
+        expect(swatch.contrastBlack).toBeGreaterThanOrEqual(1);
+        expect(swatch.contrastBlack).toBeLessThanOrEqual(21);
+      }
+      // 明るい背景に黒文字は正、暗い背景に白文字は負のLcになる
+      expect(swatches.at(0)?.apcaBlack).toBeGreaterThan(0);
+      expect(swatches.at(-1)?.apcaWhite).toBeLessThan(0);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('ピーク彩度0では全段がグレースケールでクランプなし', () => {
+      const swatches = generatePalette(250, 0);
+      for (const swatch of swatches) {
+        const [r, g, b] = [
+          swatch.hex.slice(1, 3),
+          swatch.hex.slice(3, 5),
+          swatch.hex.slice(5, 7),
+        ];
+        expect(r).toBe(g);
+        expect(g).toBe(b);
+        expect(swatch.isClamped).toBe(false);
+      }
+    });
+
+    it('高彩度の緑ではクランプされる段があり、全段sRGB内に収まる', () => {
+      const swatches = generatePalette(145, 0.4);
+      expect(swatches.some((swatch) => swatch.isClamped)).toBe(true);
+      for (const swatch of swatches) {
+        expect(isInGamut(oklchToColor(swatch.oklch, 1))).toBe(true);
+      }
+    });
+
+    it('クランプされた段の彩度は要求値より小さくなる', () => {
+      const swatches = generatePalette(145, 0.4);
+      const clamped = swatches.filter((swatch) => swatch.isClamped);
+      for (const swatch of clamped) {
+        expect(swatch.oklch.c).toBeLessThan(0.4 * CHROMA_CURVE[swatch.step]);
+      }
+    });
+
+    it('色相0と360は同じパレットになる', () => {
+      const zero = generatePalette(0, 0.15).map((swatch) => swatch.hex);
+      const full = generatePalette(360, 0.15).map((swatch) => swatch.hex);
+      expect(full).toEqual(zero);
+    });
+
+    it('toSrgbGamutの結果と表示hexが常に一致する', () => {
+      const swatches = generatePalette(30, 0.4);
+      for (const swatch of swatches) {
+        const remapped = toSrgbGamut(oklchToColor(swatch.oklch, 1));
+        expect(isInGamut(remapped)).toBe(true);
+      }
+    });
+  });
+});

--- a/apps/main/src/app/palette-maker/_utils/palette.ts
+++ b/apps/main/src/app/palette-maker/_utils/palette.ts
@@ -1,0 +1,74 @@
+import { calcApca } from '@repo/helpers/color/calc-apca';
+import { calcContrast } from '@repo/helpers/color/calc-contrast';
+import { formatHex, formatOklch } from '@repo/helpers/color/format';
+import { isInGamut, toSrgbGamut } from '@repo/helpers/color/gamut';
+import { colorToOklch, oklchToColor } from '@repo/helpers/color/spaces';
+
+import {
+  PALETTE_STEPS,
+  type PaletteStep,
+  type PaletteSwatch,
+} from '../_types/palette';
+
+// ArteOdyssey の tokens.css と同じ、全色相共通の明度ラダー
+export const LIGHTNESS_LADDER: Record<PaletteStep, number> = {
+  50: 0.975,
+  100: 0.945,
+  200: 0.9,
+  300: 0.84,
+  400: 0.75,
+  500: 0.66,
+  600: 0.575,
+  700: 0.49,
+  800: 0.41,
+  900: 0.37,
+  950: 0.18,
+};
+
+// ArteOdyssey の red ランプの彩度をピーク(500)で正規化した係数
+export const CHROMA_CURVE: Record<PaletteStep, number> = {
+  50: 0.06,
+  100: 0.16,
+  200: 0.31,
+  300: 0.56,
+  400: 0.83,
+  500: 1,
+  600: 0.94,
+  700: 0.81,
+  800: 0.67,
+  900: 0.52,
+  950: 0.37,
+};
+
+const WHITE_HEX = '#ffffff';
+const BLACK_HEX = '#000000';
+
+export const generatePalette = (
+  hue: number,
+  peakChroma: number,
+): PaletteSwatch[] =>
+  PALETTE_STEPS.map((step): PaletteSwatch => {
+    const requested = {
+      l: LIGHTNESS_LADDER[step],
+      c: peakChroma * CHROMA_CURVE[step],
+      h: hue,
+    };
+    const raw = oklchToColor(requested, 1);
+    const isClamped = !isInGamut(raw);
+    const mapped = toSrgbGamut(raw);
+    const hex = formatHex(mapped);
+    const contrastWhite = calcContrast(hex, WHITE_HEX);
+    const contrastBlack = calcContrast(hex, BLACK_HEX);
+    return {
+      step,
+      hex,
+      cssOklch: formatOklch(mapped),
+      oklch: colorToOklch(mapped),
+      isClamped,
+      contrastWhite,
+      contrastBlack,
+      apcaWhite: calcApca(WHITE_HEX, hex),
+      apcaBlack: calcApca(BLACK_HEX, hex),
+      readableText: contrastWhite >= contrastBlack ? 'white' : 'black',
+    };
+  });

--- a/apps/main/src/app/palette-maker/_utils/search-params.test.ts
+++ b/apps/main/src/app/palette-maker/_utils/search-params.test.ts
@@ -1,0 +1,41 @@
+import { isTokenName, paletteMakerParsers } from './search-params';
+
+describe('isTokenName', () => {
+  it('小文字英数字とハイフン区切りを許容する', () => {
+    expect(isTokenName('primary')).toBe(true);
+    expect(isTokenName('brand-2')).toBe(true);
+    expect(isTokenName('a1-b2-c3')).toBe(true);
+  });
+
+  it('大文字・数字始まり・記号・空文字を拒否する', () => {
+    expect(isTokenName('Primary')).toBe(false);
+    expect(isTokenName('1abc')).toBe(false);
+    expect(isTokenName('-x')).toBe(false);
+    expect(isTokenName('x-')).toBe(false);
+    expect(isTokenName('a--b')).toBe(false);
+    expect(isTokenName('a_b')).toBe(false);
+    expect(isTokenName('')).toBe(false);
+  });
+
+  it('32文字以内のみ許容する', () => {
+    expect(isTokenName('a'.repeat(32))).toBe(true);
+    expect(isTokenName('a'.repeat(33))).toBe(false);
+  });
+});
+
+describe('nameParser', () => {
+  const { parse, serialize } = paletteMakerParsers.name;
+
+  it('有効なトークン名はそのまま返す', () => {
+    expect(parse('brand')).toBe('brand');
+  });
+
+  it('不正なトークン名はnullを返しデフォルトへフォールバックさせる', () => {
+    expect(parse('Brand')).toBeNull();
+    expect(parse('a b')).toBeNull();
+  });
+
+  it('serializeと往復できる', () => {
+    expect(parse(serialize('brand-accent'))).toBe('brand-accent');
+  });
+});

--- a/apps/main/src/app/palette-maker/_utils/search-params.ts
+++ b/apps/main/src/app/palette-maker/_utils/search-params.ts
@@ -6,10 +6,11 @@ export const HUE = {
   default: 250,
 } as const;
 
+// 初期表示でガマットクランプ（＊表示）が出ないよう、h=250で全段sRGB内に収まる値にする
 export const PEAK_CHROMA = {
   min: 0,
   max: 0.4,
-  default: 0.15,
+  default: 0.12,
 } as const;
 
 export const DEFAULT_TOKEN_NAME = 'primary';

--- a/apps/main/src/app/palette-maker/_utils/search-params.ts
+++ b/apps/main/src/app/palette-maker/_utils/search-params.ts
@@ -1,0 +1,37 @@
+import { createParser, parseAsFloat } from 'nuqs/server';
+
+export const HUE = {
+  min: 0,
+  max: 360,
+  default: 250,
+} as const;
+
+export const PEAK_CHROMA = {
+  min: 0,
+  max: 0.4,
+  default: 0.15,
+} as const;
+
+export const DEFAULT_TOKEN_NAME = 'primary';
+
+const TOKEN_NAME_MAX_LENGTH = 32;
+const TOKEN_NAME_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u;
+
+export const isTokenName = (value: string): boolean =>
+  value.length <= TOKEN_NAME_MAX_LENGTH && TOKEN_NAME_PATTERN.test(value);
+
+export const paletteMakerParsers = {
+  hue: parseAsFloat.withDefault(HUE.default),
+  chroma: parseAsFloat.withDefault(PEAK_CHROMA.default),
+  name: createParser({
+    parse: (query: string): string | null =>
+      isTokenName(query) ? query : null,
+    serialize: (value: string): string => value,
+  }).withDefault(DEFAULT_TOKEN_NAME),
+};
+
+export const paletteMakerUrlKeys = {
+  hue: 'h',
+  chroma: 'c',
+  name: 'name',
+} as const;

--- a/apps/main/src/app/palette-maker/layout.tsx
+++ b/apps/main/src/app/palette-maker/layout.tsx
@@ -1,0 +1,34 @@
+import { Heading } from '@k8o/arte-odyssey';
+import type { Metadata } from 'next';
+
+export const metadata = {
+  title: 'いろばしご',
+  description:
+    'OKLCHの明度スケールで11段階のカラーパレットを生成し、コントラストを検証します。',
+  openGraph: {
+    title: 'いろばしご',
+    description:
+      'OKLCHの明度スケールで11段階のカラーパレットを生成し、コントラストを検証します。',
+    url: 'https://k8o.me/palette-maker',
+    siteName: 'k8o',
+    locale: 'ja',
+    type: 'website',
+  },
+  twitter: {
+    title: 'いろばしご',
+    card: 'summary',
+    description:
+      'OKLCHの明度スケールで11段階のカラーパレットを生成し、コントラストを検証します。',
+  },
+} satisfies Metadata;
+
+export default function Layout({ children }: LayoutProps<'/palette-maker'>) {
+  return (
+    <div className="mx-auto w-full max-w-5xl">
+      <div className="flex h-full flex-col gap-4">
+        <Heading type="h2">いろばしご</Heading>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/app/palette-maker/opengraph-image.tsx
+++ b/apps/main/src/app/palette-maker/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { OgImage } from '@/app/_components/og-image';
+
+export const alt = 'いろばしご';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default function OpenGraphImage() {
+  return OgImage({ title: 'いろばしご' });
+}

--- a/apps/main/src/app/palette-maker/page.tsx
+++ b/apps/main/src/app/palette-maker/page.tsx
@@ -1,0 +1,13 @@
+import { Suspense } from 'react';
+
+import { PaletteMaker } from './_components/palette-maker';
+
+export default function Page() {
+  return (
+    <section className="py-10">
+      <Suspense>
+        <PaletteMaker />
+      </Suspense>
+    </section>
+  );
+}

--- a/apps/main/src/shared/site/site-entries.ts
+++ b/apps/main/src/shared/site/site-entries.ts
@@ -8,6 +8,7 @@ export type SiteEntryIcon =
   | 'contrastChecker'
   | 'colorQuiz'
   | 'radiusMaker'
+  | 'paletteMaker'
   | 'mojiCount'
   | 'htmlNest'
   | 'fluida'
@@ -80,6 +81,14 @@ const entries: readonly SiteEntry[] = [
     description: 'border-radiusを視覚的に操作してCSSを生成します。',
     kind: 'tool',
     icon: 'radiusMaker',
+  },
+  {
+    title: 'いろばしご',
+    link: '/palette-maker',
+    description:
+      'OKLCHの明度スケールで11段階のカラーパレットを生成し、コントラストを検証します。',
+    kind: 'tool',
+    icon: 'paletteMaker',
   },
   {
     title: 'もじカウント',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,8 @@ settings:
 catalogs:
   default:
     '@k8o/arte-odyssey':
-      specifier: 10.7.0
-      version: 10.7.0
+      specifier: 10.8.0
+      version: 10.8.0
     '@next/env':
       specifier: 16.2.9
       version: 16.2.9
@@ -154,7 +154,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.7.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ai@7.0.4(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ai@7.0.4(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
@@ -266,7 +266,7 @@ importers:
         version: 4.0.5(react@19.2.7)(zod@4.4.3)
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.7.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ai@7.0.4(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ai@7.0.4(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
       '@repo/code-highlight':
         specifier: workspace:*
         version: link:../../packages/code-highlight
@@ -378,7 +378,7 @@ importers:
     dependencies:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
-        version: 10.7.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ai@7.0.4(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
+        version: 10.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ai@7.0.4(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
       '@mdx-js/loader':
         specifier: 3.1.1
         version: 3.1.1
@@ -1648,8 +1648,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@k8o/arte-odyssey@10.7.0':
-    resolution: {integrity: sha512-yVRPxXXAOKzpF2B0T+pWsPFADXmDeHmWNd6ScMlw/F8jwhW+s/oWdDIOXxi7EX4OatsLkvXv7d2yduRcI5S38A==}
+  '@k8o/arte-odyssey@10.8.0':
+    resolution: {integrity: sha512-HFjiifXgP8eA8WDOPzWwaIZislcv2szuUfBLyIY5fj+ntHGWkHNA0iVZlf6w3Q5GUT5hP4q3RUwTM7jRE6hfwA==}
     peerDependencies:
       '@json-render/core': '>=0.19.0'
       '@json-render/react': '>=0.19.0'
@@ -7942,7 +7942,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@k8o/arte-odyssey@10.7.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ai@7.0.4(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)':
+  '@k8o/arte-odyssey@10.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ai@7.0.4(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)':
     dependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
@@ -9763,7 +9763,7 @@ snapshots:
       '@oxc-project/runtime': 0.133.0
       '@oxc-project/types': 0.133.0
       lightningcss: 1.32.0
-      postcss: 8.5.15
+      postcss: 8.5.16
     optionalDependencies:
       '@types/node': 24.13.2
       esbuild: 0.28.1
@@ -13019,7 +13019,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.15
+      postcss: 8.5.16
       rolldown: 1.0.2
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,7 +14,7 @@ allowBuilds:
 blockExoticSubdeps: true
 
 catalog:
-  '@k8o/arte-odyssey': 10.7.0
+  '@k8o/arte-odyssey': 10.8.0
   '@next/env': 16.2.9
   '@next/mdx': 16.2.9
   '@next/third-parties': 16.2.9


### PR DESCRIPTION
## 概要

OKLCH色空間でカラーパレットを生成する新ツール「いろばしご」(`/palette-maker`) を追加します。色相とピーク彩度を選ぶと、知覚的に一貫した11段階（50〜950）の明度スケールを生成し、各段のコントラスト検証とCSS変数エクスポートまで行えます。

## 動機

色系ツール（カラーコード職人・コントラストチェッカー・カラーHexクイズ）の面を広げつつ、ArteOdysseyのトークン設計に実際に使える道具にするためです。明度ラダーをArteOdysseyのtokens.cssと同一にしているので、生成したパレットがそのままデザインシステムの文脈に乗ります。

## 詳細

- 明度ラダーはArteOdysseyと同じ全色相共通の11段（0.975〜0.18）、彩度カーブはredランプをピーク正規化した係数
- 色計算は `@repo/helpers/color/*` の既存エンジン（`colorToOklch` / `toSrgbGamut` / `calcContrast` / `calcApca`）のみで実装。依存追加なし
- sRGBに収まらない段は色相・明度を保ったまま彩度を自動調整し、`＊` マークと注記で明示
- 各段に白文字/黒文字それぞれのWCAG 2比とAPCA Lcを表示（4.5以上を成功色で表示）
- エクスポートはCSS変数と Tailwind v4 `@theme` のタブ切り替え + コピー
- 状態は nuqs でURL同期（`?h=250&c=0.12&name=primary`）し、共有URLで再現可能
- 「基準色から取り込む」欄に任意のCSS色を貼ると、OKLCHに変換して色相・ピーク彩度へ反映
- `site-entries.ts` への登録のみでトップのTools一覧・sitemap・llms.txtに反映（後者2つは自動生成）

## 気をつけるポイント

- エクスポートするoklch()値は要求値ではなく**ガマットマッピング後の実測値**です。高彩度時は彩度（ごくわずかに色相・明度も）が要求値からずれますが、表示色とエクスポート値の一致を優先しています
- 初期値は h=250 / c=0.12（初期表示でクランプの `＊` が出ない組み合わせ）
- ArteOdysseyのSliderはネイティブ `input[type=range]` のため、Storybookの合成キーイベントでは値が変わらず、キーボード操作テストはNumberField（ArrowUp）経由にしています

## 影響範囲

- 新規ルート `/palette-maker`（新規ファイルのみ）
- 既存変更は `site-entries.ts` と `site-entry-section.tsx` のツール登録2ファイルのみ

## テスト

- 単体テスト22件（パレット生成・エクスポート・URLパーサー）とStorybook playテスト17件を追加。リポジトリ全体の425件通過
- 実ブラウザでスライダー→URL反映、共有URLからの状態再現、クランプ注記、コピー動作を確認済み
