### PR TITLE
fix(ai): 非推奨の toUIMessageStreamResponse を標準ヘルパーへ移行

### DIFF
--- a/apps/ai/src/app/api/generate/route.ts
+++ b/apps/ai/src/app/api/generate/route.ts
@@ -1,4 +1,10 @@
-import { convertToModelMessages, streamText, type UIMessage } from 'ai';
+import {
+  convertToModelMessages,
+  createUIMessageStreamResponse,
+  streamText,
+  toUIMessageStream,
+  type UIMessage,
+} from 'ai';
 import * as z from 'zod/mini';
 
 import { buildSystemPrompt } from '@/features/generation/application/build-system-prompt';
@@ -82,8 +88,11 @@ export async function POST(req: Request): Promise<Response> {
     },
   });
 
-  return result.toUIMessageStreamResponse({
-    onError: (error) =>
-      error instanceof Error ? error.message : '生成中にエラーが発生しました',
+  return createUIMessageStreamResponse({
+    stream: toUIMessageStream({
+      stream: result.stream,
+      onError: (error) =>
+        error instanceof Error ? error.message : '生成中にエラーが発生しました',
+    }),
   });
 }


### PR DESCRIPTION
## 概要

`apps/ai/src/app/api/generate/route.ts` の `result.toUIMessageStreamResponse(...)` が、`ai` SDK v7 で非推奨になり oxlint `typescript(no-deprecated)` の **エラー**として検出されるようになった。これはリポジトリ全体の `pnpm run check` を落とし、pre-push の `vp check` hook をブロックする。

- 既存の問題（commit 887d2788 で導入。後続の `ai` SDK バンプで顕在化）で、他の作業とは無関係。

## 変更内容

非推奨メッセージの案内どおり、標準ヘルパー `toUIMessageStream` + `createUIMessageStreamResponse`（`result.stream` を使用）へ移行。

```ts
return createUIMessageStreamResponse({
  stream: toUIMessageStream({
    stream: result.stream,
    onError: (error) =>
      error instanceof Error ? error.message : '生成中にエラーが発生しました',
  }),
});
```

## 挙動の維持

- `onError` マッピング（`Error → error.message`、それ以外は日本語フォールバック）はそのまま維持。
- `result.stream` は SDK 公式の `fullStream` 代替（非推奨でない方）で、`toUIMessageStream` が期待する入力と一致。`createUIMessageStreamResponse` は旧メソッドが内部生成していたものと同じ SSE `Response` を返す。
- `streamText` 側の `onFinish` / `onError` は未変更。

## 検証

- [x] `pnpm run check`（リポジトリ全体の oxlint）→ exit 0、`no-deprecated` エラー解消
- [x] `pnpm -F @repo/ai run type-check`（`tsgo --noEmit`）→ exit 0