### PR TITLE
fix(reading-list): admin更新後にmainの一覧キャッシュを即時再検証する

### DIFF
--- a/apps/admin/src/app/api/crons/sync-articles/route.ts
+++ b/apps/admin/src/app/api/crons/sync-articles/route.ts
@@ -5,6 +5,7 @@ import { sendPushNotification } from '@/features/push-notification/interface/com
 import { enrichArticleMetadata } from '@/features/reading-list/application/enrich-articles';
 import { syncArticles } from '@/features/reading-list/application/sync-articles';
 import { isAuthorizedCronRequest } from '@/shared/auth/verify-cron-request';
+import { revalidateMainCache } from '@/shared/cache/revalidate-main';
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   if (!isAuthorizedCronRequest(req)) {
@@ -13,6 +14,10 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
 
   const { newArticles, updatedArticles, failedSources } = await syncArticles();
   const { enrichedArticles } = await enrichArticleMetadata();
+
+  // main の reading-list 一覧は db-content タグ付きキャッシュ（cacheLife('hours')）の
+  // ため、同期のたびに再検証して最大1時間の古い表示を防ぐ
+  await revalidateMainCache();
 
   const readingListUrl = 'https://www.k8o.me/reading-list';
   // 同日のリトライで結果カウントが変わっても重複通知しないよう、dedupe は日付のみで行う

--- a/apps/admin/src/features/reading-list/interface/article-actions.ts
+++ b/apps/admin/src/features/reading-list/interface/article-actions.ts
@@ -7,6 +7,7 @@ import { enrichArticleMetadata } from '@/features/reading-list/application/enric
 import { syncArticles } from '@/features/reading-list/application/sync-articles';
 import type { ActionState } from '@/shared/actions/action-state';
 import { verifySession } from '@/shared/auth/verify-session';
+import { revalidateMainCache } from '@/shared/cache/revalidate-main';
 
 import {
   deleteArticleById,
@@ -28,6 +29,7 @@ export async function deleteArticle(id: number): Promise<ActionState> {
     return { error: '削除に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/reading-list');
   revalidatePath('/');
   return { success: true };
@@ -50,6 +52,7 @@ export async function createArticle(
     return { error: '記事の作成に失敗しました（URL が重複している可能性）' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/reading-list');
   revalidatePath('/');
   return redirect('/reading-list');
@@ -73,6 +76,7 @@ export async function updateArticle(
     return { error: '記事の更新に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/reading-list');
   return redirect('/reading-list');
 }
@@ -89,6 +93,7 @@ export async function refetchArticleMetadata(id: number): Promise<ActionState> {
     return { error: 'OGP の再取得に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/reading-list');
   return { success: true };
 }
@@ -106,6 +111,7 @@ export async function syncArticlesAction(): Promise<SyncActionState> {
   try {
     const result = await syncArticles();
     const { enrichedArticles } = await enrichArticleMetadata();
+    await revalidateMainCache();
     revalidatePath('/reading-list');
     revalidatePath('/');
     return {

--- a/apps/admin/src/features/reading-list/interface/source-actions.ts
+++ b/apps/admin/src/features/reading-list/interface/source-actions.ts
@@ -5,6 +5,7 @@ import { redirect } from 'next/navigation';
 
 import type { ActionState } from '@/shared/actions/action-state';
 import { verifySession } from '@/shared/auth/verify-session';
+import { revalidateMainCache } from '@/shared/cache/revalidate-main';
 
 import {
   deleteArticleSourceById,
@@ -30,6 +31,7 @@ export async function createSource(
     return { error: 'ソースの作成に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/reading-list');
   return redirect('/reading-list');
 }
@@ -52,6 +54,7 @@ export async function updateSource(
     return { error: 'ソースの更新に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/reading-list');
   return redirect('/reading-list');
 }
@@ -65,6 +68,7 @@ export async function deleteSource(id: number): Promise<ActionState> {
     return { error: 'ソースの削除に失敗しました' };
   }
 
+  await revalidateMainCache();
   revalidatePath('/reading-list');
   return redirect('/reading-list');
 }

--- a/apps/main/AGENTS.md
+++ b/apps/main/AGENTS.md
@@ -45,7 +45,7 @@ Next.js の `cacheLife` は `features/*/interface` に置く。`app` のUIコン
 
 キャッシュを変更する Server Action / Route Handler は、更新対象の route に `revalidatePath` を明示する。
 
-admin の Server Action から更新されうる DB 由来のキャッシュ（talks / tags / blogs / slides の一覧・詳細）には `cacheTag('db-content')`（`@/shared/cache/cache-tags`）を付与する。admin は書き込み成功後に `/api/revalidate`（`REVALIDATE_SECRET` で認可）を叩いてこのタグを再検証する。
+admin の Server Action や cron から更新されうる DB 由来のキャッシュ（talks / tags / blogs / slides の一覧・詳細、baseline のブラウザ対応バージョン、reading-list の記事・ソース一覧）には `cacheTag('db-content')`（`@/shared/cache/cache-tags`）を付与する。admin は書き込み・同期の成功後に `/api/revalidate`（`REVALIDATE_SECRET` で認可）を叩いてこのタグを再検証する。
 
 ## TailwindCSS：ArteOdysseyカスタムトークンのみ使用
 

--- a/apps/main/src/features/reading-list/interface/queries.ts
+++ b/apps/main/src/features/reading-list/interface/queries.ts
@@ -1,4 +1,6 @@
-import { cacheLife } from 'next/cache';
+import { cacheLife, cacheTag } from 'next/cache';
+
+import { DB_CONTENT_CACHE_TAG } from '@/shared/cache/cache-tags';
 
 import {
   getArticleSources as _getArticleSources,
@@ -8,6 +10,7 @@ import {
 export async function getArticles() {
   'use cache';
   cacheLife('hours');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const articles = await _getArticles();
   return articles;
@@ -16,6 +19,7 @@ export async function getArticles() {
 export async function getArticleSources() {
   'use cache';
   cacheLife('hours');
+  cacheTag(DB_CONTENT_CACHE_TAG);
 
   const articleSources = await _getArticleSources();
   return articleSources;


### PR DESCRIPTION
## 概要

mainのreading-list一覧キャッシュ（`getArticles` / `getArticleSources`、`'use cache'` + `cacheLife('hours')`）が、adminの記事同期（手動の`syncArticlesAction`・cronの`/api/crons/sync-articles`）後も最大1時間古い内容を返していた問題を修正する。

talks / tags / blogs / slides / baseline と同様に `cacheTag('db-content')` + admin からの `/api/revalidate` による即時再検証の仕組みに載せる。

## 変更内容

- **apps/main**: `getArticles` / `getArticleSources` に `cacheTag(DB_CONTENT_CACHE_TAG)` を付与（`cacheLife('hours')` はフォールバックTTLとして維持）
- **apps/admin**: 以下の成功後に `revalidateMainCache()` を呼ぶ
  - `syncArticlesAction`（sync + enrich 後）
  - cron `/api/crons/sync-articles`（sync-baseline と同じ位置づけ）
  - 記事の CRUD・OGP再取得、ソースの CRUD（db-contentタグ付きキャッシュは admin 書き込み後に即時再検証される、という不変条件を守るため）
- **apps/main/AGENTS.md**: Cache方針の db-content 対象一覧に reading-list を追加。記載漏れだった baseline も追記し、「Server Action や cron から」「書き込み・同期の成功後に」と実態に合わせた

## 設計判断: 専用タグではなく db-content に相乗り

revalidate API（`/api/revalidate`）自体は任意のタグ文字列を受けられるため専用タグも可能だったが、以下の理由で相乗りとした。

- admin側ヘルパー `revalidateMainCache()` は db-content 固定で、sync-baseline の cron が既に同じ形（日次cron → 同期後に db-content 再検証）で相乗りしている
- db-content の定義（adminから更新されうるDB由来キャッシュ）に reading-list はそのまま合致する
- 両cronとも日次実行のため、専用タグで守れるのは talks 等の安価なDBクエリキャッシュの日1回分の再計算だけで、粒度を分ける実益がない

## 確認

- `pnpm run type-check` / `pnpm run check`: エラーなし
- `pnpm run test`: 全482テスト通過