### PR TITLE
feat(blog): Accept: text/markdown で記事のmarkdownを配信する

### DIFF
--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -7,9 +7,17 @@ const nextConfig: NextConfig = {
   allowedDevOrigins: ['main.k8o.localhost', '*.main.k8o.localhost'],
   pageExtensions: ['tsx', 'mdx', 'ts'],
   rewrites: () =>
-    Promise.resolve([
-      { source: '/blog/:slug.md', destination: '/blog/md/:slug' },
-    ]),
+    Promise.resolve({
+      // 記事ページ (/blog/:slug) より先に評価させるため beforeFiles に置く
+      beforeFiles: [
+        { source: '/blog/:slug.md', destination: '/blog/md/:slug' },
+        {
+          source: '/blog/:slug((?!feed$|md$)[a-z0-9-]+)',
+          destination: '/blog/md/:slug',
+          has: [{ type: 'header', key: 'accept', value: '.*text/markdown.*' }],
+        },
+      ],
+    }),
   compiler: {
     removeConsole: process.env['NODE_ENV'] === 'production' && {
       exclude: ['error', 'warn'],

--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -12,6 +12,11 @@ const nextConfig: NextConfig = {
       beforeFiles: [
         { source: '/blog/:slug.md', destination: '/blog/md/:slug' },
         {
+          // HTML 側の /blog/:slug に Vary: Accept は付けられない (App Router
+          // ページの Vary は Next が自前管理しており、headers() や proxy で
+          // 付けてもレンダリング時に上書きされる)。Vercel ではこの rewrite が
+          // キャッシュ参照前のルーティング層で解決され、markdown 側レスポンス
+          // には Vary: Accept が付くため、キャッシュ汚染は起きない
           source: '/blog/:slug((?!feed$|md$)[a-z0-9-]+)',
           destination: '/blog/md/:slug',
           has: [{ type: 'header', key: 'accept', value: '.*text/markdown.*' }],

--- a/apps/main/src/app/blog/md/[slug]/route.ts
+++ b/apps/main/src/app/blog/md/[slug]/route.ts
@@ -13,6 +13,9 @@ export async function GET(
     return new NextResponse(markdown, {
       headers: {
         'Content-Type': 'text/markdown; charset=utf-8',
+        // /blog/:slug は Accept で HTML と markdown を出し分けるため、
+        // 共有キャッシュが Accept をキーに含むよう明示する
+        Vary: 'Accept',
       },
     });
   } catch {


### PR DESCRIPTION
## 概要

`/blog/:slug` に `Accept: text/markdown` ヘッダー付きでリクエストすると、`.md` 拡張子と同じmarkdownを返すようにする。

## 動機

ブログ記事のmarkdownは `.md` 拡張子でのみ提供していた。AIエージェントやCLIツール向けのコンテンツネゴシエーションとして、URLを変えずに `Accept` ヘッダーでも取得できるようにする（Vercel DocsやCloudflare Docsが採用しているのと同じパターン）。

## 詳細

- `next.config.ts` のrewritesに `Accept` ヘッダー条件付きの `/blog/:slug` → `/blog/md/:slug` 書き換えを追加
  - 実ページ (`/blog/:slug`) の解決より先に評価されるよう `beforeFiles` へ移動
  - `:slug` は `[a-z0-9-]+` に制約し、RSSの `/blog/feed` と `/blog/md` は負の先読みで除外
- markdownレスポンスに `Vary: Accept` を付与（同一URLでAcceptにより内容が変わるため、共有キャッシュの汚染を防ぐ）

## 気をつけるポイント

- Acceptヘッダーはq値を解釈しない部分一致（`.*text/markdown.*`）。`text/markdown` を送るクライアントは実際にmarkdownが欲しいケースがほとんどなので実用上は十分
- ブラウザ標準のAcceptヘッダーには `text/markdown` が含まれないため、通常の閲覧には影響しない
- RSCのprefetchは `text/markdown` を含まないため誤マッチしない
- **HTML側の `/blog/:slug` には `Vary: Accept` を付けられない**。App RouterページのVaryはNextが自前管理しており（`rsc` / `next-router-state-tree` など）、`headers()` やproxyで付けたVaryはレンダリング時に上書きされることをdevで確認した（同じルールに足した検証用ヘッダーは付与されるが、Varyだけ差し替えられる）。VercelではAcceptによる分岐がキャッシュ参照前のルーティング層で解決され、markdown側レスポンスには `Vary: Accept` が付くため、HTMLキャッシュがmarkdownリクエストに返される汚染は起きない。経緯はrewriteのコメントにも記載

## 影響範囲

- `/blog/:slug` へのリクエストのルーティング（Acceptヘッダーによる分岐が追加）
- `/blog/:slug.md`・Markdownコピーボタンは従来通り

## テスト

devサーバーで以下を確認済み:

- `Accept: text/markdown` → `text/markdown; charset=utf-8` + `Vary: Accept` でmarkdownが返る
- ブラウザ相当のAccept → HTMLページ側にルーティング（ローカルDB接続時に200で確認）
- `.md` 拡張子 → 従来通り
- `/blog/feed` + `Accept: text/markdown` → feedハンドラに到達（除外が有効）
- 存在しないslug → 404