### PR TITLE
feat(code-dock): oxc設定でコードを検査・整形できる「コードドック」を追加

### DIFF
--- a/apps/main/next.config.ts
+++ b/apps/main/next.config.ts
@@ -28,6 +28,18 @@ const nextConfig: NextConfig = {
       exclude: ['error', 'warn'],
     },
   },
+  // oxlint/oxfmt は NAPI ネイティブバイナリのためバンドルせず node_modules から読む
+  serverExternalPackages: ['oxlint', 'oxfmt'],
+  outputFileTracingIncludes: {
+    // oxlint は子プロセス起動のみで静的 import されないため、トレースに乗らない
+    // バイナリ (プラットフォーム別 binding) を明示的に含める
+    '/code-dock': [
+      '**/node_modules/oxlint/**',
+      '**/node_modules/@oxlint/binding-*/**',
+      '**/node_modules/oxfmt/**',
+      '**/node_modules/@oxfmt/binding-*/**',
+    ],
+  },
   logging: {
     browserToTerminal: true,
   },

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@k8o/arte-odyssey": "catalog:",
+    "@k8o/oxc-config": "0.1.3",
     "@mdx-js/loader": "3.1.1",
     "@mdx-js/react": "3.1.1",
     "@next/mdx": "catalog:",
@@ -38,6 +39,8 @@
     "next": "catalog:",
     "next-themes": "catalog:",
     "nuqs": "2.8.9",
+    "oxfmt": "0.55.0",
+    "oxlint": "1.70.0",
     "postcss": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -55,6 +55,9 @@
     "uqr": "0.1.3",
     "zod": "4.4.3"
   },
+  "optionalDependencies": {
+    "@oxlint/binding-linux-x64-gnu": "1.70.0"
+  },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@repo/vitest-config": "workspace:*",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -55,9 +55,6 @@
     "uqr": "0.1.3",
     "zod": "4.4.3"
   },
-  "optionalDependencies": {
-    "@oxlint/binding-linux-x64-gnu": "1.70.0"
-  },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",
     "@repo/vitest-config": "workspace:*",
@@ -85,6 +82,9 @@
     "storybook-addon-mock-date": "3.1.0",
     "storybook-addon-vrt": "catalog:",
     "vitest": "catalog:"
+  },
+  "optionalDependencies": {
+    "@oxlint/binding-linux-x64-gnu": "1.70.0"
   },
   "msw": {
     "workerDirectory": [

--- a/apps/main/src/app/_components/site-entry-section/site-entry-section.tsx
+++ b/apps/main/src/app/_components/site-entry-section/site-entry-section.tsx
@@ -1,5 +1,6 @@
 import {
   BlogIcon,
+  CheckIcon,
   CodeXmlIcon,
   ColorContrastIcon,
   ColorInfoIcon,
@@ -35,6 +36,7 @@ const ICON: Record<SiteEntryIcon, ReactNode> = {
   paletteMaker: <ColorScaleIcon size="md" />,
   mojiCount: <HorizontalWritingIcon size="md" />,
   htmlNest: <CodeXmlIcon size="md" />,
+  codeDock: <CheckIcon size="md" />,
   fluida: <PaletteIcon size="md" />,
   blog: <BlogIcon size="md" />,
   talks: <SlideIcon size="md" />,

--- a/apps/main/src/app/code-dock/_components/code-dock/code-dock.stories.tsx
+++ b/apps/main/src/app/code-dock/_components/code-dock/code-dock.stories.tsx
@@ -1,0 +1,129 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, waitFor, within } from 'storybook/test';
+
+import type { LintDiagnostic } from '@/features/code-dock/interface/types';
+
+import { CodeDock } from './code-dock';
+import type { FormatAction, LintAction } from './code-dock';
+
+const sampleDiagnostic: LintDiagnostic = {
+  code: 'eslint(no-console)',
+  column: 3,
+  help: null,
+  line: 4,
+  message: 'Unexpected console statement.',
+  severity: 'warning',
+  url: 'https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html',
+};
+
+// Storybook からはネイティブバイナリを動かせないため、server action の代わりに
+// 固定の結果を返すフェイクを注入する
+const fakeLint: LintAction = (code) =>
+  Promise.resolve(
+    code.includes('console.log')
+      ? { diagnostics: [sampleDiagnostic] }
+      : { diagnostics: [] },
+  );
+
+const FORMATTED_CODE = "const greeting = 'Hello, k8o!';\n";
+
+const fakeFormat: FormatAction = () =>
+  Promise.resolve({ code: FORMATTED_CODE });
+
+const failingFormat: FormatAction = () =>
+  Promise.resolve({ error: '整形できませんでした: Unexpected token' });
+
+const meta: Meta<typeof CodeDock> = {
+  title: 'app/code-dock/code-dock',
+  component: CodeDock,
+  args: {
+    formatAction: fakeFormat,
+    lintAction: fakeLint,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof CodeDock>;
+
+// 正常系: 初期サンプルがデバウンス後に自動で検査される
+export const Primary: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('textbox', { name: 'コード' }),
+    ).toBeInTheDocument();
+    await waitFor(
+      () => {
+        expect(
+          canvas.getByText('Unexpected console statement.'),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  },
+};
+
+// 正常系: コピーボタンが表示・クリックできる (クリップボードはブラウザ依存)
+export const Copy: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'コピー' });
+    await expect(button).toBeEnabled();
+    await userEvent.click(button);
+    await expect(button).toBeInTheDocument();
+  },
+};
+
+// 正常系: 整形ボタンでエディタの内容が整形結果に置き換わり、再検査される
+export const Format: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'コードを整形' });
+
+    await userEvent.click(button);
+
+    const textarea = canvas.getByRole('textbox', { name: 'コード' });
+    await waitFor(() => {
+      expect(textarea).toHaveValue(FORMATTED_CODE);
+    });
+    await waitFor(
+      () => {
+        expect(
+          canvas.getByText('問題は見つかりませんでした'),
+        ).toBeInTheDocument();
+      },
+      { timeout: 5000 },
+    );
+  },
+};
+
+// 異常系: 整形の失敗は Alert で通知される
+export const FormatFailed: Story = {
+  args: {
+    formatAction: failingFormat,
+  },
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button', { name: 'コードを整形' });
+
+    await userEvent.click(button);
+
+    await waitFor(() => {
+      expect(
+        canvas.getByText('整形できませんでした: Unexpected token'),
+      ).toBeInTheDocument();
+    });
+  },
+};
+
+// 正常系: 言語を切り替えられる
+export const SwitchLanguage: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const select = canvas.getByRole('combobox', { name: '言語' });
+
+    await userEvent.selectOptions(select, 'ts');
+
+    await expect(select).toHaveValue('ts');
+  },
+};

--- a/apps/main/src/app/code-dock/_components/code-dock/code-dock.tsx
+++ b/apps/main/src/app/code-dock/_components/code-dock/code-dock.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import {
+  Alert,
+  Button,
+  CopyIcon,
+  FormControl,
+  Select,
+  useClipboard,
+  useDebouncedTransition,
+  useToast,
+} from '@k8o/arte-odyssey';
+import type { HighlightTheme } from '@repo/code-highlight/tokenize';
+import { useAsyncAction } from '@repo/react-hooks/use-async-action';
+import { useTheme } from 'next-themes';
+import { useEffect, useRef, useState } from 'react';
+import type { FC } from 'react';
+
+import { isLintLanguage } from '@/features/code-dock/interface/types';
+import type {
+  FormatCodeResult,
+  LintCodeResult,
+  LintDiagnostic,
+  LintLanguage,
+} from '@/features/code-dock/interface/types';
+
+import { CodeEditor } from '../code-editor';
+import { DiagnosticList } from '../diagnostic-list';
+
+// server action は直接 import せず props で受け取る (Storybook をバイナリに依存させない)
+export type LintAction = (
+  code: string,
+  language: string,
+) => Promise<LintCodeResult>;
+export type FormatAction = (
+  code: string,
+  language: string,
+) => Promise<FormatCodeResult>;
+
+type Props = {
+  lintAction: LintAction;
+  formatAction: FormatAction;
+};
+
+const LANGUAGE_OPTIONS = [
+  { label: 'TSX', value: 'tsx' },
+  { label: 'TS', value: 'ts' },
+  { label: 'JSX', value: 'jsx' },
+  { label: 'JS', value: 'js' },
+] as const;
+
+const DEFAULT_CODE = [
+  'const greeting = "Hello, k8o!"',
+  '',
+  'export const App = () => {',
+  '  console.log(greeting)',
+  '  return <p>{greeting}</p>',
+  '}',
+  '',
+].join('\n');
+
+const LINT_DEBOUNCE_MS = 600;
+
+export const CodeDock: FC<Props> = ({ lintAction, formatAction }) => {
+  const [code, setCode] = useState(DEFAULT_CODE);
+  const [language, setLanguage] = useState<LintLanguage>('tsx');
+  const [diagnostics, setDiagnostics] = useState<LintDiagnostic[] | null>(null);
+  const [lintError, setLintError] = useState<string | null>(null);
+  const [isLinting, dispatchLint] = useDebouncedTransition(LINT_DEBOUNCE_MS);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const { resolvedTheme } = useTheme();
+  // コードのハイライトはアプリのテーマに合わせる (light は one-light、それ以外は
+  // plastic)。テーマ解決前 (SSR 直後) は dark 想定の plastic にフォールバック
+  const highlightTheme: HighlightTheme =
+    resolvedTheme === 'light' ? 'one-light' : 'plastic';
+  const { error: formatError, isPending: isFormatting, run } = useAsyncAction();
+  const { writeClipboard } = useClipboard();
+  const { onOpen } = useToast();
+
+  const handleCopy = async (): Promise<void> => {
+    try {
+      await writeClipboard(code);
+      onOpen('success', 'コードをコピーしました');
+    } catch {
+      onOpen('error', 'コピーに失敗しました');
+    }
+  };
+
+  // 入力・言語変更・整形の反映のたびに、デバウンスして自動で検査する
+  useEffect(() => {
+    dispatchLint(async (signal) => {
+      if (code === '') {
+        setDiagnostics(null);
+        setLintError(null);
+        return;
+      }
+      const result = await lintAction(code, language);
+      if (signal.aborted) {
+        return;
+      }
+      if (result.error !== undefined) {
+        setLintError(result.error);
+        return;
+      }
+      setDiagnostics(result.diagnostics);
+      setLintError(null);
+    });
+  }, [code, language, dispatchLint, lintAction]);
+
+  // textarea は非制御なので、整形結果は必ず DOM に反映する (input 発火で
+  // state も同期される)。undo 履歴を残せる insertText を優先し、非対応環境では
+  // value を直接書き換えて input を発火させる
+  const applyFormatted = (formatted: string): void => {
+    const textarea = textareaRef.current;
+    if (textarea === null) {
+      setCode(formatted);
+      return;
+    }
+    if (formatted === textarea.value) {
+      return;
+    }
+    textarea.focus();
+    textarea.select();
+    // oxlint-disable-next-line typescript/no-deprecated -- undo履歴を保った全置換ができる代替APIが無い
+    const inserted = document.execCommand('insertText', false, formatted);
+    if (!inserted) {
+      // execCommand 非対応環境: 非制御なので DOM を直接書き換え、state も同期する
+      textarea.value = formatted;
+      setCode(formatted);
+    }
+  };
+
+  const handleFormat = (): void => {
+    run(() => formatAction(code, language), {
+      onSuccess: (result) => {
+        if (result.code !== undefined) {
+          applyFormatted(result.code);
+        }
+      },
+    });
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap items-end gap-4">
+        <div className="w-36">
+          <FormControl
+            label="言語"
+            renderInput={({ 'aria-labelledby': _, ...props }) => (
+              <Select
+                {...props}
+                onChange={(e) => {
+                  if (isLintLanguage(e.target.value)) {
+                    setLanguage(e.target.value);
+                  }
+                }}
+                options={LANGUAGE_OPTIONS}
+                value={language}
+              />
+            )}
+          />
+        </div>
+        <div className="ml-auto flex gap-2">
+          <Button
+            disabled={code === ''}
+            onClick={() => {
+              void handleCopy();
+            }}
+            startIcon={<CopyIcon size="sm" />}
+            type="button"
+            variant="outline"
+          >
+            コピー
+          </Button>
+          <Button
+            disabled={code === '' || isFormatting}
+            onClick={handleFormat}
+            type="button"
+          >
+            コードを整形
+          </Button>
+        </div>
+      </div>
+      <CodeEditor
+        language={language}
+        onChange={setCode}
+        textareaRef={textareaRef}
+        theme={highlightTheme}
+        value={code}
+      />
+      {formatError === undefined ? null : (
+        <Alert message={formatError} tone="error" />
+      )}
+      <DiagnosticList
+        diagnostics={diagnostics}
+        errorMessage={lintError}
+        isLinting={isLinting}
+      />
+    </div>
+  );
+};

--- a/apps/main/src/app/code-dock/_components/code-dock/index.ts
+++ b/apps/main/src/app/code-dock/_components/code-dock/index.ts
@@ -1,0 +1,1 @@
+export { CodeDock } from './code-dock';

--- a/apps/main/src/app/code-dock/_components/code-editor/code-editor.stories.tsx
+++ b/apps/main/src/app/code-dock/_components/code-editor/code-editor.stories.tsx
@@ -1,0 +1,98 @@
+import type { HighlightTheme } from '@repo/code-highlight/tokenize';
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { useState } from 'react';
+import type { FC } from 'react';
+import { expect, waitFor, within } from 'storybook/test';
+
+import type { LintLanguage } from '@/features/code-dock/interface/types';
+
+import { CodeEditor } from './code-editor';
+
+const ControlledEditor: FC<{
+  initialValue: string;
+  language: LintLanguage;
+  theme: HighlightTheme;
+}> = ({ initialValue, language, theme }) => {
+  const [value, setValue] = useState(initialValue);
+  return (
+    <CodeEditor
+      language={language}
+      onChange={setValue}
+      theme={theme}
+      value={value}
+    />
+  );
+};
+
+const meta: Meta<typeof ControlledEditor> = {
+  title: 'app/code-dock/code-editor',
+  component: ControlledEditor,
+  args: {
+    initialValue: "const greeting = 'Hello, k8o!';\n",
+    language: 'tsx',
+    theme: 'plastic',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ControlledEditor>;
+
+// 正常系: shiki のトークンで色つき表示される (実ブラウザでハイライトが動く)
+export const Primary: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('textbox', { name: 'コード' }),
+    ).toBeInTheDocument();
+    await waitFor(
+      () => {
+        const coloredTokens = canvasElement.querySelectorAll(
+          'pre code span[style*="color"]',
+        );
+        expect(coloredTokens.length).toBeGreaterThan(0);
+      },
+      { timeout: 10_000 },
+    );
+  },
+};
+
+// 正常系: ライトテーマ (one-light) では明るい面色でハイライトされる
+export const OneLight: Story = {
+  args: {
+    theme: 'one-light',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByRole('textbox', { name: 'コード' }),
+    ).toBeInTheDocument();
+    await waitFor(
+      () => {
+        const coloredTokens = canvasElement.querySelectorAll(
+          'pre code span[style*="color"]',
+        );
+        expect(coloredTokens.length).toBeGreaterThan(0);
+      },
+      { timeout: 10_000 },
+    );
+  },
+};
+
+// 正常系: 入力すると textarea の値と表示テキストが同期する
+export const Typing: Story = {
+  args: {
+    initialValue: '',
+  },
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const textarea = canvas.getByRole('textbox', { name: 'コード' });
+
+    await userEvent.type(textarea, 'const answer = 42;');
+
+    await expect(textarea).toHaveValue('const answer = 42;');
+    const pre = canvasElement.querySelector('pre');
+    await waitFor(() => {
+      expect(pre?.textContent).toContain('const answer = 42;');
+    });
+  },
+};

--- a/apps/main/src/app/code-dock/_components/code-editor/code-editor.tsx
+++ b/apps/main/src/app/code-dock/_components/code-editor/code-editor.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { FormControl } from '@k8o/arte-odyssey';
+import type {
+  HighlightedCode,
+  HighlightTheme,
+} from '@repo/code-highlight/tokenize';
+import { Fragment, useState } from 'react';
+import type { FC, ReactNode, Ref } from 'react';
+
+import type { LintLanguage } from '@/features/code-dock/interface/types';
+
+import { useHighlightedCode } from './use-highlighted-code';
+
+type Props = {
+  value: string;
+  language: LintLanguage;
+  theme: HighlightTheme;
+  onChange: (value: string) => void;
+  /** 整形結果の反映などで textarea を直接操作するための ref */
+  textareaRef?: Ref<HTMLTextAreaElement>;
+};
+
+// pre (表示) と textarea (入力) の文字メトリクスを完全に一致させるための共通クラス
+const TEXT_CLASS =
+  'p-4 font-mono text-sm leading-6 whitespace-pre-wrap break-words [tab-size:2]';
+
+// textarea は preflight の `textarea { font-family: inherit }` によりサイト既定の
+// sans-serif になり font-mono クラスが効かない。プロポーショナルだと透明文字
+// (=キャレット) が monospace の pre とズレるため、両者にインラインで monospace を
+// 強制して文字幅を一致させる
+const MONO_FONT_FAMILY =
+  'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace';
+
+// shiki の plastic (dark) / one-light (light) の面色を CSS のテーマクラスで与える。
+// JS のインラインで描くと SSR ではテーマ不明でフォールバック色になり、リロード時に
+// 一瞬見えてしまう。next-themes がハイドレーション前に付ける .dark クラスに追従する
+// CSS なら初回描画から正しい色になり、フラッシュもハイドレーション不一致も起きない。
+const SURFACE_BG = 'bg-[#fafafa] dark:bg-[#21252b]';
+const SURFACE_TEXT = 'text-[#383a42] dark:text-[#a9b2c3]';
+const SURFACE_CARET = 'caret-[#383a42] dark:caret-[#a9b2c3]';
+
+const renderTokens = (highlighted: HighlightedCode): ReactNode =>
+  highlighted.tokens.map((line, lineIndex) => (
+    <Fragment key={`line-${lineIndex.toString()}`}>
+      {line.map((token, tokenIndex) => (
+        <span
+          key={`${lineIndex.toString()}-${tokenIndex.toString()}`}
+          style={{ color: token.color ?? highlighted.fg }}
+        >
+          {token.content}
+        </span>
+      ))}
+      {lineIndex < highlighted.tokens.length - 1 ? '\n' : null}
+    </Fragment>
+  ));
+
+export const CodeEditor: FC<Props> = ({
+  value,
+  language,
+  theme,
+  onChange,
+  textareaRef,
+}) => {
+  const { tokens, ready } = useHighlightedCode(value, language, theme);
+  // IME 変換中は透明文字だと未確定文字列が見えないため、textarea 側を可視化する
+  const [isComposing, setIsComposing] = useState(false);
+  // 初回ハイライト前はプレーンなコードを見せない (色が付いてから表示する)。
+  // 高さは visibility:hidden で保持されるためレイアウトのガタつきは起きない。
+  const hideText = isComposing || !ready;
+
+  return (
+    <FormControl
+      helpText="入力するとハイライトと検査が自動で反映されます"
+      label="コード"
+      renderInput={({
+        'aria-describedby': ariaDescribedby,
+        'aria-labelledby': _,
+        disabled,
+        id,
+        invalid,
+        required,
+      }) => (
+        <div
+          className={`${SURFACE_BG} focus-within:ring-primary-border max-h-[60svh] min-h-48 overflow-auto rounded-xl focus-within:ring-2`}
+        >
+          <div className="relative min-h-full">
+            <pre
+              aria-hidden
+              className={`${TEXT_CLASS} ${SURFACE_TEXT}`}
+              style={{
+                fontFamily: MONO_FONT_FAMILY,
+                visibility: hideText ? 'hidden' : undefined,
+              }}
+            >
+              <code>{tokens === null ? value : renderTokens(tokens)}</code>
+              {/* 末尾が改行のとき textarea だけ 1 行高くなるのを防ぐ */}
+              {value.endsWith('\n') ? ' ' : null}
+            </pre>
+            <textarea
+              aria-describedby={ariaDescribedby}
+              aria-invalid={invalid || undefined}
+              autoCapitalize="off"
+              autoComplete="off"
+              autoCorrect="off"
+              className={`absolute inset-0 size-full resize-none overflow-hidden bg-transparent outline-none ${TEXT_CLASS} ${SURFACE_CARET} ${isComposing ? SURFACE_TEXT : 'text-transparent'}`}
+              disabled={disabled}
+              id={id}
+              onChange={(e) => {
+                onChange(e.target.value);
+              }}
+              onCompositionEnd={() => {
+                setIsComposing(false);
+              }}
+              onCompositionStart={() => {
+                setIsComposing(true);
+              }}
+              ref={textareaRef}
+              required={required}
+              spellCheck={false}
+              style={{ fontFamily: MONO_FONT_FAMILY }}
+              // 非制御にする。React が value を再セットしないため、遅延/トランジ
+              // ションの再レンダーでもキャレットが末尾へ飛ばない。表示用の値は
+              // onChange 経由で親の state に同期し、整形時のみ ref で DOM を書く
+              defaultValue={value}
+            />
+          </div>
+        </div>
+      )}
+    />
+  );
+};

--- a/apps/main/src/app/code-dock/_components/code-editor/index.ts
+++ b/apps/main/src/app/code-dock/_components/code-editor/index.ts
@@ -1,0 +1,1 @@
+export { CodeEditor } from './code-editor';

--- a/apps/main/src/app/code-dock/_components/code-editor/use-highlighted-code.ts
+++ b/apps/main/src/app/code-dock/_components/code-editor/use-highlighted-code.ts
@@ -1,0 +1,95 @@
+'use client';
+
+import type * as tokenize from '@repo/code-highlight/tokenize';
+import type {
+  HighlightedCode,
+  HighlightTheme,
+} from '@repo/code-highlight/tokenize';
+import { useEffect, useRef, useState } from 'react';
+
+import type { LintLanguage } from '@/features/code-dock/interface/types';
+
+// shiki を初期バンドルから外すため、初回利用時に一度だけ動的 import する
+let tokenizeModule: Promise<typeof tokenize> | null = null;
+
+const loadTokenize = (): Promise<typeof tokenize> =>
+  (tokenizeModule ??= import('@repo/code-highlight/tokenize'));
+
+// 初回ハイライトが失敗/大幅遅延しても、この時間を過ぎたらプレーンで見せる保険
+const REVEAL_FALLBACK_MS = 1500;
+
+type HighlightState = {
+  code: string;
+  language: LintLanguage;
+  theme: HighlightTheme;
+  data: HighlightedCode;
+};
+
+export type HighlightResult = {
+  /** 現在の入力・テーマに一致するトークン。再ハイライト中は null (プレーン表示) */
+  tokens: HighlightedCode | null;
+  /**
+   * 初回ハイライトが完了したか (=コードを表示してよいか)。初回ロード時に色が付く
+   * 前のプレーンなコードを見せないため、これが false の間は呼び出し側で非表示にする。
+   */
+  ready: boolean;
+};
+
+/**
+ * 入力中のコードをクライアントサイドでハイライトする。トークンが現在の入力・
+ * テーマと一致するときだけ返し、それ以外は null (プレーン表示) にフォールバックする。
+ *
+ * 面色 (bg/fg) はこのフックではなく CSS のテーマクラスで与える。SSR では
+ * ユーザーのテーマが不明なため、JS で面色を描くとフォールバック色がリロード時に
+ * 一瞬見えてしまう。CSS なら next-themes がハイドレーション前に付けるテーマクラスで
+ * 初回描画から正しい色になる。
+ *
+ * useDeferredValue は使わない。textarea を非制御にしたことで入力応答性はネイティブ
+ * に保たれており、遅延させるとトークンがプレーンへ戻る時間が伸びてチラつくため。
+ */
+export const useHighlightedCode = (
+  code: string,
+  language: LintLanguage,
+  theme: HighlightTheme,
+): HighlightResult => {
+  const [state, setState] = useState<HighlightState | null>(null);
+  const [timedOut, setTimedOut] = useState(false);
+  // 古い非同期結果で新しい入力を上書きしないための世代カウンタ
+  const requestRef = useRef(0);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setTimedOut(true);
+    }, REVEAL_FALLBACK_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, []);
+
+  useEffect(() => {
+    const requestId = requestRef.current + 1;
+    requestRef.current = requestId;
+    void (async () => {
+      try {
+        const { highlightCode } = await loadTokenize();
+        const data = await highlightCode(code, language, theme);
+        if (requestRef.current === requestId) {
+          setState({ code, data, language, theme });
+        }
+      } catch {
+        // ハイライトは装飾なので、失敗してもプレーン表示で続行する
+      }
+    })();
+  }, [code, language, theme]);
+
+  const matches =
+    state?.code === code &&
+    state.language === language &&
+    state.theme === theme;
+
+  return {
+    tokens: matches ? state.data : null,
+    // 一度でもハイライトに成功すれば以降は常に表示 (state は直近結果を保持し続ける)
+    ready: state !== null || timedOut,
+  };
+};

--- a/apps/main/src/app/code-dock/_components/diagnostic-list/diagnostic-list.stories.tsx
+++ b/apps/main/src/app/code-dock/_components/diagnostic-list/diagnostic-list.stories.tsx
@@ -1,0 +1,114 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect, within } from 'storybook/test';
+
+import type { LintDiagnostic } from '@/features/code-dock/interface/types';
+
+import { DiagnosticList } from './diagnostic-list';
+
+const sampleDiagnostics: LintDiagnostic[] = [
+  {
+    code: 'eslint(no-var)',
+    column: 1,
+    help: 'Replace var with let or const',
+    line: 1,
+    message: 'Unexpected var, use let or const instead.',
+    severity: 'error',
+    url: 'https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-var.html',
+  },
+  {
+    code: 'eslint(no-console)',
+    column: 3,
+    help: null,
+    line: 4,
+    message: 'Unexpected console statement.',
+    severity: 'warning',
+    url: 'https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-console.html',
+  },
+  {
+    code: null,
+    column: null,
+    help: null,
+    line: null,
+    message: 'Unexpected token',
+    severity: 'error',
+    url: null,
+  },
+];
+
+const meta: Meta<typeof DiagnosticList> = {
+  title: 'app/code-dock/diagnostic-list',
+  component: DiagnosticList,
+  args: {
+    diagnostics: sampleDiagnostics,
+    errorMessage: null,
+    isLinting: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof DiagnosticList>;
+
+// 正常系: 診断が severity バッジ・位置・ルールコードつきで一覧表示される
+export const Primary: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('Unexpected var, use let or const instead.'),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('L1:1')).toBeInTheDocument();
+    await expect(
+      canvas.getByRole('link', { name: 'eslint(no-var)' }),
+    ).toBeInTheDocument();
+    await expect(canvas.getByText('error 2 / warning 1')).toBeInTheDocument();
+  },
+};
+
+// 正常系: 診断 0 件は成功の Alert になる
+export const NoIssues: Story = {
+  args: {
+    diagnostics: [],
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('問題は見つかりませんでした'),
+    ).toBeInTheDocument();
+  },
+};
+
+// 正常系: 未検査 (コードが空) は案内文を表示する
+export const NotChecked: Story = {
+  args: {
+    diagnostics: null,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('コードを入力すると、自動で検査結果が表示されます。'),
+    ).toBeInTheDocument();
+  },
+};
+
+// 正常系: 検査中はスピナーを表示する
+export const Linting: Story = {
+  args: {
+    isLinting: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('検査中')).toBeInTheDocument();
+  },
+};
+
+// 異常系: 検査自体の失敗はエラーの Alert になる
+export const LintFailed: Story = {
+  args: {
+    errorMessage: 'コードの検査に失敗しました',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('コードの検査に失敗しました'),
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/main/src/app/code-dock/_components/diagnostic-list/diagnostic-list.tsx
+++ b/apps/main/src/app/code-dock/_components/diagnostic-list/diagnostic-list.tsx
@@ -45,27 +45,28 @@ const RuleCode: FC<{ diagnostic: LintDiagnostic }> = ({ diagnostic }) => {
   );
 };
 
-const DiagnosticItem: FC<{ diagnostic: LintDiagnostic }> = ({ diagnostic }) => (
-  <li className="border-border-mute flex flex-col gap-1 rounded-xl border p-4">
-    <div className="flex flex-wrap items-center gap-2">
-      <Badge
-        size="sm"
-        text={diagnostic.severity}
-        tone={severityTone(diagnostic.severity)}
-      />
-      {position(diagnostic) === null ? null : (
-        <span className="text-fg-mute font-mono text-sm">
-          {position(diagnostic)}
-        </span>
+const DiagnosticItem: FC<{ diagnostic: LintDiagnostic }> = ({ diagnostic }) => {
+  const pos = position(diagnostic);
+  return (
+    <li className="border-border-mute flex flex-col gap-1 rounded-xl border p-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge
+          size="sm"
+          text={diagnostic.severity}
+          tone={severityTone(diagnostic.severity)}
+        />
+        {pos === null ? null : (
+          <span className="text-fg-mute font-mono text-sm">{pos}</span>
+        )}
+        <RuleCode diagnostic={diagnostic} />
+      </div>
+      <p className="text-sm">{diagnostic.message}</p>
+      {diagnostic.help === null ? null : (
+        <p className="text-fg-mute text-sm">{diagnostic.help}</p>
       )}
-      <RuleCode diagnostic={diagnostic} />
-    </div>
-    <p className="text-sm">{diagnostic.message}</p>
-    {diagnostic.help === null ? null : (
-      <p className="text-fg-mute text-sm">{diagnostic.help}</p>
-    )}
-  </li>
-);
+    </li>
+  );
+};
 
 const diagnosticKey = (diagnostic: LintDiagnostic, index: number): string =>
   [

--- a/apps/main/src/app/code-dock/_components/diagnostic-list/diagnostic-list.tsx
+++ b/apps/main/src/app/code-dock/_components/diagnostic-list/diagnostic-list.tsx
@@ -1,0 +1,132 @@
+import {
+  Alert,
+  Anchor,
+  Badge,
+  Code,
+  Heading,
+  Spinner,
+} from '@k8o/arte-odyssey';
+import type { FC } from 'react';
+
+import type { LintDiagnostic } from '@/features/code-dock/interface/types';
+
+type Props = {
+  /** null は未検査 (コードが空) を表す */
+  diagnostics: LintDiagnostic[] | null;
+  isLinting: boolean;
+  errorMessage: string | null;
+};
+
+const severityTone = (
+  severity: LintDiagnostic['severity'],
+): 'error' | 'warning' => (severity === 'warning' ? 'warning' : 'error');
+
+const position = (diagnostic: LintDiagnostic): string | null => {
+  if (diagnostic.line === null) {
+    return null;
+  }
+  if (diagnostic.column === null) {
+    return `L${diagnostic.line.toString()}`;
+  }
+  return `L${diagnostic.line.toString()}:${diagnostic.column.toString()}`;
+};
+
+const RuleCode: FC<{ diagnostic: LintDiagnostic }> = ({ diagnostic }) => {
+  if (diagnostic.code === null) {
+    return null;
+  }
+  if (diagnostic.url === null) {
+    return <Code>{diagnostic.code}</Code>;
+  }
+  return (
+    <Anchor href={diagnostic.url} openInNewTab>
+      <span className="font-mono text-sm">{diagnostic.code}</span>
+    </Anchor>
+  );
+};
+
+const DiagnosticItem: FC<{ diagnostic: LintDiagnostic }> = ({ diagnostic }) => (
+  <li className="border-border-mute flex flex-col gap-1 rounded-xl border p-4">
+    <div className="flex flex-wrap items-center gap-2">
+      <Badge
+        size="sm"
+        text={diagnostic.severity}
+        tone={severityTone(diagnostic.severity)}
+      />
+      {position(diagnostic) === null ? null : (
+        <span className="text-fg-mute font-mono text-sm">
+          {position(diagnostic)}
+        </span>
+      )}
+      <RuleCode diagnostic={diagnostic} />
+    </div>
+    <p className="text-sm">{diagnostic.message}</p>
+    {diagnostic.help === null ? null : (
+      <p className="text-fg-mute text-sm">{diagnostic.help}</p>
+    )}
+  </li>
+);
+
+const diagnosticKey = (diagnostic: LintDiagnostic, index: number): string =>
+  [
+    diagnostic.line?.toString() ?? '',
+    diagnostic.column?.toString() ?? '',
+    diagnostic.code ?? '',
+    index.toString(),
+  ].join('-');
+
+const ListBody: FC<Omit<Props, 'isLinting'>> = ({
+  diagnostics,
+  errorMessage,
+}) => {
+  if (errorMessage !== null) {
+    return <Alert message={errorMessage} tone="error" />;
+  }
+  if (diagnostics === null) {
+    return (
+      <p className="text-fg-mute text-sm">
+        コードを入力すると、自動で検査結果が表示されます。
+      </p>
+    );
+  }
+  if (diagnostics.length === 0) {
+    return <Alert message="問題は見つかりませんでした" tone="success" />;
+  }
+  return (
+    <ul className="flex flex-col gap-3">
+      {diagnostics.map((diagnostic, index) => (
+        <DiagnosticItem
+          diagnostic={diagnostic}
+          key={diagnosticKey(diagnostic, index)}
+        />
+      ))}
+    </ul>
+  );
+};
+
+export const DiagnosticList: FC<Props> = ({
+  diagnostics,
+  isLinting,
+  errorMessage,
+}) => {
+  const errorCount =
+    diagnostics?.filter((d) => d.severity === 'error').length ?? 0;
+  const warningCount =
+    diagnostics?.filter((d) => d.severity === 'warning').length ?? 0;
+  const totalCount = errorCount + warningCount;
+
+  return (
+    <section className="flex flex-col gap-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <Heading type="h3">検査結果</Heading>
+        {totalCount > 0 ? (
+          <span className="text-fg-mute text-sm">
+            {`error ${errorCount.toString()} / warning ${warningCount.toString()}`}
+          </span>
+        ) : null}
+        {isLinting ? <Spinner label="検査中" size="sm" /> : null}
+      </div>
+      <ListBody diagnostics={diagnostics} errorMessage={errorMessage} />
+    </section>
+  );
+};

--- a/apps/main/src/app/code-dock/_components/diagnostic-list/index.ts
+++ b/apps/main/src/app/code-dock/_components/diagnostic-list/index.ts
@@ -1,0 +1,1 @@
+export { DiagnosticList } from './diagnostic-list';

--- a/apps/main/src/app/code-dock/layout.tsx
+++ b/apps/main/src/app/code-dock/layout.tsx
@@ -1,0 +1,35 @@
+import { Heading } from '@k8o/arte-odyssey';
+import type { Metadata } from 'next';
+
+const TITLE = 'コードドック';
+const DESCRIPTION =
+  'JavaScript/TypeScriptのコードをoxlintで検査し、oxfmtで整形します。';
+
+export const metadata = {
+  title: TITLE,
+  description: DESCRIPTION,
+  openGraph: {
+    title: TITLE,
+    description: DESCRIPTION,
+    url: 'https://k8o.me/code-dock',
+    siteName: 'k8o',
+    locale: 'ja',
+    type: 'website',
+  },
+  twitter: {
+    title: TITLE,
+    card: 'summary',
+    description: DESCRIPTION,
+  },
+} satisfies Metadata;
+
+export default function Layout({ children }: LayoutProps<'/code-dock'>) {
+  return (
+    <div className="mx-auto w-full max-w-5xl">
+      <div className="flex h-full flex-col gap-4">
+        <Heading type="h2">{TITLE}</Heading>
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/apps/main/src/app/code-dock/opengraph-image.tsx
+++ b/apps/main/src/app/code-dock/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { OgImage } from '@/app/_components/og-image';
+
+export const alt = 'コードドック';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default function OpenGraphImage() {
+  return OgImage({ title: 'コードドック' });
+}

--- a/apps/main/src/app/code-dock/page.tsx
+++ b/apps/main/src/app/code-dock/page.tsx
@@ -1,0 +1,15 @@
+import { formatCode, lintCode } from '@/features/code-dock/interface/actions';
+
+import { CodeDock } from './_components/code-dock';
+
+export default function CodeDockPage() {
+  return (
+    <section className="flex flex-col gap-6 py-10">
+      <p className="text-sm">
+        このサイトと同じoxcの設定 (oxlint / oxfmt)
+        で、入力したコードの検査と整形を試せます。
+      </p>
+      <CodeDock formatAction={formatCode} lintAction={lintCode} />
+    </section>
+  );
+}

--- a/apps/main/src/features/code-dock/application/diagnostics.test.ts
+++ b/apps/main/src/features/code-dock/application/diagnostics.test.ts
@@ -1,0 +1,123 @@
+import type { OxlintRawOutput } from '../infrastructure/oxlint-runner';
+import { toLintDiagnostics } from './diagnostics';
+
+const rawDiagnostic = (
+  overrides: Partial<OxlintRawOutput['diagnostics'][number]>,
+): OxlintRawOutput['diagnostics'][number] => ({
+  code: 'eslint(no-var)',
+  labels: [{ span: { column: 1, line: 1 } }],
+  message: 'Unexpected var, use let or const instead.',
+  severity: 'error',
+  ...overrides,
+});
+
+describe('toLintDiagnostics', () => {
+  describe('正常系', () => {
+    it('oxlintの生JSONをドメイン型へ変換する', () => {
+      const raw: OxlintRawOutput = {
+        diagnostics: [
+          rawDiagnostic({
+            help: 'Replace var with let or const',
+            labels: [{ span: { column: 5, line: 3 } }],
+            url: 'https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-var.html',
+          }),
+        ],
+      };
+
+      expect(toLintDiagnostics(raw)).toEqual([
+        {
+          code: 'eslint(no-var)',
+          column: 5,
+          help: 'Replace var with let or const',
+          line: 3,
+          message: 'Unexpected var, use let or const instead.',
+          severity: 'error',
+          url: 'https://oxc.rs/docs/guide/usage/linter/rules/eslint/no-var.html',
+        },
+      ]);
+    });
+
+    it('行→列の順でソートする', () => {
+      const raw: OxlintRawOutput = {
+        diagnostics: [
+          rawDiagnostic({ labels: [{ span: { column: 9, line: 2 } }] }),
+          rawDiagnostic({ labels: [{ span: { column: 1, line: 10 } }] }),
+          rawDiagnostic({ labels: [{ span: { column: 2, line: 2 } }] }),
+        ],
+      };
+
+      expect(
+        toLintDiagnostics(raw).map(({ column, line }) => [line, column]),
+      ).toEqual([
+        [2, 2],
+        [2, 9],
+        [10, 1],
+      ]);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('labelsが空でも位置をnullとして変換する', () => {
+      const raw: OxlintRawOutput = {
+        diagnostics: [rawDiagnostic({ labels: [] })],
+      };
+
+      const [diagnostic] = toLintDiagnostics(raw);
+      expect(diagnostic?.line).toBeNull();
+      expect(diagnostic?.column).toBeNull();
+    });
+
+    it('位置なしの診断は末尾に並ぶ', () => {
+      const raw: OxlintRawOutput = {
+        diagnostics: [
+          rawDiagnostic({ labels: [] }),
+          rawDiagnostic({ labels: [{ span: { column: 1, line: 1 } }] }),
+        ],
+      };
+
+      expect(toLintDiagnostics(raw).map(({ line }) => line)).toEqual([1, null]);
+    });
+
+    it('code/url/help/labelsがフィールドごと欠けていてもnullに正規化する', () => {
+      // reportUnusedDisableDirectives の「Unused disable directive」診断の実形式
+      const raw: OxlintRawOutput = {
+        diagnostics: [
+          {
+            message:
+              'Unused oxlint-disable directive (no problems were reported).',
+            severity: 'error',
+          },
+        ],
+      };
+
+      expect(toLintDiagnostics(raw)).toEqual([
+        {
+          code: null,
+          column: null,
+          help: null,
+          line: null,
+          message:
+            'Unused oxlint-disable directive (no problems were reported).',
+          severity: 'error',
+          url: null,
+        },
+      ]);
+    });
+
+    it('空文字のコードはnullに正規化する', () => {
+      const raw: OxlintRawOutput = {
+        diagnostics: [rawDiagnostic({ code: '' })],
+      };
+
+      expect(toLintDiagnostics(raw)[0]?.code).toBeNull();
+    });
+
+    it('未知のseverityはerrorへ倒す', () => {
+      const raw: OxlintRawOutput = {
+        diagnostics: [rawDiagnostic({ severity: 'advice' })],
+      };
+
+      expect(toLintDiagnostics(raw)[0]?.severity).toBe('error');
+    });
+  });
+});

--- a/apps/main/src/features/code-dock/application/diagnostics.ts
+++ b/apps/main/src/features/code-dock/application/diagnostics.ts
@@ -1,0 +1,44 @@
+import type {
+  OxlintRawDiagnostic,
+  OxlintRawOutput,
+} from '../infrastructure/oxlint-runner';
+
+type LintSeverity = 'error' | 'warning';
+
+export type LintDiagnostic = {
+  message: string;
+  /** 'eslint(no-var)' のようなルールコード。構文エラー等では null */
+  code: string | null;
+  severity: LintSeverity;
+  /** ルールドキュメントの URL */
+  url: string | null;
+  help: string | null;
+  /** 1 始まり。位置情報が無い診断では null */
+  line: number | null;
+  column: number | null;
+};
+
+const toDiagnostic = (raw: OxlintRawDiagnostic): LintDiagnostic => {
+  const span = raw.labels?.[0]?.span;
+  return {
+    message: raw.message ?? '',
+    code: raw.code === undefined || raw.code === '' ? null : raw.code,
+    severity: raw.severity === 'warning' ? 'warning' : 'error',
+    url: raw.url ?? null,
+    help: raw.help ?? null,
+    line: span?.line ?? null,
+    column: span?.column ?? null,
+  };
+};
+
+const positionOrder = (diagnostic: LintDiagnostic): [number, number] => [
+  diagnostic.line ?? Number.MAX_SAFE_INTEGER,
+  diagnostic.column ?? Number.MAX_SAFE_INTEGER,
+];
+
+export const toLintDiagnostics = (raw: OxlintRawOutput): LintDiagnostic[] =>
+  raw.diagnostics.map(toDiagnostic).toSorted((a, b) => {
+    const [aLine, aColumn] = positionOrder(a);
+    const [bLine, bColumn] = positionOrder(b);
+    return aLine === bLine ? aColumn - bColumn : aLine - bLine;
+  });

--- a/apps/main/src/features/code-dock/application/format-source.test.ts
+++ b/apps/main/src/features/code-dock/application/format-source.test.ts
@@ -1,0 +1,55 @@
+import { formatSource } from './format-source';
+
+// oxfmt の NAPI バインディングを直接呼ぶ統合テスト
+describe('formatSource', () => {
+  describe('正常系', () => {
+    it('ダブルクォートをシングルクォートへ整形する', async () => {
+      const result = await formatSource('const a = "b"\n', 'ts');
+
+      expect(result).toEqual({ code: "const a = 'b';\n", ok: true });
+    });
+
+    it('import宣言をモジュール名でソートする', async () => {
+      const result = await formatSource(
+        [
+          "import { z } from 'zebra';",
+          "import { a } from 'alpha';",
+          'export const x = [z, a];',
+          '',
+        ].join('\n'),
+        'ts',
+      );
+
+      expect(result).toEqual({
+        code: [
+          "import { a } from 'alpha';",
+          "import { z } from 'zebra';",
+          'export const x = [z, a];',
+          '',
+        ].join('\n'),
+        ok: true,
+      });
+    });
+
+    it('tsxのJSXを整形できる', async () => {
+      const result = await formatSource(
+        'export const App = () => <output>ok</output>\n',
+        'tsx',
+      );
+
+      expect(result).toEqual({
+        code: 'export const App = () => <output>ok</output>;\n',
+        ok: true,
+      });
+    });
+  });
+
+  describe('異常系', () => {
+    it('構文エラーではメッセージを返す', async () => {
+      const result = await formatSource('const = ;\n', 'ts');
+
+      expect(result.ok).toBe(false);
+      expect(result).toHaveProperty('message');
+    });
+  });
+});

--- a/apps/main/src/features/code-dock/application/format-source.ts
+++ b/apps/main/src/features/code-dock/application/format-source.ts
@@ -1,0 +1,18 @@
+import { runOxfmt } from '../infrastructure/oxfmt-runner';
+import type { LintLanguage } from './language';
+
+export type FormatSourceResult =
+  | { ok: true; code: string }
+  | { ok: false; message: string };
+
+export const formatSource = async (
+  code: string,
+  language: LintLanguage,
+): Promise<FormatSourceResult> => {
+  const result = await runOxfmt(code, `input.${language}`);
+  const firstError = result.errors[0];
+  if (firstError) {
+    return { message: firstError.message, ok: false };
+  }
+  return { code: result.code, ok: true };
+};

--- a/apps/main/src/features/code-dock/application/language.ts
+++ b/apps/main/src/features/code-dock/application/language.ts
@@ -1,0 +1,9 @@
+export const LINT_LANGUAGES = ['ts', 'tsx', 'js', 'jsx'] as const;
+
+export type LintLanguage = (typeof LINT_LANGUAGES)[number];
+
+export const isLintLanguage = (value: string): value is LintLanguage =>
+  (LINT_LANGUAGES as readonly string[]).includes(value);
+
+// 認証なしの公開エンドポイントのため、CPU 濫用を防ぐ入力上限 (100KB)
+export const MAX_CODE_LENGTH = 100_000;

--- a/apps/main/src/features/code-dock/application/lint-source.test.ts
+++ b/apps/main/src/features/code-dock/application/lint-source.test.ts
@@ -1,0 +1,69 @@
+import { lintSource } from './lint-source';
+
+// oxlint の実バイナリを子プロセスで起動する統合テスト
+describe('lintSource', () => {
+  describe('正常系', () => {
+    it('no-var違反をルールコード・位置つきで検出する', async () => {
+      const diagnostics = await lintSource('var x = 1;\n', 'ts');
+
+      const noVar = diagnostics.find((d) => d.code === 'eslint(no-var)');
+      expect(noVar).toBeDefined();
+      expect(noVar?.severity).toBe('error');
+      expect(noVar?.line).toBe(1);
+    });
+
+    it('問題のないコードでは空配列を返す', async () => {
+      const diagnostics = await lintSource('export const answer = 42;\n', 'ts');
+
+      expect(diagnostics).toEqual([]);
+    });
+
+    it('tsxではJSXを解釈できる', async () => {
+      const diagnostics = await lintSource(
+        'export const App = () => <output>ok</output>;\n',
+        'tsx',
+      );
+
+      expect(diagnostics).toEqual([]);
+    });
+
+    it('no-consoleはwarningとして返る', async () => {
+      const diagnostics = await lintSource("console.log('hi');\n", 'ts');
+
+      const noConsole = diagnostics.find(
+        (d) => d.code === 'eslint(no-console)',
+      );
+      expect(noConsole?.severity).toBe('warning');
+    });
+  });
+
+  describe('異常系', () => {
+    it('構文エラーも診断として返す', async () => {
+      const diagnostics = await lintSource('const = ;\n', 'ts');
+
+      expect(diagnostics.length).toBeGreaterThan(0);
+      expect(diagnostics[0]?.severity).toBe('error');
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('未使用のdisableディレクティブはコード無しの診断として返る', async () => {
+      const diagnostics = await lintSource(
+        '// oxlint-disable-next-line no-var\nexport const a = 1;\n',
+        'ts',
+      );
+
+      expect(diagnostics).toHaveLength(1);
+      expect(diagnostics[0]?.code).toBeNull();
+      expect(diagnostics[0]?.message).toContain('Unused');
+    });
+
+    it('空文字はno-empty-fileの診断になる', async () => {
+      const diagnostics = await lintSource('', 'ts');
+
+      expect(diagnostics.map((d) => d.code)).toEqual([
+        'unicorn(no-empty-file)',
+      ]);
+    });
+  });
+});

--- a/apps/main/src/features/code-dock/application/lint-source.ts
+++ b/apps/main/src/features/code-dock/application/lint-source.ts
@@ -1,0 +1,16 @@
+import { runOxlint } from '../infrastructure/oxlint-runner';
+import { toLintDiagnostics } from './diagnostics';
+import type { LintDiagnostic } from './diagnostics';
+import type { LintLanguage } from './language';
+import { buildOxlintrc } from './oxlintrc';
+
+// 設定は不変なのでモジュール読み込み時に一度だけ直列化する
+const OXLINTRC_JSON = JSON.stringify(buildOxlintrc());
+
+export const lintSource = async (
+  code: string,
+  language: LintLanguage,
+): Promise<LintDiagnostic[]> => {
+  const raw = await runOxlint(code, `input.${language}`, OXLINTRC_JSON);
+  return toLintDiagnostics(raw);
+};

--- a/apps/main/src/features/code-dock/application/oxlintrc.test.ts
+++ b/apps/main/src/features/code-dock/application/oxlintrc.test.ts
@@ -1,0 +1,70 @@
+import { buildOxlintrc } from './oxlintrc';
+
+describe('buildOxlintrc', () => {
+  describe('正常系', () => {
+    it('extendsチェーン (base→typescript→react→nextjs) の4層がマージされる', () => {
+      const rc = buildOxlintrc();
+
+      expect(rc.plugins).toEqual([
+        'eslint',
+        'oxc',
+        'unicorn',
+        'import',
+        'promise',
+        'typescript',
+        'react',
+        'jsx-a11y',
+        'react-perf',
+        'nextjs',
+      ]);
+      expect(rc.categories?.correctness).toBe('error');
+      expect(rc.categories?.style).toBe('off');
+      // 各層を代表するルールが1つのrulesに揃っていること
+      expect(rc.rules?.eqeqeq).toEqual(['error', 'always']);
+      expect(rc.rules?.['typescript/consistent-type-definitions']).toEqual([
+        'error',
+        'type',
+      ]);
+      expect(rc.rules?.['react/rules-of-hooks']).toBe('error');
+      expect(rc.rules?.['nextjs/no-img-element']).toBe('warn');
+    });
+
+    it('vite.config.tsと同じ上書きが反映される', () => {
+      const rc = buildOxlintrc();
+
+      expect(rc.rules?.['import/no-unassigned-import']).toEqual([
+        'error',
+        { allow: ['**/*.css', '@/libs/zod', 'react', 'server-only'] },
+      ]);
+      expect(rc.rules?.['no-underscore-dangle']).toBe('off');
+      expect(rc.options).toEqual({ reportUnusedDisableDirectives: 'error' });
+      expect(rc.settings?.react).toEqual({ version: '19.2.7' });
+    });
+
+    it('JSONへそのまま直列化できる', () => {
+      const rc = buildOxlintrc();
+
+      expect(JSON.parse(JSON.stringify(rc))).toEqual(rc);
+    });
+  });
+
+  describe('エッジケース (Webツールでは再現しない設定)', () => {
+    it('extendsを含まない', () => {
+      expect(buildOxlintrc()).not.toHaveProperty('extends');
+    });
+
+    it('typeAwareを含まない', () => {
+      expect(buildOxlintrc().options).not.toHaveProperty('typeAware');
+    });
+
+    it('tailwindのJSプラグインとルールを含まない', () => {
+      const { rules = {}, ...rc } = buildOxlintrc();
+
+      expect(rc).not.toHaveProperty('jsPlugins');
+      const tailwindRules = Object.keys(rules).filter((rule) =>
+        rule.startsWith('tailwindcss/'),
+      );
+      expect(tailwindRules).toEqual([]);
+    });
+  });
+});

--- a/apps/main/src/features/code-dock/application/oxlintrc.ts
+++ b/apps/main/src/features/code-dock/application/oxlintrc.ts
@@ -1,0 +1,68 @@
+import { nextjs } from '@k8o/oxc-config';
+import type { OxlintConfig } from 'oxlint';
+
+// vite.config.ts の settings.react.version と揃えて更新する。
+// react の version 実行時参照は Next のサーバーバンドルだと canary 表記になり
+// (例: 19.2.0-canary-xxx)、oxlint が設定として受け付けないため使えない
+const REACT_VERSION = '19.2.7';
+
+// .oxlintrc.json にそのまま書ける形 (extends 解決済み・直列化可能なキーのみ)
+export type FlatOxlintrc = Pick<
+  OxlintConfig,
+  'categories' | 'options' | 'plugins' | 'rules' | 'settings'
+>;
+
+const mergeInto = (target: FlatOxlintrc, source: OxlintConfig): void => {
+  if (source.plugins) {
+    // oxlint は plugins をマージではなく置換で扱うため、後勝ちで丸ごと差し替える
+    target.plugins = [...source.plugins];
+  }
+  if (source.categories) {
+    target.categories = { ...target.categories, ...source.categories };
+  }
+  if (source.rules) {
+    target.rules = { ...target.rules, ...source.rules };
+  }
+  if (source.settings) {
+    target.settings = { ...target.settings, ...source.settings };
+  }
+};
+
+const flattenInto = (target: FlatOxlintrc, config: OxlintConfig): void => {
+  for (const parent of config.extends ?? []) {
+    flattenInto(target, parent);
+  }
+  mergeInto(target, config);
+};
+
+/**
+ * リポジトリの vite.config.ts と同等の lint 設定を、oxlint CLI に渡せる
+ * 単一の .oxlintrc.json 相当へフラット化する。
+ *
+ * vite.config.ts との差分 (Web ツールでは再現しないもの):
+ * - tailwind プリセット: JS プラグイン (oxlint-tailwindcss) の実行環境が必要
+ * - typeAware: 型情報 lint は tsgolint バイナリと tsconfig が必要。
+ *   type-aware ルールが rules に残っても oxlint は黙ってスキップする
+ * - settings.next.rootDir / test・d.ts の overrides: 単一の入力ファイルには無関係
+ */
+export const buildOxlintrc = (): FlatOxlintrc => {
+  const flattened: FlatOxlintrc = {};
+  flattenInto(flattened, nextjs);
+  return {
+    ...flattened,
+    options: { reportUnusedDisableDirectives: 'error' },
+    settings: {
+      ...flattened.settings,
+      react: { version: REACT_VERSION },
+    },
+    rules: {
+      ...flattened.rules,
+      // 以下は vite.config.ts の rules 上書きと揃える
+      'import/no-unassigned-import': [
+        'error',
+        { allow: ['**/*.css', '@/libs/zod', 'react', 'server-only'] },
+      ],
+      'no-underscore-dangle': 'off',
+    },
+  };
+};

--- a/apps/main/src/features/code-dock/infrastructure/oxfmt-runner.ts
+++ b/apps/main/src/features/code-dock/infrastructure/oxfmt-runner.ts
@@ -1,0 +1,15 @@
+import 'server-only';
+import { fmt } from '@k8o/oxc-config';
+import { format } from 'oxfmt';
+
+export type OxfmtResult = Awaited<ReturnType<typeof format>>;
+
+// format() の options (FormatConfig) には設定ファイル専用キーが無いため取り除く
+const fmtOptions = { ...fmt };
+delete fmtOptions.ignorePatterns;
+delete fmtOptions.overrides;
+
+export const runOxfmt = (
+  code: string,
+  fileName: string,
+): Promise<OxfmtResult> => format(fileName, code, fmtOptions);

--- a/apps/main/src/features/code-dock/infrastructure/oxlint-runner.ts
+++ b/apps/main/src/features/code-dock/infrastructure/oxlint-runner.ts
@@ -1,0 +1,115 @@
+import 'server-only';
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+
+// code / url / help は診断によってはフィールドごと欠ける
+// (例: reportUnusedDisableDirectives の「Unused disable directive」)
+export type OxlintRawDiagnostic = {
+  message?: string;
+  code?: string;
+  severity?: string;
+  url?: string;
+  help?: string;
+  labels?: Array<{ span?: { line?: number; column?: number } }>;
+};
+
+export type OxlintRawOutput = {
+  diagnostics: OxlintRawDiagnostic[];
+};
+
+// oxlint の bin は exports マップに無く、Turbopack は require.resolve を
+// 静的解決して仮想モジュールIDへ書き換えてしまうため、require には頼らず
+// cwd から node_modules を上方向に探してパスを解決する
+const findOxlintBin = (dir: string): string => {
+  const candidate = join(dir, 'node_modules', 'oxlint', 'bin', 'oxlint');
+  if (existsSync(candidate)) {
+    return candidate;
+  }
+  const parent = dirname(dir);
+  if (parent === dir) {
+    throw new Error('oxlint の実行ファイルが見つかりませんでした');
+  }
+  return findOxlintBin(parent);
+};
+
+const OXLINT_BIN = findOxlintBin(process.cwd());
+
+const EXEC_TIMEOUT_MS = 10_000;
+const MAX_STDOUT_BYTES = 10 * 1024 * 1024;
+
+const execOxlint = (
+  configPath: string,
+  inputPath: string,
+  cwd: string,
+): Promise<string> =>
+  new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      [
+        OXLINT_BIN,
+        '-c',
+        configPath,
+        '-f',
+        'json',
+        '--no-ignore',
+        '--disable-nested-config',
+        inputPath,
+      ],
+      { cwd, maxBuffer: MAX_STDOUT_BYTES, timeout: EXEC_TIMEOUT_MS },
+      (error, stdout) => {
+        if (error === null) {
+          resolve(stdout);
+          return;
+        }
+        // 診断が 1 件でもあると exit code 1 になるため、stdout があれば正常系として扱う
+        if (error.code === 1 && stdout !== '') {
+          resolve(stdout);
+          return;
+        }
+        reject(
+          error instanceof Error ? error : new Error('oxlint の実行に失敗'),
+        );
+      },
+    );
+  });
+
+const parseOutput = (stdout: string): OxlintRawOutput => {
+  if (!stdout.trimStart().startsWith('{')) {
+    throw new Error(
+      `oxlint の出力を解釈できませんでした: ${stdout.slice(0, 500)}`,
+    );
+  }
+  const parsed: unknown = JSON.parse(stdout);
+  if (
+    typeof parsed === 'object' &&
+    parsed !== null &&
+    Array.isArray((parsed as { diagnostics?: unknown }).diagnostics)
+  ) {
+    return parsed as OxlintRawOutput;
+  }
+  throw new Error('oxlint の出力を解釈できませんでした');
+};
+
+export const runOxlint = async (
+  code: string,
+  fileName: string,
+  oxlintrcJson: string,
+): Promise<OxlintRawOutput> => {
+  // リクエストごとに専用ディレクトリを作るため、同時実行しても衝突しない
+  const tempDir = await mkdtemp(join(tmpdir(), 'code-dock-'));
+  try {
+    const configPath = join(tempDir, '.oxlintrc.json');
+    const inputPath = join(tempDir, fileName);
+    await Promise.all([
+      writeFile(configPath, oxlintrcJson, 'utf8'),
+      writeFile(inputPath, code, 'utf8'),
+    ]);
+    const stdout = await execOxlint(configPath, inputPath, tempDir);
+    return parseOutput(stdout);
+  } finally {
+    await rm(tempDir, { force: true, recursive: true });
+  }
+};

--- a/apps/main/src/features/code-dock/interface/actions.ts
+++ b/apps/main/src/features/code-dock/interface/actions.ts
@@ -1,0 +1,72 @@
+'use server';
+
+import * as z from 'zod/mini';
+
+import { configureZod } from '@/shared/validation/zod';
+
+import type { LintDiagnostic } from '../application/diagnostics';
+import { formatSource } from '../application/format-source';
+import { LINT_LANGUAGES, MAX_CODE_LENGTH } from '../application/language';
+import { lintSource } from '../application/lint-source';
+
+configureZod();
+
+const codeDockSchema = z.object({
+  code: z.string().check(z.maxLength(MAX_CODE_LENGTH)),
+  language: z.enum(LINT_LANGUAGES),
+});
+
+export type LintCodeResult =
+  | { diagnostics: LintDiagnostic[]; error?: never }
+  | { diagnostics?: never; error: string };
+
+export type FormatCodeResult =
+  | { code: string; error?: never }
+  | { code?: never; error: string };
+
+export const lintCode = async (
+  code: string,
+  language: string,
+): Promise<LintCodeResult> => {
+  const validated = codeDockSchema.safeParse({ code, language });
+  if (!validated.success) {
+    return {
+      error: validated.error.issues[0]?.message ?? '入力が不正です',
+    };
+  }
+  try {
+    const diagnostics = await lintSource(
+      validated.data.code,
+      validated.data.language,
+    );
+    return { diagnostics };
+  } catch (error) {
+    console.error('lintCode failed:', error);
+    return { error: 'コードの検査に失敗しました' };
+  }
+};
+
+export const formatCode = async (
+  code: string,
+  language: string,
+): Promise<FormatCodeResult> => {
+  const validated = codeDockSchema.safeParse({ code, language });
+  if (!validated.success) {
+    return {
+      error: validated.error.issues[0]?.message ?? '入力が不正です',
+    };
+  }
+  try {
+    const result = await formatSource(
+      validated.data.code,
+      validated.data.language,
+    );
+    if (!result.ok) {
+      return { error: `整形できませんでした: ${result.message}` };
+    }
+    return { code: result.code };
+  } catch (error) {
+    console.error('formatCode failed:', error);
+    return { error: 'コードの整形に失敗しました' };
+  }
+};

--- a/apps/main/src/features/code-dock/interface/types.ts
+++ b/apps/main/src/features/code-dock/interface/types.ts
@@ -1,0 +1,6 @@
+// 'use server' ファイル (actions.ts) からは async 関数以外を export できないため、
+// app 層へ公開する定数・型はここから再エクスポートする
+export { isLintLanguage } from '../application/language';
+export type { LintLanguage } from '../application/language';
+export type { LintDiagnostic } from '../application/diagnostics';
+export type { FormatCodeResult, LintCodeResult } from './actions';

--- a/apps/main/src/mocks/empty.ts
+++ b/apps/main/src/mocks/empty.ts
@@ -1,0 +1,3 @@
+// vitest の resolve.alias で 'server-only' を無効化するためのスタブ。
+// ファイルを空にすると unicorn/no-empty-file に検出されるためダミーの export を置く
+export const serverOnlyStub = true;

--- a/apps/main/src/shared/site/site-entries.ts
+++ b/apps/main/src/shared/site/site-entries.ts
@@ -11,6 +11,7 @@ export type SiteEntryIcon =
   | 'paletteMaker'
   | 'mojiCount'
   | 'htmlNest'
+  | 'codeDock'
   | 'fluida'
   | 'blog'
   | 'talks'
@@ -104,6 +105,14 @@ const entries: readonly SiteEntry[] = [
       'HTMLタグを選ぶと、親に置ける要素と中に入れられる子要素が浮かび上がります。',
     kind: 'tool',
     icon: 'htmlNest',
+  },
+  {
+    title: 'コードドック',
+    link: '/code-dock',
+    description:
+      'JavaScript/TypeScriptのコードをoxlintで検査し、oxfmtで整形します。',
+    kind: 'tool',
+    icon: 'codeDock',
   },
   {
     title: 'fluida',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -382,6 +382,9 @@ importers:
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
         version: 10.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ai@7.0.4(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.1)(typescript@6.0.3)(zod@4.4.3)
+      '@k8o/oxc-config':
+        specifier: 0.1.3
+        version: 0.1.3(oxfmt@0.55.0(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)))(oxlint-tailwindcss@1.3.3)(oxlint@1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)))
       '@mdx-js/loader':
         specifier: 3.1.1
         version: 3.1.1
@@ -436,6 +439,12 @@ importers:
       nuqs:
         specifier: 2.8.9
         version: 2.8.9(next@16.2.9(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      oxfmt:
+        specifier: 0.55.0
+        version: 0.55.0(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint:
+        specifier: 1.70.0
+        version: 1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0))
       postcss:
         specifier: 'catalog:'
         version: 8.5.16
@@ -7976,6 +7985,12 @@ snapshots:
     transitivePeerDependencies:
       - '@emotion/is-prop-valid'
 
+  '@k8o/oxc-config@0.1.3(oxfmt@0.55.0(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)))(oxlint-tailwindcss@1.3.3)(oxlint@1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)))':
+    optionalDependencies:
+      oxfmt: 0.55.0(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint-tailwindcss: 1.3.3
+
   '@k8o/oxc-config@0.1.3(oxfmt@0.55.0(vite-plus@0.2.1(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)))(oxlint-tailwindcss@1.3.3)(oxlint@1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)))':
     optionalDependencies:
       oxfmt: 0.55.0(vite-plus@0.2.1(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0))
@@ -11903,6 +11918,31 @@ snapshots:
       vite-plus: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
     optional: true
 
+  oxfmt@0.55.0(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)):
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.55.0
+      '@oxfmt/binding-android-arm64': 0.55.0
+      '@oxfmt/binding-darwin-arm64': 0.55.0
+      '@oxfmt/binding-darwin-x64': 0.55.0
+      '@oxfmt/binding-freebsd-x64': 0.55.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.55.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.55.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.55.0
+      '@oxfmt/binding-linux-arm64-musl': 0.55.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.55.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.55.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.55.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.55.0
+      '@oxfmt/binding-linux-x64-gnu': 0.55.0
+      '@oxfmt/binding-linux-x64-musl': 0.55.0
+      '@oxfmt/binding-openharmony-arm64': 0.55.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.55.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.55.0
+      '@oxfmt/binding-win32-x64-msvc': 0.55.0
+      vite-plus: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
+
   oxfmt@0.55.0(vite-plus@0.2.1(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)):
     dependencies:
       tinypool: 2.1.0
@@ -11996,6 +12036,30 @@ snapshots:
       oxlint-tsgolint: 0.23.0
       vite-plus: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
     optional: true
+
+  oxlint@1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.70.0
+      '@oxlint/binding-android-arm64': 1.70.0
+      '@oxlint/binding-darwin-arm64': 1.70.0
+      '@oxlint/binding-darwin-x64': 1.70.0
+      '@oxlint/binding-freebsd-x64': 1.70.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.70.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.70.0
+      '@oxlint/binding-linux-arm64-gnu': 1.70.0
+      '@oxlint/binding-linux-arm64-musl': 1.70.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.70.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.70.0
+      '@oxlint/binding-linux-riscv64-musl': 1.70.0
+      '@oxlint/binding-linux-s390x-gnu': 1.70.0
+      '@oxlint/binding-linux-x64-gnu': 1.70.0
+      '@oxlint/binding-linux-x64-musl': 1.70.0
+      '@oxlint/binding-openharmony-arm64': 1.70.0
+      '@oxlint/binding-win32-arm64-msvc': 1.70.0
+      '@oxlint/binding-win32-ia32-msvc': 1.70.0
+      '@oxlint/binding-win32-x64-msvc': 1.70.0
+      oxlint-tsgolint: 0.23.0
+      vite-plus: 0.1.24(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
 
   oxlint@1.70.0(oxlint-tsgolint@0.23.0)(vite-plus@0.2.1(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)):
     optionalDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -563,6 +563,10 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/browser-preview@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+    optionalDependencies:
+      '@oxlint/binding-linux-x64-gnu':
+        specifier: 1.70.0
+        version: 1.70.0
 
   packages/code-highlight:
     dependencies:
@@ -4862,8 +4866,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.5.8:
-    resolution: {integrity: sha512-Vq9D2x4dAIW24zcH55DTrl3/vi13UNKfXgw0yj7ULTssZ6KOdw/oyBHtlvE94KFC9yYEhgFTrGjaqqZKvV9pwA==}
+  deslop-js@0.6.2:
+    resolution: {integrity: sha512-3+wV56jJd4zx6Mob2nQ4B8nIF4J12Xc2iCagNE9kdVTzMbNEIe99vwfaxrgdFC+RQ1NHXfjUkR3C4HVYnLLSfg==}
 
   detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
@@ -6143,8 +6147,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-plugin-react-doctor@0.5.8:
-    resolution: {integrity: sha512-L0jveKAMbqF1qAqA2Ksu8aH0/Q8FDQxLwXmHYgALa2XlsxEUuamJ+1Da2MhPWJ2ahn+ekFbnWK20qixxD+fw6A==}
+  oxlint-plugin-react-doctor@0.6.2:
+    resolution: {integrity: sha512-8+YU8hwSPmS2dglPxLGRTSpaSHA5A2L0x7zU/7G+dp9V779jrpHiYMhJ5Ga9JUa0VtECHfpY+xUOYSt1IEP3YA==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tailwindcss@1.3.3:
@@ -6342,8 +6346,8 @@ packages:
     resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
     engines: {node: ^20.9.0 || >=22}
 
-  react-doctor@0.5.8:
-    resolution: {integrity: sha512-gDXDQ+48KeFq2jkVgsUhQ67oQ+kUMdnIaA+YeS9VXXZFXSg9wxY5dDxurEpILSh8RwO06W8p6uCnTR+wn5B/GA==}
+  react-doctor@0.6.2:
+    resolution: {integrity: sha512-uPFyoWhRvAG6vc7uLVbf2wg7ox0R8y+SgOAhAfAcs1soP4sIPwl4gEuWCNbAir/QIGcb5xrwFJvCM30WmgmeUg==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -6849,6 +6853,11 @@ packages:
   type-fest@5.6.0:
     resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
     engines: {node: '>=20'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
 
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
@@ -10256,14 +10265,14 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.5.8:
+  deslop-js@0.6.2:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
       minimatch: 10.2.5
       oxc-parser: 0.132.0
       oxc-resolver: 11.21.3
-      typescript: 6.0.3
+      typescript: 5.9.3
 
   detect-libc@2.0.2: {}
 
@@ -11968,7 +11977,7 @@ snapshots:
       '@oxfmt/binding-win32-x64-msvc': 0.55.0
       vite-plus: 0.2.1(@opentelemetry/api@1.9.1)(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(@vitest/ui@4.1.9)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.14.6(@types/node@24.13.2)(typescript@6.0.3))(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
 
-  oxlint-plugin-react-doctor@0.5.8:
+  oxlint-plugin-react-doctor@0.6.2:
     dependencies:
       '@typescript-eslint/types': 8.60.0
       eslint-scope: 9.1.2
@@ -12221,24 +12230,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-doctor@0.5.8(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0):
+  react-doctor@0.6.2(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.55.0
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.5.8
+      deslop-js: 0.6.2
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0(oxlint-tsgolint@0.23.0)
-      oxlint-plugin-react-doctor: 0.5.8
+      oxlint-plugin-react-doctor: 0.6.2
       prompts: 2.4.2
-      typescript: 6.0.3
+      typescript: 5.9.3
       vscode-languageserver: 9.0.1
       vscode-languageserver-textdocument: 1.0.12
       vscode-uri: 3.1.0
+      yaml: 2.9.0
     transitivePeerDependencies:
       - '@opentelemetry/exporter-trace-otlp-http'
       - eslint
@@ -12289,7 +12299,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.5.8(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)
+      react-doctor: 0.6.2(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.23.0)
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.47(react@19.2.7)
     optionalDependencies:
@@ -12845,6 +12855,8 @@ snapshots:
   type-fest@5.6.0:
     dependencies:
       tagged-tag: 1.0.0
+
+  typescript@5.9.3: {}
 
   typescript@6.0.3: {}
 


### PR DESCRIPTION
## 概要

このサイトと同じ oxc 設定 (oxlint / oxfmt、`@k8o/oxc-config` の nextjs プリセット) で、入力したコードの検査と整形を試せる公開ツール **コードドック** (`/code-dock`) を追加します。

- 入力中のシンタックスハイライト (shiki、テーマ追従: light は one-light / dark は plastic)
- 600ms デバウンスの自動 lint (診断は severity バッジ・位置・ルール docs リンク・help つきで一覧表示)
- oxfmt での整形 (Cmd+Z で整形前に戻せる)、コピー、言語切替 (ts / tsx / js / jsx)

## 実装

- **lint**: `@k8o/oxc-config` の `nextjs` プリセット (extends 4層) をフラット化して `.oxlintrc.json` を生成し、server action から一時ディレクトリで oxlint バイナリを `-f json` 実行。exit 1 は診断ありの正常系として扱う。root の vite.config.ts と同じ rules 上書きも反映
  - v1 の制約: tailwind プラグイン (JS プラグイン実行環境が必要) と typeAware (tsgolint が必要) は除外
- **format**: oxfmt の公開 JS API `format()` を `fmt` プリセットで呼ぶ (設定ファイル専用キーは除去)
- **エディタ**: 透明 textarea を shiki トークン描画の pre に重ねるオーバーレイ方式
  - textarea は非制御 (`defaultValue`)。制御にすると concurrent 再レンダーの value 再セットで Chrome がキャレットを末尾へ飛ばすため
  - preflight の `textarea { font-family: inherit }` で font-mono が効かず、プロポーショナル文字幅でキャレット位置がズレるため、monospace をインラインで強制
  - 面色は next-themes のテーマクラスに追従する CSS (`bg-[#fafafa] dark:bg-[#21252b]` 等) で与え、ハイドレーション不一致とリロード時のフラッシュを回避。初回ハイライト前はコードを隠してプレーン表示のチラつきも防ぐ (1.5s の保険フォールバックあり)
  - 整形の反映は undo 履歴に乗る `insertText` で行う
- **保護**: 認証なしの公開エンドポイントのため、入力 100KB 上限・子プロセス timeout 10s・リクエストごとの一時ディレクトリ (finally で削除)
- あわせて、vitest.config.ts の resolve.alias が参照する `mocks/empty.ts` (server-only スタブ) が過去に削除されていたため復元

## 動作確認

- ユニット 24 件 (oxlintrc ビルダー / 診断変換 / 実バイナリ統合) + Storybook 13 件 + `vp check` 0 エラー + type-check
- Playwright (実キー・実クリップボード) での E2E 18 項目: 初回ロードのプレーン非表示 / ハイライト / lint 検出 / 行またぎ連続 Backspace でキャレット異常 0 / タイプ中の背景フラッシュなし / 整形 + Undo / コピー / 言語切替 / ライト・ダーク面色 / ハイドレーションエラー 0

## レビュー時の注意

- **Vercel preview で lint / 整形を一度実行してください**。oxlint は子プロセス起動のみで静的 import されないため、`next.config.ts` の `outputFileTracingIncludes` で NAPI バイナリをトレースに含めています。preview の関数ログに `Cannot find module '@oxlint/binding-...'` が出ないことの確認が必要です (ローカルでは検証不能)
- oxlint / oxfmt / @k8o/oxc-config は vite-plus が内蔵する版と同一バージョンにピンしています。ズレても「ツールの診断とリポジトリの lint の乖離」に留まりますが、Renovate で同時更新される想定です