### PR TITLE
feat(blog): .md配信のMDXを素のmarkdownへ変換する

### DIFF
--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -45,6 +45,7 @@
     "remark": "15.0.1",
     "remark-frontmatter": "5.0.0",
     "remark-math": "6.0.0",
+    "remark-mdx": "3.1.1",
     "rss": "1.2.2",
     "server-only": "0.0.1",
     "tailwindcss": "catalog:",

--- a/apps/main/src/features/blog/application/markdown.test.ts
+++ b/apps/main/src/features/blog/application/markdown.test.ts
@@ -1,0 +1,177 @@
+import { mdxToMarkdown } from './markdown';
+
+describe('mdxToMarkdown', () => {
+  describe('正常系', () => {
+    it('frontmatterとimport文を取り除く', () => {
+      const source = [
+        '---',
+        'title: タイトル',
+        '---',
+        '',
+        "import { BaselineStatus } from '@k8o/arte-odyssey';",
+        "import { Playground } from '@/app/_components/playgrounds';",
+        '',
+        '# 見出し',
+        '',
+        '本文です。',
+      ].join('\n');
+
+      expect(mdxToMarkdown(source, 'sample')).toBe(
+        ['# 見出し', '', '本文です。', ''].join('\n'),
+      );
+    });
+
+    it('LinkCardをオートリンクへ変換する', () => {
+      const source = '<LinkCard href="https://example.com/page" />\n';
+
+      expect(mdxToMarkdown(source, 'sample')).toBe(
+        '<https://example.com/page>\n',
+      );
+    });
+
+    it('LinkCardの相対hrefはサイトURLを前置する', () => {
+      const source = '<LinkCard href="/blog/other-article" />\n';
+
+      expect(mdxToMarkdown(source, 'sample')).toBe(
+        '<https://k8o.me/blog/other-article>\n',
+      );
+    });
+
+    it('PlaygroundをWeb版への案内に置き換える', () => {
+      const source = [
+        '<Playground title="デモのタイトル">',
+        '  <Demo />',
+        '</Playground>',
+      ].join('\n');
+
+      expect(mdxToMarkdown(source, 'sample')).toBe(
+        '> インタラクティブデモ「デモのタイトル」はWeb版で試せます: <https://k8o.me/blog/sample>\n',
+      );
+    });
+
+    it('titleのないPlaygroundも案内に置き換える', () => {
+      const source = '<Playground>\n  <Demo />\n</Playground>\n';
+
+      expect(mdxToMarkdown(source, 'sample')).toBe(
+        '> インタラクティブデモはWeb版で試せます: <https://k8o.me/blog/sample>\n',
+      );
+    });
+
+    it('Imageをalt文の注記に置き換える', () => {
+      const source = [
+        "import monitor from './monitor.png';",
+        '',
+        '<Image src={monitor} alt="アクティビティモニタの画面" />',
+      ].join('\n');
+
+      expect(mdxToMarkdown(source, 'sample')).toBe(
+        '（画像: アクティビティモニタの画面）\n',
+      );
+    });
+
+    it('BaselineStatusを削除して前後の空行を詰める', () => {
+      const source = [
+        '# 見出し',
+        '',
+        '<BaselineStatus featureId="feature"></BaselineStatus>',
+        '',
+        '本文です。',
+      ].join('\n');
+
+      expect(mdxToMarkdown(source, 'sample')).toBe(
+        ['# 見出し', '', '本文です。', ''].join('\n'),
+      );
+    });
+
+    it('Alertをmessageの引用に置き換える', () => {
+      const source = '<Alert tone="warning" message="注意してください。" />\n';
+
+      expect(mdxToMarkdown(source, 'sample')).toBe('> 注意してください。\n');
+    });
+
+    it('コードブロック内の注釈ディレクティブを整理する', () => {
+      const source = [
+        '```css',
+        '/* [!og] */',
+        '.button {',
+        '  /* [!callout: 背景色から文字色を導出する] */',
+        '  color: contrast-color(lightblue);',
+        '}',
+        '```',
+      ].join('\n');
+
+      expect(mdxToMarkdown(source, 'sample')).toBe(
+        [
+          '```css',
+          '.button {',
+          '  /* 背景色から文字色を導出する */',
+          '  color: contrast-color(lightblue);',
+          '}',
+          '```',
+          '',
+        ].join('\n'),
+      );
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('コードブロック内のimport文やJSXには触れない', () => {
+      const source = [
+        '```tsx',
+        "import { useState } from 'react';",
+        '',
+        'const App = () => <Playground title="デモ" />;',
+        '```',
+      ].join('\n');
+
+      expect(mdxToMarkdown(source, 'sample')).toBe(`${source}\n`);
+    });
+
+    it('MDXのコメント式を削除する', () => {
+      const source = ['{/* TODO: あとで直す */}', '', '本文です。'].join('\n');
+
+      expect(mdxToMarkdown(source, 'sample')).toBe('本文です。\n');
+    });
+
+    it('未知のコンポーネントは子要素だけ残す', () => {
+      const source = ['<Wrapper>', '本文です。', '</Wrapper>'].join('\n');
+
+      expect(mdxToMarkdown(source, 'sample')).toBe('本文です。\n');
+    });
+
+    it('子のない未知のコンポーネントは削除する', () => {
+      const source = ['<CustomDemo />', '', '本文です。'].join('\n');
+
+      expect(mdxToMarkdown(source, 'sample')).toBe('本文です。\n');
+    });
+
+    it('小文字のHTMLタグは残しつつ中のJSXは変換する', () => {
+      const source = [
+        '<figure>',
+        '  <LinkCard href="https://example.com" />',
+        '</figure>',
+      ].join('\n');
+
+      expect(mdxToMarkdown(source, 'sample')).toBe(
+        ['<figure>', '  <https://example.com>', '</figure>', ''].join('\n'),
+      );
+    });
+
+    it('数式ブロックや通常のmarkdownは原文のまま保つ', () => {
+      const source = [
+        '## 見出し',
+        '',
+        '`inline code`と**強調**、$L$ のような数式。',
+        '',
+        '```math',
+        'C_b = \\frac{L + 0.05}{0.05}',
+        '```',
+        '',
+        '- リスト1',
+        '- リスト2',
+      ].join('\n');
+
+      expect(mdxToMarkdown(source, 'sample')).toBe(`${source}\n`);
+    });
+  });
+});

--- a/apps/main/src/features/blog/application/markdown.ts
+++ b/apps/main/src/features/blog/application/markdown.ts
@@ -1,0 +1,148 @@
+import { stripAnnotationComments } from '@repo/code-highlight/parser';
+import type { Root, RootContent } from 'mdast';
+import { remark } from 'remark';
+import remarkFrontmatter from 'remark-frontmatter';
+import remarkMath from 'remark-math';
+import remarkMdx from 'remark-mdx';
+
+type MdxJsxElement = Extract<
+  RootContent,
+  { type: 'mdxJsxFlowElement' | 'mdxJsxTextElement' }
+>;
+
+type Edit = { start: number; end: number; text: string };
+
+const SITE_URL = 'https://k8o.me';
+
+// remark-math がないと $\mathbb{N}$ のような数式内の {} がMDX式として解釈されて
+// パースに失敗するため、本番のMDXパイプライン (next.config.ts) と揃える
+const parser = remark().use(remarkMdx).use(remarkFrontmatter).use(remarkMath);
+
+const getStringAttribute = (
+  node: MdxJsxElement,
+  name: string,
+): string | undefined => {
+  for (const attr of node.attributes) {
+    if (
+      attr.type === 'mdxJsxAttribute' &&
+      attr.name === name &&
+      typeof attr.value === 'string'
+    ) {
+      return attr.value;
+    }
+  }
+  return undefined;
+};
+
+const nodeRange = (node: RootContent): [number, number] | undefined => {
+  const start = node.position?.start.offset;
+  const end = node.position?.end.offset;
+  return start === undefined || end === undefined ? undefined : [start, end];
+};
+
+// MDX記事のソースをCommonMarkとして読める素のmarkdownへ変換する。
+// 全体を再シリアライズせず、MDX固有ノードのスパンだけを元テキストから置換することで、
+// 本文のフォーマットを原文のまま保つ。
+export const mdxToMarkdown = (source: string, slug: string): string => {
+  const tree: Root = parser.parse(source);
+  const articleUrl = `${SITE_URL}/blog/${slug}`;
+  const edits: Edit[] = [];
+
+  const replace = (range: [number, number], text: string): void => {
+    edits.push({ start: range[0], end: range[1], text });
+  };
+
+  const handleJsx = (node: MdxJsxElement, range: [number, number]): void => {
+    const { name } = node;
+    if (name === 'Playground') {
+      const title = getStringAttribute(node, 'title');
+      const label =
+        title === undefined
+          ? 'インタラクティブデモ'
+          : `インタラクティブデモ「${title}」`;
+      replace(range, `> ${label}はWeb版で試せます: <${articleUrl}>`);
+      return;
+    }
+    if (name === 'LinkCard') {
+      const href = getStringAttribute(node, 'href');
+      if (href === undefined) {
+        replace(range, '');
+        return;
+      }
+      const url = href.startsWith('/') ? `${SITE_URL}${href}` : href;
+      replace(range, `<${url}>`);
+      return;
+    }
+    if (name === 'Image') {
+      const alt = getStringAttribute(node, 'alt');
+      replace(range, alt === undefined ? '' : `（画像: ${alt}）`);
+      return;
+    }
+    if (name === 'BaselineStatus') {
+      replace(range, '');
+      return;
+    }
+    if (name === 'Alert') {
+      const message = getStringAttribute(node, 'message');
+      replace(range, message === undefined ? '' : `> ${message}`);
+      return;
+    }
+    // 小文字タグはraw HTMLとしてmarkdownでも意味を持つので残し、中身だけ変換する
+    if (name !== null && /^[a-z]/u.test(name)) {
+      walk(node.children);
+      return;
+    }
+    // フラグメントと未知のコンポーネント: 子があればタグだけ剥がして中身を残す
+    const first = node.children[0];
+    const innerStart = first === undefined ? undefined : nodeRange(first)?.[0];
+    const last = node.children.at(-1);
+    const innerEnd = last === undefined ? undefined : nodeRange(last)?.[1];
+    if (innerStart === undefined || innerEnd === undefined) {
+      replace(range, '');
+      return;
+    }
+    replace([range[0], innerStart], '');
+    replace([innerEnd, range[1]], '');
+    walk(node.children);
+  };
+
+  const walk = (nodes: RootContent[]): void => {
+    for (const node of nodes) {
+      const range = nodeRange(node);
+      if (range === undefined) continue;
+
+      if (
+        node.type === 'yaml' ||
+        node.type === 'mdxjsEsm' ||
+        node.type === 'mdxFlowExpression' ||
+        node.type === 'mdxTextExpression'
+      ) {
+        replace(range, '');
+      } else if (
+        node.type === 'mdxJsxFlowElement' ||
+        node.type === 'mdxJsxTextElement'
+      ) {
+        handleJsx(node, range);
+      } else if (node.type === 'code') {
+        const slice = source.slice(range[0], range[1]);
+        const stripped = stripAnnotationComments(slice);
+        if (stripped !== slice) replace(range, stripped);
+      } else if ('children' in node) {
+        walk(node.children);
+      }
+    }
+  };
+
+  walk(tree.children);
+
+  let result = source;
+  for (const edit of edits.toSorted((a, b) => b.start - a.start)) {
+    result = result.slice(0, edit.start) + edit.text + result.slice(edit.end);
+  }
+
+  const cleaned = result
+    .replaceAll(/\n{3,}/gu, '\n\n')
+    .replace(/^\n+/u, '')
+    .replace(/\n+$/u, '');
+  return `${cleaned}\n`;
+};

--- a/apps/main/src/features/blog/interface/markdown.ts
+++ b/apps/main/src/features/blog/interface/markdown.ts
@@ -2,9 +2,8 @@ import { readFile } from 'node:fs/promises';
 
 import { cacheLife } from 'next/cache';
 
+import { mdxToMarkdown } from '../application/markdown';
 import { blogPath } from '../application/path';
-
-const FRONTMATTER_RE = /^---\n[\s\S]*?\n---\n*/u;
 
 // パストラバーサル対策: slug をファイルパスに渡す前に厳格に検証する。
 // %2F デコードで `../` 脱出を許さないよう、英小文字・数字・ハイフンのみ許可。
@@ -19,5 +18,5 @@ export async function getMarkdown(slug: string) {
   }
 
   const content = await readFile(blogPath(slug), 'utf-8');
-  return content.replace(FRONTMATTER_RE, '');
+  return mdxToMarkdown(content, slug);
 }

--- a/packages/code-highlight/src/parser.test.ts
+++ b/packages/code-highlight/src/parser.test.ts
@@ -1,4 +1,4 @@
-import { parseAnnotations } from './parser.ts';
+import { parseAnnotations, stripAnnotationComments } from './parser.ts';
 
 describe('parseAnnotations', () => {
   describe('正常系', () => {
@@ -147,6 +147,62 @@ describe('parseAnnotations', () => {
 
       expect(result.code).toBe('    const x = 1;');
       expect(result.annotations).toEqual([[{ type: 'highlight' }]]);
+    });
+  });
+});
+
+describe('stripAnnotationComments', () => {
+  describe('正常系', () => {
+    it('hl / og などの表示指示ディレクティブ行を削除する', () => {
+      const input = ['// [!hl]', 'const x = 1;', '/* [!og] */', 'x + 1;'].join(
+        '\n',
+      );
+
+      expect(stripAnnotationComments(input)).toBe(
+        ['const x = 1;', 'x + 1;'].join('\n'),
+      );
+    });
+
+    it('コールアウトはコメント記法を保ったまま本文だけ残す', () => {
+      const input = ['  // [!callout: ここがポイント]', '  const x = 1;'].join(
+        '\n',
+      );
+
+      expect(stripAnnotationComments(input)).toBe(
+        ['  // ここがポイント', '  const x = 1;'].join('\n'),
+      );
+    });
+
+    it('HTMLコメントのコールアウトもコメント記法を保つ', () => {
+      const input = ['<!-- [!callout: 補足] -->', '<div></div>'].join('\n');
+
+      expect(stripAnnotationComments(input)).toBe(
+        ['<!-- 補足 -->', '<div></div>'].join('\n'),
+      );
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('通常のコメントや未知のディレクティブには触れない', () => {
+      const input = ['// 通常のコメント', '// [!unknown]', 'const x = 1;'].join(
+        '\n',
+      );
+
+      expect(stripAnnotationComments(input)).toBe(input);
+    });
+
+    it('$ を含むコールアウト本文をそのまま残す', () => {
+      const input = ['// [!callout: $i が $n に追いつく]', 'const x = 1;'].join(
+        '\n',
+      );
+
+      expect(stripAnnotationComments(input)).toBe(
+        ['// $i が $n に追いつく', 'const x = 1;'].join('\n'),
+      );
+    });
+
+    it('空文字列を渡しても落ちない', () => {
+      expect(stripAnnotationComments('')).toBe('');
     });
   });
 });

--- a/packages/code-highlight/src/parser.ts
+++ b/packages/code-highlight/src/parser.ts
@@ -48,6 +48,25 @@ const matchDirectiveLine = (line: string): Annotation | null => {
   return null;
 };
 
+const CALLOUT_DIRECTIVE_RE = /\[!callout:\s*[^\]]+\]/u;
+
+// markdown配信などレンダリングを伴わない出力向けに、注釈ディレクティブ行を除去する。
+// コールアウトは本文が読者向けの説明なので、コメント記法を保ったまま本文だけ残す。
+export const stripAnnotationComments = (code: string): string => {
+  const outLines: string[] = [];
+  for (const line of code.split('\n')) {
+    const directive = matchDirectiveLine(line);
+    if (directive === null) {
+      outLines.push(line);
+      continue;
+    }
+    if (directive.type === 'callout') {
+      outLines.push(line.replace(CALLOUT_DIRECTIVE_RE, () => directive.text));
+    }
+  }
+  return outLines.join('\n');
+};
+
 export const parseAnnotations = (code: string): ParseResult => {
   const lines = code.split('\n');
   const outLines: string[] = [];

--- a/packages/code-highlight/src/parser.ts
+++ b/packages/code-highlight/src/parser.ts
@@ -27,7 +27,8 @@ const parseDirective = (raw: string): Annotation | null => {
   if (directive === '-') return { type: 'remove' };
   if (directive === 'og') return { type: 'og' };
 
-  const callout = /^callout:\s*(.+)$/u.exec(directive);
+  // \s* の直後を \S で始めて境界を一意にする (CodeQL: js/polynomial-redos)
+  const callout = /^callout:\s*(\S.*)$/u.exec(directive);
   if (callout) {
     const text = callout[1]?.trim();
     if (text !== undefined && text.length > 0) {
@@ -48,10 +49,6 @@ const matchDirectiveLine = (line: string): Annotation | null => {
   return null;
 };
 
-// \s は [^\]] に含まれるため \s* を挟むと曖昧になり、バックトラックが
-// 多項式時間になる (CodeQL: js/polynomial-redos)。マッチ範囲は同一。
-const CALLOUT_DIRECTIVE_RE = /\[!callout:[^\]]+\]/u;
-
 // markdown配信などレンダリングを伴わない出力向けに、注釈ディレクティブ行を除去する。
 // コールアウトは本文が読者向けの説明なので、コメント記法を保ったまま本文だけ残す。
 export const stripAnnotationComments = (code: string): string => {
@@ -63,7 +60,13 @@ export const stripAnnotationComments = (code: string): string => {
       continue;
     }
     if (directive.type === 'callout') {
-      outLines.push(line.replace(CALLOUT_DIRECTIVE_RE, () => directive.text));
+      // matchDirectiveLine を通った行は [! と閉じ ] を必ず1組含むので、
+      // 正規表現を使わず位置で置換する (CodeQL: js/polynomial-redos 回避)
+      const start = line.indexOf('[!');
+      const end = line.indexOf(']', start);
+      outLines.push(
+        `${line.slice(0, start)}${directive.text}${line.slice(end + 1)}`,
+      );
     }
   }
   return outLines.join('\n');

--- a/packages/code-highlight/src/parser.ts
+++ b/packages/code-highlight/src/parser.ts
@@ -48,7 +48,9 @@ const matchDirectiveLine = (line: string): Annotation | null => {
   return null;
 };
 
-const CALLOUT_DIRECTIVE_RE = /\[!callout:\s*[^\]]+\]/u;
+// \s は [^\]] に含まれるため \s* を挟むと曖昧になり、バックトラックが
+// 多項式時間になる (CodeQL: js/polynomial-redos)。マッチ範囲は同一。
+const CALLOUT_DIRECTIVE_RE = /\[!callout:[^\]]+\]/u;
 
 // markdown配信などレンダリングを伴わない出力向けに、注釈ディレクティブ行を除去する。
 // コールアウトは本文が読者向けの説明なので、コメント記法を保ったまま本文だけ残す。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -457,6 +457,9 @@ importers:
       remark-math:
         specifier: 6.0.0
         version: 6.0.0
+      remark-mdx:
+        specifier: 3.1.1
+        version: 3.1.1
       rss:
         specifier: 1.2.2
         version: 1.2.2


### PR DESCRIPTION
## 概要

`/blog/:slug.md` で配信するmarkdownを、生のMDXからCommonMarkとして読める素のmarkdownへ変換する。

## 動機

これまではfrontmatterを除いただけの生のMDXを返しており、import文やJSXコンポーネント（`<BaselineStatus>`・`<Playground>` など）がそのまま露出していた。import文は読者（LLM含む）にとって純粋なノイズで、Playgroundはインタラクティブデモのため本文情報がゼロになる。`text/markdown` として配信する以上、markdownとして成立する出力に寄せる。

## 詳細

`features/blog/application/markdown.ts` に `mdxToMarkdown` を追加。remark + remark-mdx でパースし、MDX固有ノードのスパンだけを元テキストから置換する方式のため、本文のフォーマットは原文のまま保たれる。

| 対象 | 変換 |
|------|------|
| frontmatter・import文・`{/* */}` 式 | 削除 |
| `<LinkCard href>` | `<https://...>` のオートリンク（相対hrefはサイトURLを前置） |
| `<Playground title>` | `> インタラクティブデモ「...」はWeb版で試せます: <記事URL>` |
| `<Image>` | `（画像: {alt}）` の注記 |
| `<BaselineStatus>` | 削除（本文がBaseline状況に言及しているため） |
| `<Alert message>` | `> {message}` の引用 |
| 未知のコンポーネント | 子があればタグだけ剥がして中身を残す。なければ削除 |
| コードブロックの `[!og]` / `[!hl]` 等 | 行ごと削除。`[!callout: ...]` はコメント記法を保って本文だけ残す |

注釈ディレクティブの文法は `@repo/code-highlight` のドメインなので、除去ロジックは `stripAnnotationComments` として同パッケージの `parser` に追加した。

## 気をつけるポイント

- パーサーに `remark-math` を含めている。ないと `$\mathbb{N}$` のような数式内の `{}` がMDX式として解釈されてパースに失敗する（本番のMDXパイプラインと同じ構成に揃えた）
- 読了時間の見積もり（`getBlogReadingTime`）も `getMarkdown` を使っているため、今後はimport文・JSXを除いた本文ベースの計算になる。実態に近づく方向だが、記事によって表示が1分ずれる可能性がある

## 影響範囲

- `/blog/:slug.md` のレスポンス内容
- Markdownコピーボタンでコピーされる内容
- 読了時間の表示

## テスト

- コンバーターのユニットテスト15件、`stripAnnotationComments` のテスト6件を追加
- 全74記事にコンバーターを通すコーパスチェックを実施し、全記事が変換成功・コードフェンス外への残留import/JSX/ディレクティブがゼロであることを確認（コードブロック内のimport文やJSXサンプルには触れないことも確認）
- devサーバーで実配信が変換済み出力になることを確認