### PR TITLE
feat(ai): 公開共有 serve に DBベースのグローバルレート制限を追加

### DIFF
--- a/apps/ai/src/features/share/application/serve-limit.test.ts
+++ b/apps/ai/src/features/share/application/serve-limit.test.ts
@@ -140,13 +140,15 @@ describe('gatedServe', () => {
     });
 
     it('記録が失敗しても配信は止めず URL を返す', async () => {
-      const { deps, servedCount } = makeDeps({
+      const { deps, servedCount, recordedCount } = makeDeps({
         count: 0,
         recordThrows: true,
       });
       const url = await gatedServe(deps);
       expect(url).toBe('https://served.example');
       expect(servedCount()).toBe(1);
+      // best-effort: record を試みた（呼んでから例外を投げた）ことまで確認する。
+      expect(recordedCount()).toBe(1);
     });
   });
 

--- a/apps/ai/src/features/share/application/serve-limit.test.ts
+++ b/apps/ai/src/features/share/application/serve-limit.test.ts
@@ -1,0 +1,161 @@
+import {
+  gatedServe,
+  isOverServeLimit,
+  serveWindowStartIso,
+  shareServeLimit,
+} from './serve-limit';
+
+describe('serve-limit', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  describe('正常系', () => {
+    it('上限未満は false、上限到達以上で true', () => {
+      expect(isOverServeLimit(29, 30)).toBe(false);
+      expect(isOverServeLimit(30, 30)).toBe(true);
+      expect(isOverServeLimit(31, 30)).toBe(true);
+    });
+
+    it('serveWindowStartIso は now から1時間前の ISO を返す', () => {
+      const now = Date.parse('2026-06-23T12:00:00.000Z');
+      expect(serveWindowStartIso(now)).toBe('2026-06-23T11:00:00.000Z');
+    });
+
+    it('shareServeLimit は正の整数 env を採用する', () => {
+      vi.stubEnv('AI_SHARE_SERVE_LIMIT_PER_HOUR', '80');
+      expect(shareServeLimit()).toBe(80);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('env 未設定は既定値 30 にフォールバックする', () => {
+      vi.stubEnv('AI_SHARE_SERVE_LIMIT_PER_HOUR', '');
+      expect(shareServeLimit()).toBe(30);
+    });
+
+    it('不正な env は既定値 30 にフォールバックする', () => {
+      vi.stubEnv('AI_SHARE_SERVE_LIMIT_PER_HOUR', 'abc');
+      expect(shareServeLimit()).toBe(30);
+    });
+
+    it('0 以下の env は既定値 30 にフォールバックする', () => {
+      vi.stubEnv('AI_SHARE_SERVE_LIMIT_PER_HOUR', '0');
+      expect(shareServeLimit()).toBe(30);
+      vi.stubEnv('AI_SHARE_SERVE_LIMIT_PER_HOUR', '-5');
+      expect(shareServeLimit()).toBe(30);
+    });
+
+    it('小数の env は整数でないため既定値 30 にフォールバックする', () => {
+      vi.stubEnv('AI_SHARE_SERVE_LIMIT_PER_HOUR', '10.5');
+      expect(shareServeLimit()).toBe(30);
+    });
+  });
+});
+
+describe('gatedServe', () => {
+  type CountFn = (input: { sinceIso: string }) => Promise<number>;
+  type Over = {
+    count?: number | CountFn;
+    serveUrl?: string | null;
+    recordThrows?: boolean;
+    limit?: number;
+  };
+
+  // 決定的な依存を組み立てる。呼び出し回数を数えて serve/record の発火を検証する。
+  const makeDeps = (over: Over) => {
+    let served = 0;
+    let recorded = 0;
+    const count = over.count ?? 0;
+    const countRecentServes: CountFn =
+      typeof count === 'function'
+        ? count
+        : (): Promise<number> => Promise.resolve(count);
+    const deps = {
+      slug: 'slug-x',
+      now: Date.parse('2026-06-23T12:00:00.000Z'),
+      limit: over.limit ?? 30,
+      countRecentServes,
+      serve: (): Promise<string | null> => {
+        served += 1;
+        return Promise.resolve(
+          over.serveUrl === undefined
+            ? 'https://served.example'
+            : over.serveUrl,
+        );
+      },
+      recordServe: (): Promise<void> => {
+        recorded += 1;
+        return over.recordThrows === true
+          ? Promise.reject(new Error('record boom'))
+          : Promise.resolve();
+      },
+    };
+    return {
+      deps,
+      servedCount: (): number => served,
+      recordedCount: (): number => recorded,
+    };
+  };
+
+  describe('正常系', () => {
+    it('上限未満なら serve し、成功時に1回だけ記録して URL を返す', async () => {
+      const { deps, servedCount, recordedCount } = makeDeps({ count: 29 });
+      const url = await gatedServe(deps);
+      expect(url).toBe('https://served.example');
+      expect(servedCount()).toBe(1);
+      expect(recordedCount()).toBe(1);
+    });
+
+    it('countRecentServes は now から1時間前の sinceIso で問い合わせる', async () => {
+      let capturedSince = '';
+      const { deps } = makeDeps({
+        count: (input: { sinceIso: string }): Promise<number> => {
+          capturedSince = input.sinceIso;
+          return Promise.resolve(0);
+        },
+      });
+      await gatedServe(deps);
+      expect(capturedSince).toBe('2026-06-23T11:00:00.000Z');
+    });
+  });
+
+  describe('異常系', () => {
+    it('上限到達なら serve せず（課金させず）記録もせず null を返す', async () => {
+      const { deps, servedCount, recordedCount } = makeDeps({ count: 30 });
+      const url = await gatedServe(deps);
+      expect(url).toBeNull();
+      expect(servedCount()).toBe(0);
+      expect(recordedCount()).toBe(0);
+    });
+
+    it('カウント取得が失敗しても fail-open で serve する', async () => {
+      const { deps, servedCount, recordedCount } = makeDeps({
+        count: (): Promise<number> => Promise.reject(new Error('db down')),
+      });
+      const url = await gatedServe(deps);
+      expect(url).toBe('https://served.example');
+      expect(servedCount()).toBe(1);
+      expect(recordedCount()).toBe(1);
+    });
+
+    it('記録が失敗しても配信は止めず URL を返す', async () => {
+      const { deps, servedCount } = makeDeps({
+        count: 0,
+        recordThrows: true,
+      });
+      const url = await gatedServe(deps);
+      expect(url).toBe('https://served.example');
+      expect(servedCount()).toBe(1);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('serve が null を返したら記録しない（実配信していないため）', async () => {
+      const { deps, recordedCount } = makeDeps({ count: 0, serveUrl: null });
+      const url = await gatedServe(deps);
+      expect(url).toBeNull();
+      expect(recordedCount()).toBe(0);
+    });
+  });
+});

--- a/apps/ai/src/features/share/application/serve-limit.ts
+++ b/apps/ai/src/features/share/application/serve-limit.ts
@@ -1,0 +1,67 @@
+// 課金保護: 公開共有（/s/[slug]）の Sandbox serve/起動を、プロセス内クールダウンでは効かない
+// クロスインスタンスのグローバル上限で縛る安全網（1時間スライディングウィンドウ、上限は env で調整可能）。
+// プロセス内 single-flight（serve-cooldown）が warm 中の重複を吸収する上で、これは cold start/起動の
+// 絶対数を DB カウントで縛る二層目にあたる。
+const WINDOW_MS = 60 * 60 * 1000;
+const DEFAULT_LIMIT = 30;
+
+const parseLimit = (raw: string | undefined): number => {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : DEFAULT_LIMIT;
+};
+
+export const shareServeLimit = (): number =>
+  parseLimit(process.env['AI_SHARE_SERVE_LIMIT_PER_HOUR']);
+
+// now を引数に取り決定的に保つ。
+export const serveWindowStartIso = (now: number): string =>
+  new Date(now - WINDOW_MS).toISOString();
+
+export const isOverServeLimit = (count: number, limit: number): boolean =>
+  count >= limit;
+
+type GatedServeDeps = {
+  slug: string;
+  // 決定的テスト用に now/limit/count/serve/record を注入する。
+  now: number;
+  limit: number;
+  countRecentServes: (input: { sinceIso: string }) => Promise<number>;
+  serve: () => Promise<string | null>;
+  recordServe: (input: { slug: string }) => Promise<void>;
+};
+
+// DB のグローバル上限を評価してから serve し、実際に serve できた分だけ記録する。
+// - over-limit のときは serve せず（＝課金させず）null を返す。
+// - fail-open: カウント取得の DB エラーで公開ページを壊さない（配信を続ける）。
+// - 記録失敗は配信を止めない（best-effort）。
+// resolveServeWithCooldown に渡す serve として合成される前提で、warm な cache/in-flight ヒットは
+// 呼び出し側の single-flight が弾くため、ここへ来た時点で「実際に serve する」呼び出しである。
+export const gatedServe = async (
+  deps: GatedServeDeps,
+): Promise<string | null> => {
+  let overLimit = false;
+  try {
+    const recent = await deps.countRecentServes({
+      sinceIso: serveWindowStartIso(deps.now),
+    });
+    overLimit = isOverServeLimit(recent, deps.limit);
+  } catch (error) {
+    console.error(
+      '共有 serve レート制限のカウント取得に失敗（fail-open で配信）',
+      error,
+    );
+  }
+  if (overLimit) {
+    return null;
+  }
+
+  const url = await deps.serve();
+  if (url !== null) {
+    try {
+      await deps.recordServe({ slug: deps.slug });
+    } catch (error) {
+      console.error('共有 serve 利用ログの記録に失敗', error);
+    }
+  }
+  return url;
+};

--- a/apps/ai/src/features/share/application/share.ts
+++ b/apps/ai/src/features/share/application/share.ts
@@ -5,7 +5,12 @@ import {
   setVisibility,
 } from '@/features/projects/application/projects';
 
+import {
+  countRecentServes,
+  recordServe,
+} from '../infrastructure/serve-usage-repository';
 import { resolveServeWithCooldown } from './serve-cooldown';
+import { gatedServe, shareServeLimit } from './serve-limit';
 import { shareProvider } from './share-provider';
 
 export type PublishedShare = {
@@ -89,8 +94,10 @@ export const getPublicShare = async (
 };
 
 // 閲覧時に iframe へ出す配信 URL を解決する（Sandbox を起こして配信）。
-// 未認証の公開経路なので、slug 単位の single-flight + 短期クールダウンで匿名トラフィックによる
-// Sandbox cold start の濫発を抑える。
+// 未認証の公開経路なので二層で抑制する: (1) プロセス内 single-flight + 短期クールダウンで warm 中の
+// 重複を吸収し、(2) 通過したものは DB のグローバル上限（クロスインスタンス）で cold start/起動の
+// 絶対数を縛る。gatedServe を resolveServeWithCooldown に渡すことで、DB 評価・記録は「実際に
+// serve する」呼び出しでのみ走る（warm な cache/in-flight ヒットはカウントしない）。
 export const resolveShareEntry = async (
   slug: string,
 ): Promise<{ url: string } | null> => {
@@ -99,7 +106,14 @@ export const resolveShareEntry = async (
     return null;
   }
   const url = await resolveServeWithCooldown(slug, () =>
-    shareProvider.serve(slug, share.code),
+    gatedServe({
+      slug,
+      now: Date.now(),
+      limit: shareServeLimit(),
+      countRecentServes,
+      serve: () => shareProvider.serve(slug, share.code),
+      recordServe,
+    }),
   );
   if (url === null) {
     return null;

--- a/apps/ai/src/features/share/infrastructure/serve-usage-repository.ts
+++ b/apps/ai/src/features/share/infrastructure/serve-usage-repository.ts
@@ -1,0 +1,22 @@
+import 'server-only';
+import { db } from '@repo/database';
+import type { AiApp } from '@repo/database/schema';
+import { and, count, eq, gte } from 'drizzle-orm';
+
+// 公開共有の Sandbox serve/起動ログ（ai_share_serves）。クロスインスタンスなグローバルレート制限の基盤。
+const serves = db._schema.aiShareServes;
+const APP: AiApp = 'ui-studio';
+
+export const countRecentServes = async (input: {
+  sinceIso: string;
+}): Promise<number> => {
+  const [row] = await db
+    .select({ total: count() })
+    .from(serves)
+    .where(and(eq(serves.app, APP), gte(serves.createdAt, input.sinceIso)));
+  return row?.total ?? 0;
+};
+
+export const recordServe = async (input: { slug: string }): Promise<void> => {
+  await db.insert(serves).values({ app: APP, slug: input.slug });
+};

--- a/packages/database/README.md
+++ b/packages/database/README.md
@@ -95,6 +95,12 @@ erDiagram
     text created_at
     text updated_at
   }
+  ai_share_serves {
+    integer id PK
+    text app
+    text slug
+    text created_at
+  }
   ai_usages {
     integer id PK
     text app

--- a/packages/database/migrations/0060_grey_archangel.sql
+++ b/packages/database/migrations/0060_grey_archangel.sql
@@ -1,0 +1,8 @@
+CREATE TABLE `ai_share_serves` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`app` text NOT NULL,
+	`slug` text NOT NULL,
+	`created_at` text NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `ai_share_serves_created_at_idx` ON `ai_share_serves` (`created_at`);

--- a/packages/database/migrations/meta/0060_snapshot.json
+++ b/packages/database/migrations/meta/0060_snapshot.json
@@ -1,0 +1,1917 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "f49ee271-417f-419c-9d02-38496df95c00",
+  "prevId": "6acf7fb9-b481-49b8-b3fa-bc9e7aca0df6",
+  "tables": {
+    "ai_project_versions": {
+      "name": "ai_project_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_project_versions_project_id_idx": {
+          "name": "ai_project_versions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_project_versions_project_id_ai_projects_id_fk": {
+          "name": "ai_project_versions_project_id_ai_projects_id_fk",
+          "tableFrom": "ai_project_versions",
+          "tableTo": "ai_projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_projects": {
+      "name": "ai_projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "fork_of": {
+          "name": "fork_of",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_snapshot": {
+          "name": "public_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_projects_slug_idx": {
+          "name": "ai_projects_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "ai_projects_user_id_idx": {
+          "name": "ai_projects_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "ai_projects_app_idx": {
+          "name": "ai_projects_app_idx",
+          "columns": [
+            "app"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_projects_user_id_user_id_fk": {
+          "name": "ai_projects_user_id_user_id_fk",
+          "tableFrom": "ai_projects",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_share_serves": {
+      "name": "ai_share_serves",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_share_serves_created_at_idx": {
+          "name": "ai_share_serves_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_usages": {
+      "name": "ai_usages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_usages_user_id_idx": {
+          "name": "ai_usages_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "ai_usages_created_at_idx": {
+          "name": "ai_usages_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_usages_user_id_user_id_fk": {
+          "name": "ai_usages_user_id_user_id_fk",
+          "tableFrom": "ai_usages",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_attempts": {
+          "name": "summary_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "article_sources",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "baseline_snapshots": {
+      "name": "baseline_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "browser_implementations": {
+          "name": "browser_implementations",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "baseline_snapshots_feature_id_idx": {
+          "name": "baseline_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "baseline_snapshots_status_check": {
+          "name": "baseline_snapshots_status_check",
+          "value": "\"baseline_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_view_dailies": {
+      "name": "blog_view_dailies",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "blog_view_dailies_date_idx": {
+          "name": "blog_view_dailies_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_view_dailies_blog_id_blogs_id_fk": {
+          "name": "blog_view_dailies_blog_id_blogs_id_fk",
+          "tableFrom": "blog_view_dailies",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_view_dailies_blog_id_date_pk": {
+          "columns": [
+            "blog_id",
+            "date"
+          ],
+          "name": "blog_view_dailies_blog_id_date_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "browser_support": {
+      "name": "browser_support",
+      "columns": {
+        "browser": {
+          "name": "browser",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "feedbacks",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_logs": {
+      "name": "push_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "succeeded": {
+          "name": "succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed": {
+          "name": "failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_logs_dedupe_key_idx": {
+          "name": "push_logs_dedupe_key_idx",
+          "columns": [
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "push_logs_sent_at_idx": {
+          "name": "push_logs_sent_at_idx",
+          "columns": [
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "push_logs_kind_check": {
+          "name": "push_logs_kind_check",
+          "value": "\"push_logs\".\"kind\" IN ('readings_updated', 'baseline_updated')"
+        }
+      }
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_idx": {
+          "name": "push_subscriptions_endpoint_idx",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_tag": {
+      "name": "slide_tag",
+      "columns": {
+        "slide_id": {
+          "name": "slide_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slide_tag_slide_id_idx": {
+          "name": "slide_tag_slide_id_idx",
+          "columns": [
+            "slide_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_tag_id_idx": {
+          "name": "slide_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_unique_idx": {
+          "name": "slide_tag_unique_idx",
+          "columns": [
+            "slide_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "slide_tag_slide_id_slides_id_fk": {
+          "name": "slide_tag_slide_id_slides_id_fk",
+          "tableFrom": "slide_tag",
+          "tableTo": "slides",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "slide_tag_tag_id_tags_id_fk": {
+          "name": "slide_tag_tag_id_tags_id_fk",
+          "tableFrom": "slide_tag",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slides": {
+      "name": "slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slides_slug_idx": {
+          "name": "slides_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "tableTo": "talks",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "tableTo": "tags",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "tableTo": "blogs",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1782911458601,
       "tag": "0059_bizarre_venus",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "6",
+      "when": 1783389032240,
+      "tag": "0060_grey_archangel",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/src/schema/ai-share-serves.ts
+++ b/packages/database/src/schema/ai-share-serves.ts
@@ -1,0 +1,19 @@
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core';
+
+import { AI_APPS } from './ai-projects';
+
+// 公開共有（/s/[slug]）閲覧時の Sandbox serve/起動イベントのログ。未認証経路なので userId は持たない。
+// プロセス内クールダウンでは効かないクロスインスタンスのグローバルレート制限（課金保護）の基盤で、
+// 実際に serve した回数だけ1行を積む（cache/in-flight ヒットは記録しない）。
+export const aiShareServes = sqliteTable(
+  'ai_share_serves',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    app: text('app', { enum: AI_APPS }).notNull(),
+    slug: text('slug').notNull(),
+    createdAt: text('created_at')
+      .notNull()
+      .$defaultFn(() => new Date().toISOString()),
+  },
+  (table) => [index('ai_share_serves_created_at_idx').on(table.createdAt)],
+);

--- a/packages/database/src/schema/index.ts
+++ b/packages/database/src/schema/index.ts
@@ -5,6 +5,7 @@ import {
   aiProjectVersionsRelations,
 } from './ai-project-versions';
 import { aiProjects, aiProjectsRelations } from './ai-projects';
+import { aiShareServes } from './ai-share-serves';
 import { aiUsages, aiUsagesRelations } from './ai-usages';
 import { articleSources, articleSourcesRelations } from './article-sources';
 import { articles, articlesRelations } from './articles';
@@ -62,6 +63,7 @@ export const schema = {
   aiProjects,
   aiProjectVersions,
   aiUsages,
+  aiShareServes,
 };
 
 export const relations = {

--- a/turbo.json
+++ b/turbo.json
@@ -16,6 +16,7 @@
     "build": {
       "dependsOn": ["^build"],
       "env": [
+        "AI_SHARE_SERVE_LIMIT_PER_HOUR",
         "AI_TEMPLATE_SNAPSHOT_ID",
         "ALLOWED_EMAILS",
         "BETTER_AUTH_SECRET",


### PR DESCRIPTION
## 背景（監査で判明した High 指摘）

`/s/[slug]` の配信は公開ページ用に意図的に未認証。`resolveShareEntryAction` → `resolveShareEntry` → `shareProvider.serve()` で Vercel Sandbox の起動/再開（vCPU課金）まで到達する。

抑制は `serve-cooldown.ts` のプロセス内 Map（30秒TTL single-flight）のみで、**サーバレスの複数インスタンス間では効かない**。公開 slug を知る匿名クライアントが叩き続けると idle timeout が更新され続け課金が継続する。`/api/generate` が `ai_usages` ベースの DB throttle を持つのと非対称だった。

## 変更内容

`shareProvider.serve()` に、`/api/generate` と同型の **DBベース・クロスインスタンスなグローバル制限**を追加し、既存のプロセス内 single-flight と合わせた**二層構成**にした。

### DB（`@repo/database`）
- 新テーブル **`ai_share_serves`** を追加。未認証経路なので `userId` を持たず `{id, app, slug, created_at}` + `created_at` index。`ai_usages` の `userId NOT NULL` 制約を崩さないため既存テーブル拡張ではなく新設した
- マイグレーション **`0060_grey_archangel.sql`** を生成（seed / id 直書きなし）。ローカルDBへ `migrate` 適用しテーブル・index を実DBで確認済み

### アプリ（`apps/ai`）
- **`serve-limit.ts`** — 決定的な純ロジック（`shareServeLimit` / `serveWindowStartIso` / `isOverServeLimit`）と、clock/count/serve/record を注入する純関数 `gatedServe`
- **`serve-usage-repository.ts`** — `countRecentServes` / `recordServe`（`infrastructure/` 配置で import 境界準拠）
- **`resolveShareEntry`** を二層化:
  1. 既存のプロセス内 single-flight + 30秒クールダウンで **warm 中の重複を吸収**
  2. 通過したものだけ DB のグローバル上限（1時間スライディングウィンドウ）で **cold start/起動の絶対数を縛る**
  - `gatedServe` を `resolveServeWithCooldown` に渡す `serve` として合成することで、DB評価・記録は「実際に serve する」呼び出しでのみ走る。**warm な cache/in-flight ヒットは評価も記録もされない**
- 上限は env **`AI_SHARE_SERVE_LIMIT_PER_HOUR`（既定 30）** で調整可能。`turbo.json` の `build.env` にも追記

## 設計判断（実装時にユーザー確認済み）

| 項目 | 判断 |
|---|---|
| 制限スコープ | **グローバルのみ**（per-IP は入れない） |
| DBエラー時 | **fail-open**（配信を優先し公開ページを壊さない。ログは出す）。記録失敗も配信を止めない best-effort |
| 既定の上限/時 | **30**（env で調整可） |

## テスト

- `serve-limit` の純ロジックと `gatedServe` の挙動（over-limit→serveしない・fail-open・記録失敗でも配信・serve null は記録しない）に単体テストを追加
- ✅ features test 19 pass ／ type-check ／ lint・format（自ファイル）／ ls-lint

## レビュアー向けメモ

- **クロスインスタンスの warm はカウントされる**: 別インスタンスは sandbox が global に warm かを安価に判定できないため cold 判定で serve→記録する（保守的＝「起動の絶対数を縛る」に合致）。in-process warm は非カウント
- **count→insert は非アトミック**: 複数インスタンス同時 cold で上限を僅かに超え得るが、`/api/generate` と同じ粗い安全網の割り切り
- 上限到達時は正規閲覧者にも「プレビューを表示できませんでした」が出る（`null`→failed 表示）。グローバル上限の性質上のトレードオフ
- `pnpm run build` は未実行（apps/main・admin の `.env.local` が本 worktree に未配置のため）。type-check で担保
- **無関係な既存問題**: `apps/ai/src/app/api/generate/route.ts:85` の `toUIMessageStreamResponse` 非推奨が repo 全体の `pnpm run check` を落とす。本PRの変更外（commit 887d2788 由来）で別途対応