### PR TITLE
chore(knip): main由来の未使用exportを削除しknipをgreenにする

### DIFF
--- a/apps/ai/src/app/(authenticated)/_components/studio/chat-panel.tsx
+++ b/apps/ai/src/app/(authenticated)/_components/studio/chat-panel.tsx
@@ -29,7 +29,7 @@ const AssistantRow: FC<{ children: ReactNode }> = ({ children }) => (
 
 // 生成テキストから吹き出しに出す説明文を取り出す。スタジオ（UI / スライド）ごとに
 // 出力フォーマットが違うため差し替え可能にする（モジュールレベルの定数を渡すこと）。
-export type DescribeMessage = (text: string) => string | null;
+type DescribeMessage = (text: string) => string | null;
 
 const describeUiMessage: DescribeMessage = (text) =>
   parseGeneration(text).meta?.description ?? null;

--- a/apps/ai/src/app/_components/slide-deck/index.ts
+++ b/apps/ai/src/app/_components/slide-deck/index.ts
@@ -1,4 +1,3 @@
-export { Cover } from './cover';
 export { DeckPrint } from './deck-print';
 export {
   DeckHighlightsContext,

--- a/apps/ai/src/features/generation/application/modes.ts
+++ b/apps/ai/src/features/generation/application/modes.ts
@@ -1,4 +1,2 @@
 // 生成モードの単一ソース。route の zod enum・クライアントの送信値がここから派生する。
 export const GENERATION_MODES = ['ui', 'slides'] as const;
-
-export type GenerationMode = (typeof GENERATION_MODES)[number];

--- a/apps/main/src/app/palette-maker/_utils/search-params.ts
+++ b/apps/main/src/app/palette-maker/_utils/search-params.ts
@@ -13,7 +13,7 @@ export const PEAK_CHROMA = {
   default: 0.12,
 } as const;
 
-export const DEFAULT_TOKEN_NAME = 'primary';
+const DEFAULT_TOKEN_NAME = 'primary';
 
 const TOKEN_NAME_MAX_LENGTH = 32;
 const TOKEN_NAME_PATTERN = /^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$/u;

--- a/knip.json
+++ b/knip.json
@@ -10,7 +10,6 @@
   "ignoreBinaries": ["mise", "which"],
   "workspaces": {
     ".": {
-      "entry": ["vite.config.ts"],
       "ignoreDependencies": ["@vercel/next-browser"]
     },
     "apps/main": {


### PR DESCRIPTION
## 概要

`pnpm run knip` が main 時点から検出していた未使用 export 4 件と設定ヒント 1 件により exit 1 となり、CI（`.github/workflows/knip.yml`）が失敗していた。これらを解消して knip を green にする。

いずれも feature ブランチで変更したファイルではなく、main 時点から存在していたもの。各シンボルの利用状況を確認し、純粋に未使用なものだけを削除・非公開化した。

## 変更内容

| 対象 | 対応 | 補足 |
|------|------|------|
| `Cover` (`apps/ai/.../slide-deck/index.ts`) | バレルの再 export を削除 | コンポーネント実体は `deck-slide-view` が `../cover` から直接 import しており利用継続。トップレベルバレルの再 export のみが未使用だった |
| `DEFAULT_TOKEN_NAME` (`apps/main/.../palette-maker/_utils/search-params.ts`) | `export` を外しファイル内定数化 | 同ファイル内の `withDefault` でのみ利用 |
| `DescribeMessage` (`apps/ai/.../studio/chat-panel.tsx`) | `export` を外す | 同ファイル内でのみ利用する型 |
| `GenerationMode` (`apps/ai/.../generation/application/modes.ts`) | 型を削除 | どこからも未参照。route の zod enum が使う `GENERATION_MODES` 定数は維持 |
| `knip.json` | `workspaces["."].entry` の `vite.config.ts` を削除 | knip の Vite プラグインが自動検出するため冗長（`treatConfigHintsAsErrors: true` によりエラー扱いだった） |

## 確認

- `pnpm run knip` → エラーゼロで正常終了
- `pnpm run type-check` → 全 8 パッケージ成功
- `pnpm run check` → エラーゼロ（既存 warning のみ）