### PR TITLE
fix: アプリ全体監査で見つかった High/Medium 問題の修正（10件）

### DIFF
--- a/.github/workflows/pavo.yml
+++ b/.github/workflows/pavo.yml
@@ -16,7 +16,12 @@ jobs:
   pavo:
     # Skip on PRs from forks: secrets are not exposed to fork workflows so the App
     # token step would fail anyway, and we don't want a permanent red Actions run.
-    if: ${{ github.event.pull_request.head.repo.fork != true }}
+    # review_comment はリポジトリの誰でも投稿できるため、コメント起点の実行は owner に限定する
+    # （write 権限 bot トークン + Claude トークンを持つため、第三者コメントでの起動を防ぐ）。
+    if: >-
+      ${{ github.event.pull_request.head.repo.fork != true &&
+          (github.event_name != 'pull_request_review_comment' ||
+           github.event.sender.login == github.repository_owner) }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/apps/admin/src/features/baseline/infrastructure/baseline-repository.ts
+++ b/apps/admin/src/features/baseline/infrastructure/baseline-repository.ts
@@ -73,7 +73,12 @@ export const findBaselineSnapshots = async ({
     })
     .from(db._schema.baselineSnapshots)
     .where(where)
-    .orderBy(desc(db._schema.baselineSnapshots.date))
+    // date は YYYY-MM-DD で重複が多いため、一意な id を tiebreaker に足して
+    // ページ境界での行の重複・欠落を防ぐ。
+    .orderBy(
+      desc(db._schema.baselineSnapshots.date),
+      desc(db._schema.baselineSnapshots.id),
+    )
     .limit(pageSize)
     .offset((page - 1) * pageSize);
 

--- a/apps/admin/src/features/blog/infrastructure/blog-repository.ts
+++ b/apps/admin/src/features/blog/infrastructure/blog-repository.ts
@@ -86,7 +86,9 @@ export const findBlogs = async ({
       eq(db._schema.blogViews.blogId, db._schema.blogs.id),
     )
     .where(where)
-    .orderBy(orderBy)
+    // created_at / views は seed で重複するため、一意な id を tiebreaker に足して
+    // ページ境界での行の重複・欠落を防ぐ。
+    .orderBy(orderBy, desc(db._schema.blogs.id))
     .limit(pageSize)
     .offset((page - 1) * pageSize);
 

--- a/apps/admin/src/features/comments/infrastructure/comment-repository.ts
+++ b/apps/admin/src/features/comments/infrastructure/comment-repository.ts
@@ -67,7 +67,8 @@ export const findComments = async ({
       eq(db._schema.comments.feedbackId, db._schema.feedbacks.id),
     )
     .where(where)
-    .orderBy(desc(db._schema.comments.createdAt))
+    // created_at が同値でもページ境界で行が重複・欠落しないよう一意な id を tiebreaker に足す
+    .orderBy(desc(db._schema.comments.createdAt), desc(db._schema.comments.id))
     .limit(pageSize)
     .offset((page - 1) * pageSize);
 
@@ -125,11 +126,13 @@ export const findCommentStats = async (): Promise<CommentStats> => {
   };
 };
 
-// blog_comment は commentId にカスケード設定が無いため、
-// 先に紐付け行を削除してから本体を削除する。
+// blog_comment は commentId にカスケード設定が無いため、先に紐付け行を削除してから
+// 本体を削除する。途中失敗で紐付けだけ消える不整合を避けるため transaction で囲う。
 export const deleteCommentById = async (id: number): Promise<void> => {
-  await db
-    .delete(db._schema.blogComment)
-    .where(eq(db._schema.blogComment.commentId, id));
-  await db.delete(db._schema.comments).where(eq(db._schema.comments.id, id));
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(db._schema.blogComment)
+      .where(eq(db._schema.blogComment.commentId, id));
+    await tx.delete(db._schema.comments).where(eq(db._schema.comments.id, id));
+  });
 };

--- a/apps/admin/src/features/reading-list/application/sync-articles.test.ts
+++ b/apps/admin/src/features/reading-list/application/sync-articles.test.ts
@@ -19,7 +19,9 @@ vi.mock('@repo/database', () => ({
       },
     },
     insert: vi.fn().mockReturnValue({
-      values: vi.fn(),
+      values: vi.fn().mockReturnValue({
+        onConflictDoNothing: vi.fn(),
+      }),
     }),
     update: vi.fn().mockReturnValue({
       set: vi.fn().mockReturnValue({
@@ -132,7 +134,9 @@ describe('syncArticles', () => {
         imageUrl: 'https://web.dev/og.png',
       });
 
-      const valuesMock = vi.fn();
+      const valuesMock = vi
+        .fn()
+        .mockReturnValue({ onConflictDoNothing: vi.fn() });
       vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
 
       await syncArticles();
@@ -174,7 +178,9 @@ describe('syncArticles', () => {
 
       vi.mocked(db.query.articles.findMany).mockResolvedValue([]);
 
-      const valuesMock = vi.fn();
+      const valuesMock = vi
+        .fn()
+        .mockReturnValue({ onConflictDoNothing: vi.fn() });
       vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
 
       await syncArticles();
@@ -441,7 +447,9 @@ describe('syncArticles', () => {
 
       vi.mocked(db.query.articles.findMany).mockResolvedValue([]);
 
-      const valuesMock = vi.fn();
+      const valuesMock = vi
+        .fn()
+        .mockReturnValue({ onConflictDoNothing: vi.fn() });
       vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
 
       const result = await syncArticles();
@@ -478,7 +486,9 @@ describe('syncArticles', () => {
 
       vi.mocked(db.query.articles.findMany).mockResolvedValue([]);
 
-      const valuesMock = vi.fn();
+      const valuesMock = vi
+        .fn()
+        .mockReturnValue({ onConflictDoNothing: vi.fn() });
       vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
 
       const result = await syncArticles();
@@ -527,7 +537,9 @@ describe('syncArticles', () => {
 
       vi.mocked(db.query.articles.findMany).mockResolvedValue([]);
 
-      const valuesMock = vi.fn();
+      const valuesMock = vi
+        .fn()
+        .mockReturnValue({ onConflictDoNothing: vi.fn() });
       vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
 
       const result = await syncArticles();
@@ -536,6 +548,52 @@ describe('syncArticles', () => {
       expect(valuesMock).toHaveBeenCalledWith([
         expect.objectContaining({ url: 'https://web.dev/blog/safe' }),
       ]);
+    });
+
+    it('同一同期内で重複する URL は1件だけ追加する', async () => {
+      vi.mocked(db.query.articleSources.findMany).mockResolvedValue([
+        {
+          id: 1,
+          title: 'web.dev',
+          url: 'https://web.dev/feed.xml',
+          siteUrl: 'https://web.dev',
+          type: 'feed' as const,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ]);
+
+      mockParseString.mockResolvedValue({
+        items: [
+          {
+            title: '記事',
+            link: 'https://web.dev/blog/dup',
+            isoDate: '2026-03-10T00:00:00Z',
+          },
+          {
+            title: '記事（重複配信）',
+            link: 'https://web.dev/blog/dup',
+            isoDate: '2026-03-11T00:00:00Z',
+          },
+        ],
+      });
+
+      vi.mocked(db.query.articles.findMany).mockResolvedValue([]);
+
+      const onConflictMock = vi.fn();
+      const valuesMock = vi
+        .fn()
+        .mockReturnValue({ onConflictDoNothing: onConflictMock });
+      vi.mocked(db.insert).mockReturnValue({ values: valuesMock } as never);
+
+      const result = await syncArticles();
+
+      expect(result.newArticles).toBe(1);
+      expect(valuesMock).toHaveBeenCalledWith([
+        expect.objectContaining({ url: 'https://web.dev/blog/dup' }),
+      ]);
+      // unique 違反を握って冪等にするため onConflictDoNothing を必ず通す
+      expect(onConflictMock).toHaveBeenCalled();
     });
 
     it('既にDBに存在するURLの記事は追加しない', async () => {

--- a/apps/admin/src/features/reading-list/application/sync-articles.ts
+++ b/apps/admin/src/features/reading-list/application/sync-articles.ts
@@ -122,11 +122,18 @@ export async function syncArticles(): Promise<SyncResult> {
   const existingByUrl = new Map(existingArticles.map((a) => [a.url, a.title]));
 
   const newArticles: FeedArticle[] = [];
+  const seenNewUrls = new Set<string>();
   const articlesToUpdate: Array<{ url: string; title: string }> = [];
 
   for (const candidate of allCandidates) {
     const existingTitle = existingByUrl.get(candidate.url);
     if (existingTitle === undefined) {
+      // 複数フィードが同一 URL を配信する/同一フィードに同じ link が複数回現れると、
+      // articles_url_idx(unique) 違反で INSERT 全体が失敗するため、この同期内で重複排除する
+      if (seenNewUrls.has(candidate.url)) {
+        continue;
+      }
+      seenNewUrls.add(candidate.url);
       newArticles.push(candidate);
     } else if (existingTitle !== candidate.title) {
       articlesToUpdate.push({
@@ -149,7 +156,11 @@ export async function syncArticles(): Promise<SyncResult> {
         };
       },
     );
-    await db.insert(db._schema.articles).values(newArticleRows);
+    // cron と手動同期の並走で同一 URL が同時に入り得るため、unique 違反を握って冪等にする
+    await db
+      .insert(db._schema.articles)
+      .values(newArticleRows)
+      .onConflictDoNothing({ target: db._schema.articles.url });
   }
 
   if (articlesToUpdate.length > 0) {

--- a/apps/admin/src/features/reading-list/infrastructure/reading-list-repository.ts
+++ b/apps/admin/src/features/reading-list/infrastructure/reading-list-repository.ts
@@ -164,7 +164,17 @@ export const updateArticleSource = async (
 };
 
 export const deleteArticleSourceById = async (id: number): Promise<void> => {
-  await db
-    .delete(db._schema.articleSources)
-    .where(eq(db._schema.articleSources.id, id));
+  // articles.article_source_id は onDelete 未指定(NO ACTION)。子記事を残したままソースを
+  // 消すと FK 制約で失敗し（FK 非強制環境では孤児記事が残る）。子記事 → ソースの順で同一
+  // transaction で消す（配列順に実行され、削除時点で参照が無くなり FK を満たす）。
+  await db.transaction((tx) =>
+    Promise.all([
+      tx
+        .delete(db._schema.articles)
+        .where(eq(db._schema.articles.articleSourceId, id)),
+      tx
+        .delete(db._schema.articleSources)
+        .where(eq(db._schema.articleSources.id, id)),
+    ]),
+  );
 };

--- a/apps/admin/src/features/talks/infrastructure/talk-repository.ts
+++ b/apps/admin/src/features/talks/infrastructure/talk-repository.ts
@@ -106,8 +106,13 @@ export const updateTalkById = async (
     .where(eq(db._schema.talks.id, id));
 };
 
-// talk_tag は talkId にカスケード設定が無いため先に削除する。
+// talk_tag は talkId にカスケード設定が無いため先に削除する。途中失敗でタグ紐付けだけ
+// 消える不整合を避けるため transaction で囲う。
 export const deleteTalkById = async (id: number): Promise<void> => {
-  await db.delete(db._schema.talkTag).where(eq(db._schema.talkTag.talkId, id));
-  await db.delete(db._schema.talks).where(eq(db._schema.talks.id, id));
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(db._schema.talkTag)
+      .where(eq(db._schema.talkTag.talkId, id));
+    await tx.delete(db._schema.talks).where(eq(db._schema.talks.id, id));
+  });
 };

--- a/apps/main/src/features/blog/application/submit-feedback.ts
+++ b/apps/main/src/features/blog/application/submit-feedback.ts
@@ -25,20 +25,27 @@ export const submitFeedback = async (
   }
 
   try {
-    const insertComments = await db
-      .insert(db._schema.comments)
-      .values({
-        message: comment,
-        feedbackId,
-      })
-      .returning({ insertedId: db._schema.comments.id });
+    // コメント本体と blog 紐付けは原子的に入れる。途中失敗で「blog に紐付かない
+    // 孤児コメント」（お問い合わせと区別できない）が残らないよう transaction で囲う。
+    await db.transaction(async (tx) => {
+      const insertComments = await tx
+        .insert(db._schema.comments)
+        .values({
+          message: comment,
+          feedbackId,
+        })
+        .returning({ insertedId: db._schema.comments.id });
 
-    if (insertComments[0]?.insertedId !== undefined) {
-      await db.insert(db._schema.blogComment).values({
+      const insertedId = insertComments[0]?.insertedId;
+      if (insertedId === undefined) {
+        throw new Error('コメントIDの取得に失敗しました');
+      }
+
+      await tx.insert(db._schema.blogComment).values({
         blogId: blog.id,
-        commentId: insertComments[0].insertedId,
+        commentId: insertedId,
       });
-    }
+    });
 
     return {
       success: true,

--- a/apps/main/src/features/blog/interface/actions.test.ts
+++ b/apps/main/src/features/blog/interface/actions.test.ts
@@ -2,8 +2,8 @@ import { db } from '@repo/database';
 
 import { feedback } from './actions';
 
-vi.mock('@repo/database', () => ({
-  db: {
+vi.mock('@repo/database', () => {
+  const mockDb = {
     query: {
       blogs: {
         findFirst: vi.fn(),
@@ -21,14 +21,18 @@ vi.mock('@repo/database', () => ({
         }),
       }),
     }),
+    // submitFeedback は transaction で囲う。tx として db 自身を渡し、既存の
+    // db.insert モック・アサーションをそのまま活かす。
+    transaction: vi.fn((cb: (tx: typeof mockDb) => unknown) => cb(mockDb)),
     _schema: {
       comments: {
         id: 'comments.id',
       },
       blogComment: {},
     },
-  },
-}));
+  };
+  return { db: mockDb };
+});
 vi.mock('@/shared/validation/zod', () => ({
   configureZod: vi.fn(),
 }));

--- a/apps/main/src/features/blog/interface/actions.ts
+++ b/apps/main/src/features/blog/interface/actions.ts
@@ -1,10 +1,21 @@
 'use server';
 
+import * as z from 'zod/mini';
+
 import { configureZod } from '@/shared/validation/zod';
 
 import { submitFeedback } from '../application/submit-feedback';
 
 configureZod();
+
+// Server Action は任意のクライアントから任意のシリアライズ値で呼べるため、
+// 型（comment が文字列か等）を trust boundary として検証する。文字数・組み合わせ
+// といった業務ルールは下の個別チェックでユーザー向けメッセージを保つ。
+const feedbackSchema = z.object({
+  slug: z.string().check(z.minLength(1), z.maxLength(200)),
+  feedbackId: z.nullable(z.number().check(z.int(), z.positive())),
+  comment: z.string(),
+});
 
 type Result =
   | {
@@ -20,20 +31,33 @@ export const feedback = async (
   feedbackId: number | null,
   comment: string,
 ): Promise<Result> => {
-  if (comment === '' && feedbackId === null) {
+  const validated = feedbackSchema.safeParse({ slug, feedbackId, comment });
+  if (!validated.success) {
+    return {
+      success: false,
+      message:
+        validated.error.issues[0]?.message ?? '入力内容が正しくありません',
+    };
+  }
+
+  if (validated.data.comment === '' && validated.data.feedbackId === null) {
     return {
       success: false,
       message: 'コメントまたはフィードバックIDのいずれかを入力してください',
     };
   }
 
-  if (comment.length > 500) {
+  if (validated.data.comment.length > 500) {
     return {
       success: false,
       message: 'コメントは500文字以内で入力してください',
     };
   }
 
-  const result = await submitFeedback(slug, feedbackId, comment);
+  const result = await submitFeedback(
+    validated.data.slug,
+    validated.data.feedbackId,
+    validated.data.comment,
+  );
   return result;
 };

--- a/apps/main/src/features/tags/application/tags.test.ts
+++ b/apps/main/src/features/tags/application/tags.test.ts
@@ -41,7 +41,7 @@ describe('getTags', () => {
     ]);
     vi.mocked(db.query.tags.findMany).mockImplementation(mockMany);
 
-    const tags = await getTags(1);
+    const tags = await getTags();
 
     expect(tags).toHaveLength(1);
     expect(tags[0]?.name).toBe('tag1');

--- a/apps/main/src/features/tags/application/tags.ts
+++ b/apps/main/src/features/tags/application/tags.ts
@@ -1,6 +1,6 @@
 import { db } from '@repo/database';
 
-export async function getTags(page = 1): Promise<
+export async function getTags(): Promise<
   Array<{
     id: number;
     name: string;
@@ -25,8 +25,7 @@ export async function getTags(page = 1): Promise<
         },
       },
     },
-    limit: 100,
-    offset: (page - 1) * 100,
+    orderBy: (fields, { asc }) => asc(fields.name),
   });
 
   return tags.map((tag) => ({

--- a/apps/main/src/features/tags/interface/queries.ts
+++ b/apps/main/src/features/tags/interface/queries.ts
@@ -5,12 +5,12 @@ import { DB_CONTENT_CACHE_TAG } from '@/shared/cache/cache-tags';
 import { getTag as _getTag } from '../application/tag';
 import { getTags as _getTags } from '../application/tags';
 
-export async function getTags(page = 1) {
+export async function getTags() {
   'use cache';
   cacheLife('max');
   cacheTag(DB_CONTENT_CACHE_TAG);
 
-  const tags = await _getTags(page);
+  const tags = await _getTags();
   return tags;
 }
 

--- a/packages/helpers/src/date/format.ts
+++ b/packages/helpers/src/date/format.ts
@@ -2,19 +2,44 @@ const WEEKDAYS = ['日', '月', '火', '水', '木', '金', '土'] as const;
 
 const pad2 = (n: number): string => String(n).padStart(2, '0');
 
+// 実行環境のローカルTZに依存すると、サーバー(UTC)描画とクライアント描画で日付/時刻が
+// ずれ、date-only 値では表示日が1日ずれたり hydration mismatch を起こす。閲覧者の
+// TZ に関わらず一定の表示にするため、既定で日本時間に固定して整形する。
+const DEFAULT_TIME_ZONE = 'Asia/Tokyo';
+
 export const formatDate = (
   date: Date,
   formatStr = 'yyyy年M月d日(E)',
+  timeZone = DEFAULT_TIME_ZONE,
 ): string => {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+    hour: 'numeric',
+    minute: 'numeric',
+    hourCycle: 'h23',
+  }).formatToParts(date);
+  const lookup = (type: Intl.DateTimeFormatPartTypes): number =>
+    Number(parts.find((part) => part.type === type)?.value ?? '0');
+
+  const year = lookup('year');
+  const month = lookup('month');
+  const day = lookup('day');
+  // 指定TZの暦日から曜日を得る（UTC で同じ暦日を作り getUTCDay で参照する）。
+  const weekday =
+    WEEKDAYS[new Date(Date.UTC(year, month - 1, day)).getUTCDay()];
+
   const replacements: Record<string, string> = {
-    yyyy: String(date.getFullYear()),
-    MM: pad2(date.getMonth() + 1),
-    M: String(date.getMonth() + 1),
-    dd: pad2(date.getDate()),
-    d: String(date.getDate()),
-    HH: pad2(date.getHours()),
-    mm: pad2(date.getMinutes()),
-    E: WEEKDAYS[date.getDay()] ?? '',
+    yyyy: String(year),
+    MM: pad2(month),
+    M: String(month),
+    dd: pad2(day),
+    d: String(day),
+    HH: pad2(lookup('hour')),
+    mm: pad2(lookup('minute')),
+    E: weekday ?? '',
   };
 
   return formatStr.replaceAll(
@@ -44,12 +69,28 @@ if (import.meta.vitest) {
     expect(result).toBe(expected);
   });
 
-  it('ゼロ埋め・時刻付きのフォーマットに対応する', () => {
+  it('ゼロ埋め・時刻付きのフォーマットに対応する（既定は日本時間）', () => {
     vi.useFakeTimers();
     vi.setSystemTime('2022-03-05T09:08:00Z');
 
-    expect(formatDate(new Date(), 'yyyy/MM/dd HH:mm')).toBe('2022/03/05 09:08');
+    // 09:08 UTC は JST では 18:08
+    expect(formatDate(new Date(), 'yyyy/MM/dd HH:mm')).toBe('2022/03/05 18:08');
     expect(formatDate(new Date(), 'M/d')).toBe('3/5');
     expect(formatDate(new Date(), 'yyyy')).toBe('2022');
+  });
+
+  it('date-only 値が閲覧TZに関わらず日付をずらさない', () => {
+    // UTC 深夜として解釈される date-only 文字列でも、JST 固定なら同じ暦日で表示される
+    expect(formatDate(new Date('2025-03-17'), 'yyyy/MM/dd')).toBe('2025/03/17');
+  });
+
+  it('timeZone を明示指定できる', () => {
+    const instant = new Date('2022-03-05T09:08:00Z');
+    expect(formatDate(instant, 'yyyy/MM/dd HH:mm', 'UTC')).toBe(
+      '2022/03/05 09:08',
+    );
+    expect(formatDate(instant, 'yyyy/MM/dd HH:mm', 'Asia/Tokyo')).toBe(
+      '2022/03/05 18:08',
+    );
   });
 }

--- a/packages/react-hooks/src/use-async-action.ts
+++ b/packages/react-hooks/src/use-async-action.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState, useTransition } from 'react';
+import { useCallback, useRef, useState, useTransition } from 'react';
 
 type ActionResult = {
   error?: string;
@@ -11,27 +11,49 @@ type RunHandlers<T> = {
   onError?: (message: string) => void;
 };
 
+const FALLBACK_ERROR_MESSAGE =
+  '処理に失敗しました。時間をおいて再度お試しください。';
+
 export const useAsyncAction = () => {
   const [isPending, startTransition] = useTransition();
   const [error, setError] = useState<string>();
+  // 連続実行時、古い run の結果で最新の状態を上書きしないための世代カウンタ
+  const runIdRef = useRef(0);
 
   const run = useCallback(
     <T extends ActionResult>(
       action: () => Promise<T>,
       handlers?: RunHandlers<T>,
     ): void => {
-      setError(undefined);
-      startTransition(async () => {
-        const result = await action();
-        if (result.error !== undefined) {
-          if (handlers?.onError) {
-            handlers.onError(result.error);
-          } else {
-            setError(result.error);
-          }
+      const runId = (runIdRef.current += 1);
+      const isStale = (): boolean => runId !== runIdRef.current;
+      const handleError = (message: string): void => {
+        if (isStale()) {
           return;
         }
-        handlers?.onSuccess?.(result);
+        if (handlers?.onError) {
+          handlers.onError(message);
+        } else {
+          setError(message);
+        }
+      };
+
+      setError(undefined);
+      startTransition(async () => {
+        try {
+          const result = await action();
+          if (isStale()) {
+            return;
+          }
+          if (result.error !== undefined) {
+            handleError(result.error);
+            return;
+          }
+          handlers?.onSuccess?.(result);
+        } catch {
+          // action 自体の reject（ネットワーク断・500 等）でも UI を無反応にせずエラー表示する
+          handleError(FALLBACK_ERROR_MESSAGE);
+        }
       });
     },
     [],

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,7 @@
     "build": {
       "dependsOn": ["^build"],
       "env": [
+        "AI_GENERATE_LIMIT_PER_HOUR",
         "AI_TEMPLATE_SNAPSHOT_ID",
         "ALLOWED_EMAILS",
         "BETTER_AUTH_SECRET",
@@ -24,8 +25,13 @@
         "GITHUB_CLIENT_SECRET",
         "NEXT_PUBLIC_GOOGLE_ANALYTICS_ID",
         "SAKANA_API_KEY",
+        "SAKANA_BASE_URL",
+        "SUMMARY_MODEL",
         "TURSO_AUTH_TOKEN",
-        "TURSO_DATABASE_URL"
+        "TURSO_DATABASE_URL",
+        "VAPID_PRIVATE_KEY",
+        "VAPID_PUBLIC_KEY",
+        "VAPID_SUBJECT"
       ],
       "inputs": ["$TURBO_DEFAULT$", ".env", ".env.*"],
       "outputs": [".next/**", "!.next/cache/**"]


### PR DESCRIPTION
## 概要

アプリケーション全体の監査（6領域を並列レビュー＋型/lint/テスト）で見つかった問題のうち、**確度が高く安全に検証できる修正**をまとめて対応します。High 4件＋Medium 6件、計10コミット（すべてアトミック）。

各コミットは独立して revert 可能です。DBが必要な設計変更やスキーマ変更（下記「今回は含めないもの」）は別対応にしています。

## 含まれる修正

### High
- **`fix(tags)`** タグ一覧の100件切り捨てを解消し名前順で全件返す — `limit:100` かつ `orderBy` 無しで、seed済みの約140タグのうち約40件が `/tags`・sitemap から不可視だった
- **`fix(reading-list)`** 記事を持つソースの削除を子記事ごと transaction で消す — `articles.article_source_id` が `onDelete` 未指定で、記事を持つソースの削除が FK 制約で失敗（非強制環境では孤児記事でページが落ちる）していた
- **`ci(pavo)`** レビューコメント起点の実行を owner 限定にする — `pull_request_review_comment` はリポジトリの誰でも投稿でき、write 権限 bot トークン＋Claude トークンを持つ LLM 実行を第三者が起動できた
- **`chore(turbo)`** build.env に不足していた環境変数を追加 — strict env mode で `VAPID_PUBLIC_KEY` 等が剥がされ、通知ページに空文字が焼き込まれ push 購読が無音で壊れていた

### Medium
- **`fix(helpers)`** `formatDate` を日本時間固定にし TZ 依存の日付ずれ・hydration mismatch を解消
- **`fix(reading-list)`** 記事同期の重複 URL で INSERT 全滅を防ぐ（同期内 dedupe ＋ `onConflictDoNothing`）
- **`fix(react-hooks)`** `useAsyncAction` が action の reject を握りつぶす問題を修正（フォールバック表示＋世代ガード）
- **`fix(blog)`** フィードバック Server Action に zod 型検証を追加（非文字列 comment による文字数チェックのバイパスを防止）
- **`fix`** 2段階の DB 書き込みを transaction で原子化（フィードバック挿入・コメント削除・トーク削除）
- **`fix(admin)`** 一覧ページングに一意な id の tiebreaker を追加（blogs / baseline / comments のページ境界での重複・欠落を解消）

## テスト

- `pnpm run type-check` 8/8 ✅
- `pnpm run check` 0 errors（残 17 warning は既存の意図的なもの）
- `pnpm run test` 全 852 件パス ✅（helpers / admin に回帰テストを追加）
- `turbo run build --dry=json` で追加した env が build に乗ること＆ envMode strict を確認

## 今回は含めないもの（別対応）

いずれも設計判断・スキーマ変更/マイグレーション・新規インフラを伴い、ローカル DB が起動しない環境では安全に検証できないため分離：

- **未認証の公開共有からの Vercel Sandbox 課金**（DBベースの永続レート制限が必要）→ 別タスク化済み
- preview 環境の認証 OFF / admin・ai のセキュリティヘッダ / main の CSP 基盤（Reporting-Endpoints・Trusted Types）/ fork PR で CI 不走行 / `blog_comment` の PK・unique 追加 / フィードバックのレート制限

## メモ

- comments の一覧 tiebreaker（M12）は、同一ファイルの transaction 変更（M10）と同じファイルに入ったため `fix: 2段階のDB書き込みを...` コミットに同梱されています。
