### PR TITLE
fix(main): スライドのナビゲーションボタンがクリックで反応しない問題を修正

### DIFF
--- a/apps/main/src/app/slides/_components/slide-deck/nav-button/nav-button.stories.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/nav-button/nav-button.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
-import { expect, within } from 'storybook/test';
+import { expect, fn, within } from 'storybook/test';
 
 import { NavButton } from './nav-button';
 
@@ -7,7 +7,7 @@ const meta: Meta<typeof NavButton> = {
   title: 'app/slides/slide-deck/nav-button',
   component: NavButton,
   args: {
-    onAction: () => undefined,
+    onAction: fn(() => undefined),
   },
 };
 
@@ -19,12 +19,22 @@ export const Prev: Story = {
     direction: 'prev',
     disabled: false,
   },
+  play: async ({ args, canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: '前のスライド' }));
+    await expect(args.onAction).toHaveBeenCalledTimes(1);
+  },
 };
 
 export const Next: Story = {
   args: {
     direction: 'next',
     disabled: false,
+  },
+  play: async ({ args, canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: '次のスライド' }));
+    await expect(args.onAction).toHaveBeenCalledTimes(1);
   },
 };
 
@@ -33,9 +43,11 @@ export const Disabled: Story = {
     direction: 'next',
     disabled: true,
   },
-  play: async ({ canvasElement }) => {
+  play: async ({ args, canvasElement, userEvent }) => {
     const canvas = within(canvasElement);
     const button = canvas.getByRole('button', { name: '次のスライド' });
     await expect(button).toBeDisabled();
+    await userEvent.click(button);
+    await expect(args.onAction).not.toHaveBeenCalled();
   },
 };

--- a/apps/main/src/app/slides/_components/slide-deck/nav-button/nav-button.tsx
+++ b/apps/main/src/app/slides/_components/slide-deck/nav-button/nav-button.tsx
@@ -12,24 +12,9 @@ type Props = {
 export const NavButton: FC<Props> = ({ direction, disabled, onAction }) => (
   <IconButton
     color="transparent"
+    disabled={disabled}
     label={direction === 'prev' ? '前のスライド' : '次のスライド'}
     onAction={onAction}
-    renderItem={({
-      className,
-      children,
-      'aria-label': ariaLabel,
-      triggerProps,
-    }) => (
-      <button
-        aria-label={ariaLabel}
-        className={className}
-        disabled={disabled}
-        type="button"
-        {...triggerProps}
-      >
-        {children}
-      </button>
-    )}
   >
     <ChevronIcon direction={direction === 'prev' ? 'left' : 'right'} />
   </IconButton>


### PR DESCRIPTION
## 概要

スライドビューアー（DeckViewer / DeckPresenter）のフッターにある「前のスライド」「次のスライド」ボタンが、クリックしても反応しない問題を修正しました。

## 動機

\`@k8o/arte-odyssey\` v10.7.0 の \`IconButton\` は、\`renderItem\` 使用時にカスタム要素へ Tooltip 用の \`triggerProps\`（\`onMouseEnter\` / \`onMouseLeave\` / \`onFocus\` / \`onBlur\` / \`aria-describedby\` / \`ref\`）しか渡さず、\`onAction\` / \`onClick\` を配線しません。NavButton は \`renderItem\` でカスタム \`button\` を描画していたため、クリックしても \`onAction\` が呼ばれない状態でした（矢印キー操作は deck 側のキーハンドラで動くため気づきにくい）。

Storybook の play テストを先に追加して、修正前のコードで Chromium 実ブラウザのクリックが \`onAction\` を呼ばないこと（0 times）を再現確認しています。

## 詳細

- \`nav-button.tsx\`: \`renderItem\` でのカスタム \`button\` 描画をやめ、\`IconButton\` に \`disabled\` と \`onAction\` を直接渡す形に変更
- \`nav-button.stories.tsx\`:
  - Prev / Next: クリックで \`onAction\` が1回呼ばれることを検証する play テストを追加
  - Disabled: 既存の \`toBeDisabled\` 検証に加え、クリックしても \`onAction\` が呼ばれないことを検証

## 気をつけるポイント

- 旧実装（\`renderItem\` 経路）では disabled 時の視覚スタイル（\`opacity-50\` / \`cursor-not-allowed\`）が適用されていませんでしたが、デフォルト描画では適用されるようになります。無効状態が見た目で分かるようになる改善ですが、**VRT に差分が出る可能性があります**
- DeckViewer ヘッダーの「Slides一覧へ戻る」も \`renderItem\` を使っていますが、こちらは \`Link\`（href によるナビゲーション）なので影響なし・変更不要です

## 影響範囲

- \`/slides/[slug]\` のスライドビューアーと発表者モードのナビゲーションボタン

## テスト

- \`pnpm run test --project=storybook\`（slide-deck 配下 4ファイル・10件）: パス
- \`pnpm run check\` / \`pnpm run type-check\`: パス