### PR TITLE
feat: サイト改善監査に基づくSEO・セキュリティ・a11y・パフォーマンスの小改善

### DIFF
--- a/apps/admin/src/app/api/crons/sync-baseline/route.ts
+++ b/apps/admin/src/app/api/crons/sync-baseline/route.ts
@@ -3,6 +3,7 @@ import { type NextRequest, NextResponse } from 'next/server';
 import { syncBaseline } from '@/features/baseline/application/sync-baseline';
 import { sendPushNotification } from '@/features/push-notification/interface/commands';
 import { isAuthorizedCronRequest } from '@/shared/auth/verify-cron-request';
+import { revalidateMainCache } from '@/shared/cache/revalidate-main';
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   if (!isAuthorizedCronRequest(req)) {
@@ -11,6 +12,10 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   try {
     const { newFeatures, statusChanges } = await syncBaseline();
+
+    // browser_support(min versions) は main の RootLayout が db-content タグ経由で
+    // 参照するため、同期後に再検証してフロアの鮮度を保つ
+    await revalidateMainCache();
 
     const hasChanges = newFeatures.length > 0 || statusChanges.length > 0;
 

--- a/apps/admin/src/features/baseline/interface/actions.ts
+++ b/apps/admin/src/features/baseline/interface/actions.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from 'next/cache';
 import { syncBaseline } from '@/features/baseline/application/sync-baseline';
 import type { ActionState } from '@/shared/actions/action-state';
 import { verifySession } from '@/shared/auth/verify-session';
+import { revalidateMainCache } from '@/shared/cache/revalidate-main';
 
 type SyncActionState = ActionState & {
   newFeatures?: number;
@@ -17,6 +18,8 @@ export async function syncBaselineAction(): Promise<SyncActionState> {
   try {
     const result = await syncBaseline();
     revalidatePath('/baseline');
+    // main の RootLayout が参照する browser_support(db-content タグ)を再検証する
+    await revalidateMainCache();
     return {
       newFeatures: result.newFeatures.length,
       statusChanges: result.statusChanges.length,

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -3,23 +3,64 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 import { isAuthEnabled } from './shared/auth/auth-enabled';
 
+const isDev = process.env.NODE_ENV === 'development';
+
+// admin は認証済みの管理面で外部埋め込みを持たないため、main より厳格にできる
+// （GA / codepen / vercel-scripts の許可は不要）。DB 書き込みや push 送信を
+// 担う面なので XSS・クリックジャッキングの被害範囲を CSP で絞る
+const cspHeader = `
+    default-src 'self';
+    script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''};
+    style-src 'self' 'unsafe-inline';
+    img-src 'self' https: blob: data:;
+    font-src 'self';
+    worker-src 'self' blob:;
+    connect-src 'self';
+    frame-src 'self';
+    object-src 'none';
+    base-uri 'self';
+    form-action 'self';
+    frame-ancestors 'none';
+    ${isDev ? '' : 'upgrade-insecure-requests;'}
+`;
+
+const contentSecurityPolicyHeaderValue = cspHeader
+  .replaceAll(/\s{2,}/gu, ' ')
+  .trim();
+
+function withSecurityHeaders(response: NextResponse): NextResponse {
+  response.headers.set(
+    'Content-Security-Policy',
+    contentSecurityPolicyHeaderValue,
+  );
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+  response.headers.set('Referrer-Policy', 'same-origin');
+  response.headers.set(
+    'Permissions-Policy',
+    'camera=(), microphone=(), geolocation=(), browsing-topics=()',
+  );
+  return response;
+}
+
 export function proxy(request: NextRequest) {
   if (!isAuthEnabled) {
-    return NextResponse.next();
+    return withSecurityHeaders(NextResponse.next());
   }
 
   const { pathname } = request.nextUrl;
 
   if (pathname === '/sign-in') {
-    return NextResponse.next();
+    return withSecurityHeaders(NextResponse.next());
   }
 
   const sessionCookie = getSessionCookie(request);
   if (sessionCookie === null) {
-    return NextResponse.redirect(new URL('/sign-in', request.url));
+    return withSecurityHeaders(
+      NextResponse.redirect(new URL('/sign-in', request.url)),
+    );
   }
 
-  return NextResponse.next();
+  return withSecurityHeaders(NextResponse.next());
 }
 
 export const config = {

--- a/apps/main/src/app/_components/global-layout/header/header.tsx
+++ b/apps/main/src/app/_components/global-layout/header/header.tsx
@@ -8,7 +8,9 @@ export const Header: FC<{ children: ReactNode }> = ({ children }) => {
 
   return (
     <header
-      className={`sticky top-0 z-50 flex items-center justify-center p-4 transition-transform duration-300 ${
+      // focus-within: キーボードでヘッダー内コントロールへ移動したら常に表示する
+      // (WCAG 2.4.11)。motion-reduce: 動きの抑制設定を尊重する
+      className={`sticky top-0 z-50 flex items-center justify-center p-4 transition-transform duration-300 focus-within:translate-y-0 motion-reduce:transition-none ${
         scrollDirection.y === 'down' ? '-translate-y-full' : 'translate-y-0'
       }`}
     >

--- a/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -19,7 +19,7 @@ import {
   type getBlogsByTags,
   getBlogToc,
 } from '@/features/blog/interface/queries';
-import { blogPostingJsonLd } from '@/shared/site/json-ld';
+import { blogBreadcrumbJsonLd, blogPostingJsonLd } from '@/shared/site/json-ld';
 
 import { END_OF_CONTENT_ID } from './constants';
 import { CopyMarkdownButton } from './copy-markdown-button';
@@ -132,13 +132,18 @@ export const BlogLayoutContent: FC<BlogLayoutContentProps> = ({
 };
 
 export const BlogLayout: FC<BlogLayoutProps> = async ({ children, slug }) => {
-  const blog = await getBlogContent(slug);
-  const headingTree = await getBlogToc(slug);
-  const readingTime = await getBlogReadingTime(slug);
+  // 3つは相互依存のない独立した 'use cache' クエリなので、キャッシュミス時の
+  // 動的レンダーやビルド時プリレンダーで直列に待たないよう並列化する
+  const [blog, headingTree, readingTime] = await Promise.all([
+    getBlogContent(slug),
+    getBlogToc(slug),
+    getBlogReadingTime(slug),
+  ]);
 
   return (
     <>
       <JsonLd data={blogPostingJsonLd(blog)} />
+      <JsonLd data={blogBreadcrumbJsonLd(blog)} />
       <BlogLayoutContent
         blog={blog}
         headingTree={headingTree}

--- a/apps/main/src/app/blog/_components/blog-layout/table-of-contents/table-of-contents.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/table-of-contents/table-of-contents.tsx
@@ -17,6 +17,7 @@ const LinkButton: FC<{
   onNavigate: (id: string) => void;
 }> = ({ depth, text, isActive, onNavigate }) => (
   <Link
+    aria-current={isActive ? 'location' : undefined}
     className={cn(
       'inline-block w-full rounded-xl px-4 py-2 transition-colors hover:bg-bg-mute focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-border-info focus-visible:ring-offset-2 sm:text-lg',
       depth === 2 && 'pl-8 text-sm sm:text-md',
@@ -125,17 +126,19 @@ export const TableOfContents: FC<{
         <ProgressBar activeId={activeId} headingTree={headingTree} />
         <span className="truncate">{summaryText}</span>
       </summary>
-      <ul className="text-fg-base flex max-h-[75vh] flex-col overflow-y-scroll p-2">
-        {headingTree.children.map((node) => (
-          <TocItem
-            activeId={activeId}
-            depth={1}
-            key={node.text}
-            node={node}
-            onNavigate={setActiveId}
-          />
-        ))}
-      </ul>
+      <nav aria-label="もくじ">
+        <ul className="text-fg-base flex max-h-[75vh] flex-col overflow-y-scroll p-2">
+          {headingTree.children.map((node) => (
+            <TocItem
+              activeId={activeId}
+              depth={1}
+              key={node.text}
+              node={node}
+              onNavigate={setActiveId}
+            />
+          ))}
+        </ul>
+      </nav>
     </details>
   );
 };

--- a/apps/main/src/app/blog/feed/route.ts
+++ b/apps/main/src/app/blog/feed/route.ts
@@ -15,7 +15,7 @@ async function generateRssFeed() {
   const blogs = await getBlogContents();
 
   return buildRssFeed({
-    title: metadata.title,
+    title: `k8o ${metadata.title}`,
     description: metadata.description,
     feedUrl: `${BLOG_URL}/feed`,
     siteUrl: BLOG_URL,
@@ -36,7 +36,7 @@ export async function GET() {
 
   return new NextResponse(xml, {
     headers: {
-      'Content-Type': 'application/xml',
+      'Content-Type': 'application/rss+xml; charset=utf-8',
     },
   });
 }

--- a/apps/main/src/app/blog/md/[slug]/route.ts
+++ b/apps/main/src/app/blog/md/[slug]/route.ts
@@ -16,6 +16,11 @@ export async function GET(
         // /blog/:slug は Accept で HTML と markdown を出し分けるため、
         // 共有キャッシュが Accept をキーに含むよう明示する
         Vary: 'Accept',
+        // 本文はデプロイ時に固定される MDX 由来で、Vercel の CDN キャッシュは
+        // デプロイで無効化される。CopyMarkdown やエージェントからの再取得を
+        // 関数実行なしで返せるよう CDN にキャッシュさせる
+        'Cache-Control':
+          'public, s-maxage=86400, stale-while-revalidate=604800',
       },
     });
   } catch {

--- a/apps/main/src/app/code-dock/_components/code-dock/code-dock.tsx
+++ b/apps/main/src/app/code-dock/_components/code-dock/code-dock.tsx
@@ -16,6 +16,10 @@ import { useTheme } from 'next-themes';
 import { useEffect, useRef, useState } from 'react';
 import type { FC } from 'react';
 
+import {
+  DEFAULT_SAMPLE_CODE,
+  DEFAULT_SAMPLE_LANGUAGE,
+} from '@/features/code-dock/interface/default-sample';
 import { isLintLanguage } from '@/features/code-dock/interface/types';
 import type {
   FormatCodeResult,
@@ -40,6 +44,9 @@ export type FormatAction = (
 type Props = {
   lintAction: LintAction;
   formatAction: FormatAction;
+  // page.tsx がサーバー側でキャッシュした初期サンプルの診断結果。渡された場合は
+  // マウント時の再検査を省略する（未指定＝Storybook 等では従来どおり検査する）
+  initialDiagnostics?: LintDiagnostic[] | null;
 };
 
 const LANGUAGE_OPTIONS = [
@@ -49,24 +56,25 @@ const LANGUAGE_OPTIONS = [
   { label: 'JS', value: 'js' },
 ] as const;
 
-const DEFAULT_CODE = [
-  'const greeting = "Hello, k8o!"',
-  '',
-  'export const App = () => {',
-  '  console.log(greeting)',
-  '  return <p>{greeting}</p>',
-  '}',
-  '',
-].join('\n');
-
 const LINT_DEBOUNCE_MS = 600;
 
-export const CodeDock: FC<Props> = ({ lintAction, formatAction }) => {
-  const [code, setCode] = useState(DEFAULT_CODE);
-  const [language, setLanguage] = useState<LintLanguage>('tsx');
-  const [diagnostics, setDiagnostics] = useState<LintDiagnostic[] | null>(null);
+export const CodeDock: FC<Props> = ({
+  lintAction,
+  formatAction,
+  initialDiagnostics,
+}) => {
+  const [code, setCode] = useState(DEFAULT_SAMPLE_CODE);
+  const [language, setLanguage] = useState<LintLanguage>(
+    DEFAULT_SAMPLE_LANGUAGE,
+  );
+  const [diagnostics, setDiagnostics] = useState<LintDiagnostic[] | null>(
+    initialDiagnostics ?? null,
+  );
   const [lintError, setLintError] = useState<string | null>(null);
   const [isLinting, dispatchLint] = useDebouncedTransition(LINT_DEBOUNCE_MS);
+  // 初期サンプルの診断結果を props で受け取っている場合、マウント直後の再検査は
+  // 不要なので最初の effect を 1 度だけスキップする
+  const shouldSkipInitialLint = useRef(Array.isArray(initialDiagnostics));
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const { resolvedTheme } = useTheme();
   // コードのハイライトはアプリのテーマに合わせる (light は one-light、それ以外は
@@ -88,6 +96,10 @@ export const CodeDock: FC<Props> = ({ lintAction, formatAction }) => {
 
   // 入力・言語変更・整形の反映のたびに、デバウンスして自動で検査する
   useEffect(() => {
+    if (shouldSkipInitialLint.current) {
+      shouldSkipInitialLint.current = false;
+      return;
+    }
     dispatchLint(async (signal) => {
       if (code === '') {
         setDiagnostics(null);

--- a/apps/main/src/app/code-dock/page.tsx
+++ b/apps/main/src/app/code-dock/page.tsx
@@ -1,15 +1,26 @@
 import { formatCode, lintCode } from '@/features/code-dock/interface/actions';
+import { getDefaultLintDiagnostics } from '@/features/code-dock/interface/queries';
 
 import { CodeDock } from './_components/code-dock';
 
-export default function CodeDockPage() {
+export default async function CodeDockPage() {
+  // 初期サンプルの診断結果はデプロイ単位でキャッシュ済み。取得に失敗した場合は
+  // null を渡し、クライアントがマウント時に検査するフォールバックに任せる
+  const initialDiagnostics = await getDefaultLintDiagnostics().catch(
+    () => null,
+  );
+
   return (
     <section className="flex flex-col gap-6 py-10">
       <p className="text-sm">
         このサイトと同じoxcの設定 (oxlint / oxfmt)
         で、入力したコードの検査と整形を試せます。
       </p>
-      <CodeDock formatAction={formatCode} lintAction={lintCode} />
+      <CodeDock
+        formatAction={formatCode}
+        initialDiagnostics={initialDiagnostics}
+        lintAction={lintCode}
+      />
     </section>
   );
 }

--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
@@ -19,6 +19,12 @@ export const ColorToHex: FC = () => {
 
   return (
     <div className="flex flex-col gap-6">
+      {/* 正誤と正解の hex をスクリーンリーダーに通知する永続ライブリージョン */}
+      <output className="sr-only">
+        {phase === 'result'
+          ? `${isCorrect ? '正解' : '不正解'}。正解は #${targetHex} です`
+          : ''}
+      </output>
       <div
         className="flex h-48 w-full items-center justify-center rounded-xl"
         style={{ backgroundColor: `#${targetHex}` }}
@@ -85,6 +91,7 @@ export const ColorToHex: FC = () => {
           return (
             <button
               aria-label={`Hexの選択肢: #${hex}`}
+              aria-pressed={isSelected}
               className={[
                 'relative flex h-14 items-center justify-center rounded-xl border border-border-base font-mono text-sm tracking-wider transition-all',
                 'bg-bg-base',

--- a/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
@@ -19,6 +19,12 @@ export const HexToColor: FC = () => {
 
   return (
     <div className="flex flex-col gap-6">
+      {/* 正誤と正解の hex をスクリーンリーダーに通知する永続ライブリージョン */}
+      <output className="sr-only">
+        {phase === 'result'
+          ? `${isCorrect ? '正解' : '不正解'}。正解は #${targetHex} です`
+          : ''}
+      </output>
       <div className="text-center">
         <p className="font-mono text-3xl font-bold tracking-widest">
           #{targetHex}
@@ -39,6 +45,7 @@ export const HexToColor: FC = () => {
           return (
             <button
               aria-label={`色の選択肢: #${hex}`}
+              aria-pressed={isSelected}
               className={[
                 'relative flex h-28 items-center justify-center rounded-xl transition-all',
                 isSelected && phase === 'question'

--- a/apps/main/src/app/contrast-checker/_components/apca-result-table/apca-result-table.tsx
+++ b/apps/main/src/app/contrast-checker/_components/apca-result-table/apca-result-table.tsx
@@ -75,9 +75,15 @@ export const ApcaResultTable: FC<Props> = ({ lc }) => {
       <table className="hidden w-full sm:table">
         <thead>
           <tr className="border-border-base bg-bg-mute md:text-md border-b text-xs font-medium sm:text-sm">
-            <th className="px-3 py-2 sm:px-4 sm:py-3">判定</th>
-            <th className="px-3 py-2 sm:px-4 sm:py-3">基準</th>
-            <th className="px-3 py-2 text-left sm:px-4 sm:py-3">用途</th>
+            <th className="px-3 py-2 sm:px-4 sm:py-3" scope="col">
+              判定
+            </th>
+            <th className="px-3 py-2 sm:px-4 sm:py-3" scope="col">
+              基準
+            </th>
+            <th className="px-3 py-2 text-left sm:px-4 sm:py-3" scope="col">
+              用途
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/apps/main/src/app/contrast-checker/_components/check-contrast/check-contrast.tsx
+++ b/apps/main/src/app/contrast-checker/_components/check-contrast/check-contrast.tsx
@@ -3,7 +3,7 @@
 import { Alert, Heading } from '@k8o/arte-odyssey';
 import { calcApca } from '@repo/helpers/color/calc-apca';
 import { calcContrast } from '@repo/helpers/color/calc-contrast';
-import { type FC, useState } from 'react';
+import { type FC, useEffect, useState } from 'react';
 
 import { ApcaResultTable } from '../apca-result-table';
 import { ColorPallet } from '../color-pallet';
@@ -28,8 +28,23 @@ export const CheckContrast: FC = () => {
   const isInvalidAaNormalText = contrast < WCAG_THRESHOLDS.AA_NORMAL_TEXT;
   const isInvalidAaaNormalText = contrast < WCAG_THRESHOLDS.AAA_NORMAL_TEXT;
 
+  // カラーピッカーのドラッグ中は change が連続発火するため、読み上げは
+  // デバウンスして最新の結果だけをスクリーンリーダーに通知する
+  const [announcement, setAnnouncement] = useState('');
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setAnnouncement(
+        `コントラスト比 ${contrast.toFixed(2)}対1、APCA Lc ${apcaLc.toFixed(1)}`,
+      );
+    }, 500);
+    return () => {
+      clearTimeout(id);
+    };
+  }, [contrast, apcaLc]);
+
   return (
     <div className="flex flex-col gap-8">
+      <output className="sr-only">{announcement}</output>
       <div className="grid grid-cols-2 gap-4">
         <ColorPallet color={baseColor} label="背景色" setColor={setBaseColor} />
         <ColorPallet

--- a/apps/main/src/app/contrast-checker/_components/result-table/result-table.tsx
+++ b/apps/main/src/app/contrast-checker/_components/result-table/result-table.tsx
@@ -109,9 +109,15 @@ export const ResultTable: FC<Props> = ({
       <table className="hidden w-full sm:table">
         <thead>
           <tr className="border-border-base bg-bg-mute md:text-md border-b text-xs font-medium sm:text-sm">
-            <th className="px-3 py-2 sm:px-4 sm:py-3">AA</th>
-            <th className="px-3 py-2 sm:px-4 sm:py-3">AAA</th>
-            <th className="px-3 py-2 text-left sm:px-4 sm:py-3">テキスト</th>
+            <th className="px-3 py-2 sm:px-4 sm:py-3" scope="col">
+              AA
+            </th>
+            <th className="px-3 py-2 sm:px-4 sm:py-3" scope="col">
+              AAA
+            </th>
+            <th className="px-3 py-2 text-left sm:px-4 sm:py-3" scope="col">
+              テキスト
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/apps/main/src/app/layout.tsx
+++ b/apps/main/src/app/layout.tsx
@@ -16,7 +16,10 @@ import { mPlus2 } from './_styles/font';
 
 export const metadata = {
   metadataBase: new URL('https://k8o.me'),
-  title: 'k8o',
+  title: {
+    default: 'k8o',
+    template: '%s | k8o',
+  },
   description: 'k8oの活動や制作物をまとめた個人サイト',
   generator: 'Next.js',
   applicationName: 'k8o',

--- a/apps/main/src/app/llms.txt/route.ts
+++ b/apps/main/src/app/llms.txt/route.ts
@@ -50,6 +50,8 @@ async function _generateLlmContent() {
 WebフロントエンドとTypeScriptが好きで、Baselineを追いながらWeb標準の進化を楽しんでいます。
 デザインシステムの構築を通じて、デザインとフロントエンドの交差点を探っています。
 
+各ブログ記事は URL の末尾に \`.md\` を付けると Markdown 形式で取得できます（例: https://k8o.me/blog/example.md）。
+
 ## ページ一覧
 ${entriesContent}
 `;

--- a/apps/main/src/app/moji-count/_components/text-field/text-field.tsx
+++ b/apps/main/src/app/moji-count/_components/text-field/text-field.tsx
@@ -1,16 +1,30 @@
 'use client';
 
 import { FormControl, Textarea } from '@k8o/arte-odyssey';
-import { useDeferredValue, useState } from 'react';
+import { useDeferredValue, useEffect, useState } from 'react';
 
+import { countGraphemeLength } from '../../_utils/count-text';
 import { TextLength } from '../text-length';
 
 export const TextField = () => {
   const [text, setText] = useState('');
   const deferredText = useDeferredValue(text);
 
+  // タイピング中は入力の都度カウントが変わるため、読み上げはデバウンスして
+  // 入力が落ち着いてから最新の文字数だけをスクリーンリーダーに通知する
+  const [announcement, setAnnouncement] = useState('');
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setAnnouncement(`${countGraphemeLength(text).toString()}文字`);
+    }, 500);
+    return () => {
+      clearTimeout(id);
+    };
+  }, [text]);
+
   return (
     <div className="flex grow flex-col gap-2">
+      <output className="sr-only">{announcement}</output>
       <div className="h-full *:h-full">
         <FormControl
           label="カウントしたい文字列"

--- a/apps/main/src/app/moji-count/_components/text-field/text-field.tsx
+++ b/apps/main/src/app/moji-count/_components/text-field/text-field.tsx
@@ -11,11 +11,14 @@ export const TextField = () => {
   const deferredText = useDeferredValue(text);
 
   // タイピング中は入力の都度カウントが変わるため、読み上げはデバウンスして
-  // 入力が落ち着いてから最新の文字数だけをスクリーンリーダーに通知する
+  // 入力が落ち着いてから最新の文字数だけをスクリーンリーダーに通知する。
+  // 未入力時は読み上げない（初期マウントで「0文字」が鳴るのを避ける）
   const [announcement, setAnnouncement] = useState('');
   useEffect(() => {
     const id = setTimeout(() => {
-      setAnnouncement(`${countGraphemeLength(text).toString()}文字`);
+      if (text !== '') {
+        setAnnouncement(`${countGraphemeLength(text).toString()}文字`);
+      }
     }, 500);
     return () => {
       clearTimeout(id);

--- a/apps/main/src/app/palette-maker/_components/contrast-table/contrast-table.tsx
+++ b/apps/main/src/app/palette-maker/_components/contrast-table/contrast-table.tsx
@@ -1,3 +1,4 @@
+import { AlertIcon } from '@k8o/arte-odyssey';
 import type { FC } from 'react';
 
 import type { PaletteSwatch } from '../../_types/palette';
@@ -15,30 +16,39 @@ type ContrastValueProps = {
   apca: number;
 };
 
-const ContrastValue: FC<ContrastValueProps> = ({ hex, text, ratio, apca }) => (
-  <div className="flex items-center gap-2">
-    <span
-      aria-hidden="true"
-      className="flex size-8 shrink-0 items-center justify-center rounded-md text-sm font-bold"
-      style={{
-        backgroundColor: hex,
-        color: text === 'white' ? '#ffffff' : '#000000',
-      }}
-    >
-      Aa
-    </span>
-    <div className="flex flex-col">
+const ContrastValue: FC<ContrastValueProps> = ({ hex, text, ratio, apca }) => {
+  const isPass = ratio >= AA_NORMAL_TEXT;
+
+  return (
+    <div className="flex items-center gap-2">
       <span
-        className={`text-sm font-bold ${
-          ratio >= AA_NORMAL_TEXT ? 'text-fg-success' : 'text-fg-error'
-        }`}
+        aria-hidden="true"
+        className="flex size-8 shrink-0 items-center justify-center rounded-md text-sm font-bold"
+        style={{
+          backgroundColor: hex,
+          color: text === 'white' ? '#ffffff' : '#000000',
+        }}
       >
-        {ratio.toFixed(2)}
+        Aa
       </span>
-      <span className="text-fg-mute text-xs">Lc {apca.toFixed(1)}</span>
+      <div className="flex flex-col">
+        {/* 合否を色だけに頼らず、アイコン(形)と読み上げテキストでも伝える */}
+        <span
+          className={`flex items-center gap-1 text-sm font-bold ${
+            isPass ? 'text-fg-success' : 'text-fg-error'
+          }`}
+        >
+          <AlertIcon size="sm" status={isPass ? 'success' : 'error'} />
+          {ratio.toFixed(2)}
+          <span className="sr-only">
+            {isPass ? '（AA合格）' : '（AA不合格）'}
+          </span>
+        </span>
+        <span className="text-fg-mute text-xs">Lc {apca.toFixed(1)}</span>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export const ContrastTable: FC<Props> = ({ swatches }) => (
   <div className="flex flex-col gap-2">
@@ -86,11 +96,21 @@ export const ContrastTable: FC<Props> = ({ swatches }) => (
       <table className="hidden w-full sm:table">
         <thead>
           <tr className="border-border-base bg-bg-mute border-b text-left text-sm font-medium">
-            <th className="px-4 py-3">段</th>
-            <th className="px-4 py-3">色</th>
-            <th className="px-4 py-3">OKLCH</th>
-            <th className="px-4 py-3">白文字</th>
-            <th className="px-4 py-3">黒文字</th>
+            <th className="px-4 py-3" scope="col">
+              段
+            </th>
+            <th className="px-4 py-3" scope="col">
+              色
+            </th>
+            <th className="px-4 py-3" scope="col">
+              OKLCH
+            </th>
+            <th className="px-4 py-3" scope="col">
+              白文字
+            </th>
+            <th className="px-4 py-3" scope="col">
+              黒文字
+            </th>
           </tr>
         </thead>
         <tbody>
@@ -135,7 +155,7 @@ export const ContrastTable: FC<Props> = ({ swatches }) => (
       </table>
     </div>
     <p className="text-fg-mute text-xs">
-      WCAG比は4.5以上（通常テキストのAA基準）を合格として色分けしています
+      WCAG比は4.5以上（通常テキストのAA基準）を合格とし、色とアイコンで示しています
     </p>
   </div>
 );

--- a/apps/main/src/app/reading-list/feed/route.ts
+++ b/apps/main/src/app/reading-list/feed/route.ts
@@ -15,7 +15,7 @@ async function generateRssFeed() {
   const articles = await getArticles();
 
   return buildRssFeed({
-    title: metadata.title,
+    title: `k8o ${metadata.title}`,
     description: metadata.description,
     feedUrl: `${READING_LIST_URL}/feed`,
     siteUrl: READING_LIST_URL,
@@ -39,7 +39,7 @@ export async function GET() {
 
   return new NextResponse(xml, {
     headers: {
-      'Content-Type': 'application/xml',
+      'Content-Type': 'application/rss+xml; charset=utf-8',
     },
   });
 }

--- a/apps/main/src/app/slides/feed/route.ts
+++ b/apps/main/src/app/slides/feed/route.ts
@@ -15,7 +15,7 @@ async function generateRssFeed() {
   const slides = await getSlideContents();
 
   return buildRssFeed({
-    title: metadata.title,
+    title: `k8o ${metadata.title}`,
     description: metadata.description,
     feedUrl: `${SLIDES_URL}/feed`,
     siteUrl: SLIDES_URL,
@@ -35,7 +35,7 @@ export async function GET() {
 
   return new NextResponse(xml, {
     headers: {
-      'Content-Type': 'application/xml',
+      'Content-Type': 'application/rss+xml; charset=utf-8',
     },
   });
 }

--- a/apps/main/src/app/slides/layout.tsx
+++ b/apps/main/src/app/slides/layout.tsx
@@ -5,6 +5,11 @@ import Link from 'next/link';
 export const metadata = {
   title: 'Slides',
   description: '登壇や発表で使ったスライドをまとめています。',
+  alternates: {
+    types: {
+      'application/rss+xml': 'https://k8o.me/slides/feed',
+    },
+  },
   openGraph: {
     title: 'Slides',
     description: '登壇や発表で使ったスライドをまとめています。',

--- a/apps/main/src/app/tags/[id]/page.tsx
+++ b/apps/main/src/app/tags/[id]/page.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 
+import { JsonLd } from '@/app/_components/json-ld';
 import { getTag, getTags } from '@/features/tags/interface/queries';
+import { tagBreadcrumbJsonLd } from '@/shared/site/json-ld';
 
 import { TagContent } from '../_components/tag-content';
 
@@ -56,5 +58,10 @@ export default async function Page({ params }: PageProperties) {
     notFound();
   }
 
-  return <TagContent {...tag} />;
+  return (
+    <>
+      <JsonLd data={tagBreadcrumbJsonLd(tag)} />
+      <TagContent {...tag} />
+    </>
+  );
 }

--- a/apps/main/src/features/baseline/interface/queries.ts
+++ b/apps/main/src/features/baseline/interface/queries.ts
@@ -1,7 +1,8 @@
-import { cacheLife } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
 
 import { getBaselineFeatures as _getBaselineFeatures } from '@/features/baseline/application/baseline';
 import { getBaselineMinVersions as _getBaselineMinVersions } from '@/features/baseline/application/browser-support';
+import { DB_CONTENT_CACHE_TAG } from '@/shared/cache/cache-tags';
 
 export async function getBaselineFeatures() {
   'use cache';
@@ -16,7 +17,13 @@ export async function getBaselineFeatures() {
 
 export async function getBaselineMinVersions() {
   'use cache';
-  cacheLife('minutes');
+  // RootLayout が Suspense 境界外で await するため、この cacheLife が全ページの
+  // 静的シェルの寿命になる。'minutes'(expire 1h) だと低トラフィック時に毎時
+  // シェルが動的レンダーへ落ちるので、'days'(revalidate 1日 / expire 1週間)で
+  // 背景更新に寄せる。admin の baseline 同期(cron / 手動)は完了後に db-content を
+  // 再検証するため、フロア更新はこのタグ経由で即時に反映される
+  cacheLife('days');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const minVersions = await _getBaselineMinVersions();
   return minVersions;

--- a/apps/main/src/features/code-dock/interface/default-sample.ts
+++ b/apps/main/src/features/code-dock/interface/default-sample.ts
@@ -1,0 +1,16 @@
+import type { LintLanguage } from '../application/language';
+
+// code-dock の初期表示に使うサンプル。全訪問者共通なので page.tsx はこのコードの
+// 診断結果をサーバー側でキャッシュして初期 props として渡し、クライアントはマウント
+// 時の再検査を省略する。クライアントとサーバーが同じ値を参照するよう一元化する
+export const DEFAULT_SAMPLE_CODE = [
+  'const greeting = "Hello, k8o!"',
+  '',
+  'export const App = () => {',
+  '  console.log(greeting)',
+  '  return <p>{greeting}</p>',
+  '}',
+  '',
+].join('\n');
+
+export const DEFAULT_SAMPLE_LANGUAGE: LintLanguage = 'tsx';

--- a/apps/main/src/features/code-dock/interface/queries.ts
+++ b/apps/main/src/features/code-dock/interface/queries.ts
@@ -1,0 +1,18 @@
+import { cacheLife } from 'next/cache';
+
+import type { LintDiagnostic } from '../application/diagnostics';
+import { lintSource } from '../application/lint-source';
+import { DEFAULT_SAMPLE_CODE, DEFAULT_SAMPLE_LANGUAGE } from './default-sample';
+
+// 初期サンプルは全訪問者共通で、oxlint 設定が変わらない限り結果も不変。デプロイ
+// 単位でキャッシュし、マウント時に全訪問者が oxlint の子プロセスを起動するのを避ける
+export async function getDefaultLintDiagnostics(): Promise<LintDiagnostic[]> {
+  'use cache';
+  cacheLife('max');
+
+  const diagnostics = await lintSource(
+    DEFAULT_SAMPLE_CODE,
+    DEFAULT_SAMPLE_LANGUAGE,
+  );
+  return diagnostics;
+}

--- a/apps/main/src/proxy.ts
+++ b/apps/main/src/proxy.ts
@@ -2,18 +2,6 @@ import { type NextRequest, NextResponse } from 'next/server';
 
 const isDev = process.env.NODE_ENV === 'development';
 
-function getOrigin(): string {
-  const portlessUrl = process.env['PORTLESS_URL'];
-  if (portlessUrl !== undefined && portlessUrl !== '') {
-    return portlessUrl.replace(/^http:/u, 'https:');
-  }
-  const vercelUrl = process.env['VERCEL_URL'];
-  if (vercelUrl !== undefined && vercelUrl !== '') {
-    return `https://${vercelUrl}`;
-  }
-  return 'https://k8o.me';
-}
-
 const cspHeader = `
     default-src 'self';
     script-src 'self' 'unsafe-inline' https://www.googletagmanager.com https://va.vercel-scripts.com https://vercel.live${isDev ? " 'unsafe-eval'" : ''};
@@ -41,15 +29,23 @@ const contentSecurityPolicyHeaderValue = cspHeader
   .replaceAll(/\s{2,}/gu, ' ')
   .trim();
 
-export function proxy(_request: NextRequest) {
+export function proxy(request: NextRequest) {
   const response = NextResponse.next();
   response.headers.set(
     'Content-Security-Policy',
     contentSecurityPolicyHeaderValue,
   );
+  // 配信オリジンそのものを report 先にする。VERCEL_URL などデプロイ固有 URL は
+  // Vercel の Deployment Protection で SSO にリダイレクトされ、ブラウザからの
+  // CSP 違反レポート POST が届かず全損するため使わない
   response.headers.set(
     'Reporting-Endpoints',
-    `csp-endpoint="${getOrigin()}/api/reports"`,
+    `csp-endpoint="${request.nextUrl.origin}/api/reports"`,
+  );
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+  response.headers.set(
+    'Permissions-Policy',
+    'camera=(), microphone=(), geolocation=(), browsing-topics=()',
   );
 
   return response;

--- a/apps/main/src/shared/site/json-ld.test.ts
+++ b/apps/main/src/shared/site/json-ld.test.ts
@@ -1,7 +1,9 @@
 import {
+  blogBreadcrumbJsonLd,
   blogPostingJsonLd,
   personJsonLd,
   serializeJsonLd,
+  tagBreadcrumbJsonLd,
   talkEventsJsonLd,
   websiteJsonLd,
 } from './json-ld';
@@ -95,6 +97,70 @@ describe('blogPostingJsonLd', () => {
     it('タグが空の場合はkeywordsを出力に含めないべき', () => {
       const jsonLd = blogPostingJsonLd({ ...blog, tags: [] });
       expect(serializeJsonLd(jsonLd)).not.toContain('keywords');
+    });
+  });
+});
+
+describe('blogBreadcrumbJsonLd', () => {
+  describe('正常系', () => {
+    it('ホーム > Blog > 記事タイトルの階層を持つBreadcrumbListを返すべき', () => {
+      expect(
+        blogBreadcrumbJsonLd({ slug: 'sample-post', title: 'サンプル記事' }),
+      ).toMatchObject({
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'ホーム',
+            item: 'https://k8o.me',
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Blog',
+            item: 'https://k8o.me/blog',
+          },
+          {
+            '@type': 'ListItem',
+            position: 3,
+            name: 'サンプル記事',
+            item: 'https://k8o.me/blog/sample-post',
+          },
+        ],
+      });
+    });
+  });
+});
+
+describe('tagBreadcrumbJsonLd', () => {
+  describe('正常系', () => {
+    it('ホーム > Tags > タグ名の階層を持つBreadcrumbListを返すべき', () => {
+      expect(tagBreadcrumbJsonLd({ id: 42, name: 'CSS' })).toMatchObject({
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'ホーム',
+            item: 'https://k8o.me',
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Tags',
+            item: 'https://k8o.me/tags',
+          },
+          {
+            '@type': 'ListItem',
+            position: 3,
+            name: 'CSS',
+            item: 'https://k8o.me/tags/42',
+          },
+        ],
+      });
     });
   });
 });

--- a/apps/main/src/shared/site/json-ld.ts
+++ b/apps/main/src/shared/site/json-ld.ts
@@ -76,6 +76,46 @@ export function blogPostingJsonLd(blog: BlogPostingInput): JsonLdObject {
   };
 }
 
+type BreadcrumbItem = {
+  name: string;
+  url: string;
+};
+
+function breadcrumbList(items: readonly BreadcrumbItem[]): JsonLdObject {
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: items.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: item.url,
+    })),
+  };
+}
+
+export function blogBreadcrumbJsonLd(blog: {
+  slug: string;
+  title: string;
+}): JsonLdObject {
+  return breadcrumbList([
+    { name: 'ホーム', url: SITE_URL },
+    { name: 'Blog', url: `${SITE_URL}/blog` },
+    { name: blog.title, url: `${SITE_URL}/blog/${blog.slug}` },
+  ]);
+}
+
+export function tagBreadcrumbJsonLd(tag: {
+  id: number;
+  name: string;
+}): JsonLdObject {
+  return breadcrumbList([
+    { name: 'ホーム', url: SITE_URL },
+    { name: 'Tags', url: `${SITE_URL}/tags` },
+    { name: tag.name, url: `${SITE_URL}/tags/${tag.id.toString()}` },
+  ]);
+}
+
 type TalkEventInput = {
   title: string;
   eventName: string;

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,6 @@
 [tools]
 node = "24.18.0"
 pnpm = "11.9.0"
+# ローカル DB(turso dev) の起動に必要。scripts/local-db.ts が `mise which turso`
+# で解決するため、暗黙のグローバル依存にせず宣言する
+turso = "1.0.29"


### PR DESCRIPTION
サイト改善監査に基づく、低リスクな小改善のまとめ。SEO/配信・セキュリティヘッダー・アクセシビリティ・パフォーマンス/DX の4カテゴリを、概念ごとのアトミックなコミットで実装した。

## 変更内容

### SEO・配信
- 全ページの `<title>` にサイト名テンプレート `%s | k8o` を適用
- RSSフィードのチャンネル名にサイト名を付与、Content-Type を `application/rss+xml` に、slides に RSS autodiscovery を追加
- llms.txt に `.md` 取得規約を明記、`/blog/:slug.md` に CDN 向け `Cache-Control` を付与
- 記事・タグページに BreadcrumbList 構造化データを追加（テスト付き）

### セキュリティ
- **`fix`**: main の CSP 違反レポート送信先が `VERCEL_URL`（SSO保護されたデプロイ固有URL）を指し本番で全損していたのを、`request.nextUrl.origin` に修正。あわせて `X-Content-Type-Options` / `Permissions-Policy` を追加
- admin（DB書き込み・push送信を担う認証済み面）に CSP・Referrer-Policy 等のセキュリティヘッダーを全レスポンスへ付与

### アクセシビリティ
- カラーHexクイズに `aria-pressed` と正誤/正解を読み上げる `<output>`
- いろばしごの WCAG 合否を色だけでなくアイコン＋SRテキストでも表示
- コントラストチェッカー/もじカウントにデバウンス付きライブリージョン
- 判定テーブルの `<th scope="col">`、ヘッダーの `focus-within`/`motion-reduce`、目次の `nav`＋`aria-current`

### パフォーマンス・DX
- ルートシェルの毎時失効を解消（`getBaselineMinVersions` を `cacheLife('days')`＋`cacheTag('db-content')` にし、baseline 同期時に main を再検証）
- BlogLayout の独立3クエリを `Promise.all` で並列化
- code-dock の初期サンプル lint 結果をキャッシュし、マウント時の oxlint 子プロセス起動を回避
- mise.toml に turso CLI を宣言

## レビュー・検証
- リポジトリ専用 reviewer で自己レビュー実施。指摘（baseline再検証の欠落=High、moji-countのデバウンス統一=Medium、code-dock初期言語のハードコード=Low）はすべて本PR内で修正済み
- 検証: 型チェック（main/admin）・lint/format・ls-lint すべて green。ユニットテスト（main 234 / admin 142）、対象コンポーネントの Storybook（axe a11y チェック含む）通過
- 未検証: 本番HTTPヘッダーの実挙動（CSPレポート送信先・Cache-Control）はフルスタック起動での目視まではしていない。プレビューデプロイでの確認を推奨

## スコープ外（別途判断が必要）
`/privacy` ページ、Push新着通知のスキーマ、rate limit、DBバックアップ/マイグレーションCI、英語化、canonicalホストのVercel設定切替 は今回含めていない。
