### PR TITLE
fix(vrt): PRコメントのdeleted列がundefinedになる不具合を修正する

### DIFF
--- a/.github/scripts/vrt-comment.mjs
+++ b/.github/scripts/vrt-comment.mjs
@@ -33,18 +33,18 @@ if (reports.length === 0) {
       ? '⚠️ **視覚的な差分があります。** @k35o 内容を確認し、意図した変更ならそのままマージしてください（マージ後のmain実行が新しいベースラインになります）。'
       : '✅ **差分はありません。**',
     '',
-    '| | passed | changed | added | deleted | report |',
-    '| --- | ---: | ---: | ---: | ---: | --- |',
+    '| | passed | changed | added | removed | skipped | report |',
+    '| --- | ---: | ---: | ---: | ---: | ---: | --- |',
   );
   for (const { label, url, report } of reports) {
     const s = report.summary;
     const link = url === '' ? '—' : `[開く](${url})`;
     lines.push(
-      `| ${label} | ${s.passed} | ${s.changed} | ${s.added} | ${s.deleted} | ${link} |`,
+      `| ${label} | ${s.passed} | ${s.changed} | ${s.added} | ${s.removed} | ${s.skipped} | ${link} |`,
     );
   }
   for (const { label, report } of reports) {
-    for (const status of ['changed', 'added', 'deleted']) {
+    for (const status of ['changed', 'added', 'removed']) {
       const items = report.items.filter((item) => item.status === status);
       if (items.length === 0) continue;
       lines.push('', `### ${label}: ${status}`);


### PR DESCRIPTION
## 概要

VRTのPRコメント表で `deleted` 列が `undefined` と表示される不具合を修正します。

storybook-addon-vrt **0.2.0** で `report.json` のステータス語彙が `deleted` → `removed` にリネームされた（[CHANGELOG](https://github.com/k35o/storybook-addon-vrt/blob/main/packages/storybook-addon-vrt/CHANGELOG.md) の破壊的変更）にもかかわらず、`.github/scripts/vrt-comment.mjs` が旧キー `summary.deleted` を参照し続けていたため、`s.deleted` が `undefined` になっていました。

実例: https://github.com/k35o/k8o/pull/1966 のコメント

```
| | passed | changed | added | deleted | report |
| main | 234 | 2 | 0 | undefined | ... |
```

## 変更内容

- `summary.deleted` → `summary.removed` に追従
- 0.2.0 で新設された `skipped`（未キャプチャのストーリー）列を表に追加
- 詳細リストの対象ステータスも `deleted` → `removed` に更新

## 修正後の出力（0.2.0スキーマのreport.jsonで確認）

```
| | passed | changed | added | removed | skipped | report |
| main | 234 | 2 | 0 | 0 | 12 | [開く](...) |
```

`undefined` が解消され、`removed` と `skipped` が正しく表示されることをローカルで検証済みです。