### PR TITLE
fix(slides): スライド一覧取得のlimit:100を撤廃し全公開スライドを返す

### DIFF
--- a/apps/main/src/app/_components/global-layout/global-layout.stories.tsx
+++ b/apps/main/src/app/_components/global-layout/global-layout.stories.tsx
@@ -5,6 +5,12 @@ import { GlobalLayout } from './global-layout';
 const meta: Meta<typeof GlobalLayout> = {
   title: 'app/globals/global-layout',
   component: GlobalLayout,
+  beforeEach: () => {
+    // browser-baseline-notice の Dismiss Story が同一セッションの sessionStorage に
+    // dismissed を残すと OutdatedBrowser のバナーが消えて VRT が不安定になるため、
+    // Story 実行前に必ずクリアする。
+    sessionStorage.removeItem('k8o:browser-baseline-notice-dismissed');
+  },
 };
 
 export default meta;

--- a/apps/main/src/features/slides/application/slides.test.ts
+++ b/apps/main/src/features/slides/application/slides.test.ts
@@ -53,5 +53,26 @@ describe('slides service', () => {
 
       expect(result).toStrictEqual([]);
     });
+
+    it('公開スライドが100件を超えても全件取得する', async () => {
+      // サイトマップ・フィードが getSlideContents 経由でこの結果を全件前提で
+      // 使うため、クエリに件数上限を設けないことを保証する
+      const mockSlides = Array.from({ length: 150 }, (_, i) => ({
+        id: i + 1,
+        slug: `slide-${(i + 1).toString()}`,
+        published: true,
+        createdAt: new Date().toISOString(),
+        slideTag: [],
+      }));
+
+      vi.mocked(db.query.slides.findMany).mockResolvedValue(mockSlides);
+
+      const result = await getSlides();
+
+      expect(result).toHaveLength(150);
+      expect(db.query.slides.findMany).toHaveBeenCalledWith(
+        expect.not.objectContaining({ limit: expect.anything() }),
+      );
+    });
   });
 });

--- a/apps/main/src/features/slides/application/slides.ts
+++ b/apps/main/src/features/slides/application/slides.ts
@@ -10,7 +10,6 @@ export const getSlides = async () => {
       },
     },
     where: (slideFields, { eq }) => eq(slideFields.published, true),
-    limit: 100,
     orderBy(fields, operators) {
       return [operators.desc(fields.createdAt), operators.desc(fields.id)];
     },


### PR DESCRIPTION
## 変更内容

- `getSlides()` から `limit: 100` を削除し、全公開スライドを返すようにした
- 「公開スライドが100件を超えても全件取得する（`findMany` に `limit` を渡さない）」ことを保証する境界テストを `slides.test.ts` に追加した

## 背景

`getSlides()` が `limit: 100` をハードコードしており、`getSlideContents()` を共有するサイトマップ（`app/sitemap.ts`）・フィード（`app/slides/feed/route.ts`）・スライド一覧（`app/slides/page.tsx`）で、公開スライドが100件を超えた時点で古いスライドが無警告で欠落する状態だった。

ブログ側の同種の修正（`getBlogs()` の limit 撤廃）と同じ方針で、件数を絞る表示が必要になった場合は UI 側の責務とし、共有クエリ層では上限を設けない。

## レビュー観点

- キャッシュ制御（`cacheLife('max')` + `cacheTag('db-content')`）は interface 層の `getSlideContents()` にあり、application 層の今回の変更では触っていない
- テストは blog 側の `blogs.test.ts` の境界テストと同じパターン（150件のモック + `expect.not.objectContaining({ limit: ... })`）

## 検証

- `vitest run src/features/slides/application/slides.test.ts`: 3テストすべてパス
- apps/main 全体のテスト: 147ファイル・483テストパス
- `pnpm run type-check`: パス

## 追記: VRT の Story 間リーク修正（886229cf）

VRT で `global-layout` の `Outdated-Browser` に差分（バナー消失）が出たが、本 PR の slides 変更とは無関係の Story 隔離不足だった。`browser-baseline-notice` の `Dismiss` Story が `k8o:browser-baseline-notice-dismissed` を sessionStorage に残すと、同一セッションで実行される `OutdatedBrowser` のバナーが描画されない。`browser-baseline-notice.stories.tsx` と同様に `beforeEach` でキーをクリアして隔離した（#1963 の nuqs リーク修正と同種の対応）。
