### PR TITLE
test(main): palette-maker Story を NuqsTestingAdapter で隔離しVRTのStory間リークを解消する

### DIFF
--- a/apps/main/src/app/palette-maker/_components/palette-maker/palette-maker.stories.tsx
+++ b/apps/main/src/app/palette-maker/_components/palette-maker/palette-maker.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { NuqsTestingAdapter } from 'nuqs/adapters/testing';
 import { expect, within } from 'storybook/test';
 
 import { PALETTE_STEPS } from '../../_types/palette';
@@ -7,6 +8,16 @@ import { PaletteMaker } from './palette-maker';
 const meta: Meta<typeof PaletteMaker> = {
   title: 'app/palette-maker/palette-maker',
   component: PaletteMaker,
+  // usePaletteState は nuqs で URL に状態を持つ。プレビュー共通の NuqsAdapter は
+  // 実際の window.location を共有するため、VRT の全Story並列実行で PasteBaseColor
+  // の色相が PasteAchromaticBaseColor に漏れる。Storyごとに隔離された Adapter で包む
+  decorators: [
+    (Story) => (
+      <NuqsTestingAdapter>
+        <Story />
+      </NuqsTestingAdapter>
+    ),
+  ],
 };
 
 export default meta;


### PR DESCRIPTION
## 概要

PR #1954（依存更新）マージ後から継続的に失敗していた VRT ワークフローを修正する。失敗は色ロジックのバグではなく **Storybook の Story 隔離不足**が原因。

失敗内容:
- ファイル: `apps/main/src/app/palette-maker/_components/palette-maker/palette-maker.stories.tsx`
- Story: `PasteAchromaticBaseColor`
- アサーション: `expect(hue.getAttribute('aria-valuenow')).toBe(hueBefore)` が `expected '250' to be '29.2'` で失敗

## 原因

`palette-maker` は `usePaletteState`（nuqs `useQueryStates`）で状態を **URL** に持つ。Storybook 共通の `AppProvider` が本物の `NuqsAdapter`（`nuqs/adapters/next/app`）で全 Story を包んでおり、これは**実際の `window.location`（プロセス共有）**に読み書きする。

VRT の全Story並列実行では 1 つの window を共有するため、`PasteBaseColor` が入力した `#ff0000`（→ 色相 29.2）が共有 URL（`?h=29.2`）に残り、次の `PasteAchromaticBaseColor` の `hueBefore` に漏れる。単体実行では再現せず、全Story並列でのみ決定的に再現していた（`storybook-addon-vrt` 0.2.0 の描画スケジューリング変更で顕在化）。

## 変更

`palette-maker.stories.tsx` の `meta.decorators` に `NuqsTestingAdapter`（`nuqs/adapters/testing`）を追加し、Story ごとに URL 状態を隔離する。これで palette-maker は共有 window に読み書きしなくなり、Story 間リークが双方向で消える。

このパターンは既存の `baseline-feature-list.stories.tsx` と同一で、リポジトリの確立済みの隔離手法に揃えている。vrt 0.1.0 への据え置きは、実バグ（隔離不足）を隠しアップグレードも止めるため採用しない。

## 動作確認

- `vp check`（lint/format）: pass
- `pnpm -F main type-check`: pass
- `pnpm exec vitest run --project=storybook palette-maker.stories`: 6/6 pass
- VRT: ローカルでは回さない方針のため、**本PRの CI vrt ジョブが緑になること**で確認する

## レビュアー向けメモ

`radius-maker` / `html-nest` の Story も real な nuqs コンポーネントを interactive に描画しつつ未隔離で、同じ潜在リークを抱える。現状 VRT では落ちておらず、本PRの diff と他の VRT ベースラインを膨らませないため本PRには含めず、別タスクとして横展開する。