### PR TITLE
feat(main): カラーHexクイズの選択肢をradiogroupにしキーボード操作を実装する

### DIFF
--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-quiz.stories.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-quiz.stories.tsx
@@ -36,9 +36,10 @@ export const ColorToHexSubmit: Story = {
     const canvas = within(canvasElement);
 
     const panel = canvas.getByRole('tabpanel');
-    const optionButtons = within(panel).getAllByRole('button', {
-      name: /^Hexの選択肢:/u,
+    const group = within(panel).getByRole('radiogroup', {
+      name: 'Hexの選択肢',
     });
+    const optionButtons = within(group).getAllByRole('radio');
     await expect(optionButtons.length).toBeGreaterThan(0);
     await userEvent.click(optionButtons[0] as HTMLElement);
 
@@ -52,6 +53,66 @@ export const ColorToHexSubmit: Story = {
     await expect(
       canvas.getByRole('button', { name: '次の問題へ' }),
     ).toBeInTheDocument();
+  },
+};
+
+// 選択肢が radiogroup として矢印キーで選択移動できる（selection follows focus）
+export const KeyboardSelectsOption: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const panel = canvas.getByRole('tabpanel');
+    const group = within(panel).getByRole('radiogroup');
+    const radios = within(group).getAllByRole('radio');
+    const last = radios.length - 1;
+
+    // 未選択時は先頭だけがタブ移動先（roving tabindex）
+    await expect(radios[0]).toHaveAttribute('tabindex', '0');
+    await expect(radios[1]).toHaveAttribute('tabindex', '-1');
+
+    // 矢印キーで選択が focus に追従して移動し、tabindex も移る
+    (radios[0] as HTMLElement).focus();
+    await userEvent.keyboard('{ArrowRight}');
+    await expect(radios[1]).toHaveAttribute('aria-checked', 'true');
+    await expect(radios[1]).toHaveFocus();
+    await expect(radios[1]).toHaveAttribute('tabindex', '0');
+    await expect(radios[0]).toHaveAttribute('tabindex', '-1');
+
+    // 先頭での ArrowLeft は末尾へ折り返す
+    (radios[0] as HTMLElement).focus();
+    await userEvent.keyboard('{ArrowLeft}');
+    await expect(radios[last]).toHaveAttribute('aria-checked', 'true');
+    await expect(radios[last]).toHaveFocus();
+
+    // Home / End で先頭・末尾へ移動する
+    await userEvent.keyboard('{Home}');
+    await expect(radios[0]).toHaveAttribute('aria-checked', 'true');
+    await userEvent.keyboard('{End}');
+    await expect(radios[last]).toHaveAttribute('aria-checked', 'true');
+
+    await expect(
+      canvas.getByRole('button', { name: '回答する' }),
+    ).toBeEnabled();
+  },
+};
+
+// 「次の問題へ」で回答ボタンが disabled 化してもフォーカスが body に落ちず、
+// 新しい問題の先頭選択肢へ移る
+export const FocusMovesToFirstOptionOnNext: Story = {
+  play: async ({ canvasElement, userEvent }) => {
+    const canvas = within(canvasElement);
+    const radios = within(
+      within(canvas.getByRole('tabpanel')).getByRole('radiogroup'),
+    ).getAllByRole('radio');
+
+    await userEvent.click(radios[0] as HTMLElement);
+    await userEvent.click(canvas.getByRole('button', { name: '回答する' }));
+    await userEvent.click(canvas.getByRole('button', { name: '次の問題へ' }));
+
+    // 問題が変わり選択肢は作り直されるため、フォーカスは新しい先頭 radio にある
+    const nextRadios = within(
+      within(canvas.getByRole('tabpanel')).getByRole('radiogroup'),
+    ).getAllByRole('radio');
+    await expect(nextRadios[0]).toHaveFocus();
   },
 };
 
@@ -83,9 +144,10 @@ export const HexToColorSubmit: Story = {
     await userEvent.click(tab);
 
     const panel = canvas.getByRole('tabpanel');
-    const optionButtons = within(panel).getAllByRole('button', {
-      name: /^色の選択肢:/u,
+    const group = within(panel).getByRole('radiogroup', {
+      name: '色の選択肢',
     });
+    const optionButtons = within(group).getAllByRole('radio');
     await expect(optionButtons.length).toBeGreaterThan(0);
     await userEvent.click(optionButtons[0] as HTMLElement);
 

--- a/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/color-to-hex.tsx
@@ -4,6 +4,7 @@ import { Badge, Button } from '@k8o/arte-odyssey';
 import type { FC } from 'react';
 
 import { useColorQuiz } from './use-color-quiz';
+import { useQuizRadioGroup } from './use-quiz-radio-group';
 
 export const ColorToHex: FC = () => {
   const {
@@ -16,6 +17,11 @@ export const ColorToHex: FC = () => {
     handleSubmit,
     handleNext,
   } = useColorQuiz();
+  const { getRadioProps, focusFirstOptionAfter } = useQuizRadioGroup({
+    options,
+    selectedHex,
+    onSelect: setSelectedHex,
+  });
 
   return (
     <div className="flex flex-col gap-6">
@@ -81,17 +87,29 @@ export const ColorToHex: FC = () => {
           )}
         </div>
       )}
-      <div className="grid grid-cols-2 gap-4">
-        {options.map((hex) => {
+      <div
+        aria-label="Hexの選択肢"
+        className="grid grid-cols-2 gap-4"
+        role="radiogroup"
+      >
+        {options.map((hex, index) => {
           const isSelected = selectedHex === hex;
           const isAnswer = hex === targetHex;
           const showCorrectBadge = phase === 'result' && isAnswer;
           const showWrongBadge = phase === 'result' && isSelected && !isAnswer;
+          // result 時は各選択肢の正誤も読み上げに含める（視覚バッジの内容は
+          // 親の aria-label に上書きされ SR に届かないため）
+          const optionLabel = showCorrectBadge
+            ? `#${hex}（正解）`
+            : showWrongBadge
+              ? `#${hex}（あなたの回答・不正解）`
+              : `#${hex}`;
 
           return (
             <button
-              aria-label={`Hexの選択肢: #${hex}`}
-              aria-pressed={isSelected}
+              key={hex}
+              {...getRadioProps(hex, index)}
+              aria-label={optionLabel}
               className={[
                 'relative flex h-14 items-center justify-center rounded-xl border border-border-base font-mono text-sm tracking-wider transition-all',
                 'bg-bg-base',
@@ -105,7 +123,6 @@ export const ColorToHex: FC = () => {
                 .filter(Boolean)
                 .join(' ')}
               disabled={phase === 'result'}
-              key={hex}
               onClick={() => {
                 setSelectedHex(hex);
               }}
@@ -136,7 +153,13 @@ export const ColorToHex: FC = () => {
           回答する
         </Button>
       ) : (
-        <Button fullWidth onClick={handleNext} size="lg">
+        <Button
+          fullWidth
+          onClick={() => {
+            focusFirstOptionAfter(handleNext);
+          }}
+          size="lg"
+        >
           次の問題へ
         </Button>
       )}

--- a/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/hex-to-color.tsx
@@ -4,6 +4,7 @@ import { Badge, Button } from '@k8o/arte-odyssey';
 import type { FC } from 'react';
 
 import { useColorQuiz } from './use-color-quiz';
+import { useQuizRadioGroup } from './use-quiz-radio-group';
 
 export const HexToColor: FC = () => {
   const {
@@ -16,6 +17,11 @@ export const HexToColor: FC = () => {
     handleSubmit,
     handleNext,
   } = useColorQuiz();
+  const { getRadioProps, focusFirstOptionAfter } = useQuizRadioGroup({
+    options,
+    selectedHex,
+    onSelect: setSelectedHex,
+  });
 
   return (
     <div className="flex flex-col gap-6">
@@ -35,17 +41,29 @@ export const HexToColor: FC = () => {
           </p>
         )}
       </div>
-      <div className="grid grid-cols-2 gap-4">
-        {options.map((hex) => {
+      <div
+        aria-label="色の選択肢"
+        className="grid grid-cols-2 gap-4"
+        role="radiogroup"
+      >
+        {options.map((hex, index) => {
           const isSelected = selectedHex === hex;
           const isAnswer = hex === targetHex;
           const showCorrectBadge = phase === 'result' && isAnswer;
           const showWrongBadge = phase === 'result' && isSelected && !isAnswer;
+          // result 時は各選択肢の正誤も読み上げに含める（視覚バッジの内容は
+          // 親の aria-label に上書きされ SR に届かないため）
+          const optionLabel = showCorrectBadge
+            ? `#${hex}（正解）`
+            : showWrongBadge
+              ? `#${hex}（あなたの回答・不正解）`
+              : `#${hex}`;
 
           return (
             <button
-              aria-label={`色の選択肢: #${hex}`}
-              aria-pressed={isSelected}
+              key={hex}
+              {...getRadioProps(hex, index)}
+              aria-label={optionLabel}
               className={[
                 'relative flex h-28 items-center justify-center rounded-xl transition-all',
                 isSelected && phase === 'question'
@@ -58,7 +76,6 @@ export const HexToColor: FC = () => {
                 .filter(Boolean)
                 .join(' ')}
               disabled={phase === 'result'}
-              key={hex}
               onClick={() => {
                 setSelectedHex(hex);
               }}
@@ -99,7 +116,13 @@ export const HexToColor: FC = () => {
           回答する
         </Button>
       ) : (
-        <Button fullWidth onClick={handleNext} size="lg">
+        <Button
+          fullWidth
+          onClick={() => {
+            focusFirstOptionAfter(handleNext);
+          }}
+          size="lg"
+        >
           次の問題へ
         </Button>
       )}

--- a/apps/main/src/app/color-quiz/_components/color-quiz/use-quiz-radio-group.ts
+++ b/apps/main/src/app/color-quiz/_components/color-quiz/use-quiz-radio-group.ts
@@ -1,0 +1,88 @@
+import { type KeyboardEvent, useCallback, useRef } from 'react';
+import { flushSync } from 'react-dom';
+
+type Params = {
+  options: readonly string[];
+  selectedHex: string | null;
+  onSelect: (hex: string) => void;
+};
+
+// クイズの選択肢は「4択から1つ」の排他選択なので、WAI-ARIA の radiogroup として
+// 実装する。roving tabindex（タブ移動先は1つ）と矢印/Home/End キーでの選択移動
+// （selection follows focus）を提供し、各ボタンに radio ロールの props を配る。
+export const useQuizRadioGroup = ({
+  options,
+  selectedHex,
+  onSelect,
+}: Params) => {
+  const buttonsRef = useRef<Array<HTMLButtonElement | null>>([]);
+  // ref コールバックはインライン生成すると毎コミットで detach/attach が走るため、
+  // index ごとに安定したコールバックを一度だけ生成して使い回す
+  const refSetters = useRef<Array<(el: HTMLButtonElement | null) => void>>([]);
+  const getRefSetter = (index: number) => {
+    refSetters.current[index] ??= (el: HTMLButtonElement | null) => {
+      buttonsRef.current[index] = el;
+    };
+    return refSetters.current[index];
+  };
+
+  const selectedIndex =
+    selectedHex === null ? -1 : options.indexOf(selectedHex);
+  // 未選択のときは先頭をタブ移動先にする（APG の推奨）
+  const activeIndex = Math.max(selectedIndex, 0);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
+      const last = options.length - 1;
+      let next: number;
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          next = index === last ? 0 : index + 1;
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          next = index === 0 ? last : index - 1;
+          break;
+        case 'Home':
+          next = 0;
+          break;
+        case 'End':
+          next = last;
+          break;
+        default:
+          return;
+      }
+      event.preventDefault();
+      const hex = options[next];
+      if (hex === undefined) {
+        return;
+      }
+      onSelect(hex);
+      buttonsRef.current[next]?.focus();
+    },
+    [options, onSelect],
+  );
+
+  // 「次の問題へ」で状態を更新した直後に、先頭の選択肢へフォーカスを移す。
+  // state 更新は本来非同期でバッチされ、直後に focus すると更新前（選択肢がまだ
+  // disabled）の DOM を掴むため flushSync で確定させてから focus する。これにより
+  // 回答ボタンが disabled 化してフォーカスが body へ落ちるのを防ぐ。副作用を effect
+  // ではなくクリックイベントの結果として扱うことで StrictMode の二重実行も無関係になる。
+  const focusFirstOptionAfter = useCallback((update: () => void) => {
+    flushSync(update);
+    buttonsRef.current[0]?.focus();
+  }, []);
+
+  const getRadioProps = (hex: string, index: number) => ({
+    role: 'radio' as const,
+    'aria-checked': selectedHex === hex,
+    tabIndex: index === activeIndex ? 0 : -1,
+    ref: getRefSetter(index),
+    onKeyDown: (event: KeyboardEvent<HTMLButtonElement>) => {
+      handleKeyDown(event, index);
+    },
+  });
+
+  return { getRadioProps, focusFirstOptionAfter };
+};


### PR DESCRIPTION
#1958 の直後にpushした本コミットがマージに含まれなかったため、取り込み直すPR。

カラーHexクイズの選択肢を `aria-pressed`（排他選択に不適なトグルボタン意味論）から
WAI-ARIA の **radiogroup** に作り替える。

## 変更内容
- 共有フック `useQuizRadioGroup`：`role="radio"` / `aria-checked` / **roving tabindex** /
  矢印・Home・End キーでの選択移動（selection follows focus）/ 端での折り返し
- 「次の問題へ」で回答ボタンが disabled 化しフォーカスが body に落ちる問題を、
  新しい問題で先頭選択肢へフォーカスを移して解消（初期マウントでは奪わない）
- result 時は各選択肢の `aria-label` に正誤（正解 / あなたの回答）を含め、
  視覚バッジの情報を SR にも届ける
- ref コールバックを index ごとに安定化し、毎コミットの detach/attach チャーンを回避
- roving tabindex・折り返し・Home/End を検証する play テストを追加

## 補足
2列グリッドに対し上下キーは±1（1次元）だが、radiogroup は本来1次元パターンで
APG 準拠。role=radiogroup への2Dナビは非標準のため現状の1次元モデルを採用している。

## 検証
- `pnpm run check` 0 errors / 型チェック pass
- color-quiz Story 6/6 pass（axe a11y チェック＋拡充したキーボードテスト含む）

4観点（APGキーボード / フォーカス管理 / SRセマンティクス / 回帰）の敵対的a11y検証を通し、
確認された指摘（フォーカス喪失・per-option SRラベル・ref安定化・テスト網羅）に対応済み。
