### PR TITLE
fix(blog): slug検証をblogPathに集約しfeatureId重複の勝者を決定化する

### DIFF
--- a/apps/main/src/features/blog/application/feature-blog-map.test.ts
+++ b/apps/main/src/features/blog/application/feature-blog-map.test.ts
@@ -1,0 +1,112 @@
+import { getBlogMetadata } from './blog';
+import { getBlogs } from './blogs';
+import { getFeatureBlogMap } from './feature-blog-map';
+
+vi.mock('./blog', () => ({ getBlogMetadata: vi.fn() }));
+vi.mock('./blogs', () => ({ getBlogs: vi.fn() }));
+
+const blogRow = (id: number, slug: string) => ({ id, slug, tags: [] });
+
+const metadata = (title: string, featureIds?: string[]) => ({
+  title,
+  description: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  ...(featureIds ? { featureIds } : {}),
+});
+
+describe('getFeatureBlogMap', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('正常系', () => {
+    it('featureIdsを持つ記事からマップを構築する', async () => {
+      vi.mocked(getBlogs).mockResolvedValue([
+        blogRow(1, 'blog-a'),
+        blogRow(2, 'blog-b'),
+      ]);
+      vi.mocked(getBlogMetadata)
+        .mockResolvedValueOnce(metadata('記事A', ['feature-1', 'feature-2']))
+        .mockResolvedValueOnce(metadata('記事B', ['feature-3']));
+
+      const result = await getFeatureBlogMap();
+
+      expect(result).toStrictEqual({
+        'feature-1': { slug: 'blog-a', title: '記事A' },
+        'feature-2': { slug: 'blog-a', title: '記事A' },
+        'feature-3': { slug: 'blog-b', title: '記事B' },
+      });
+    });
+
+    it('featureIdsが無い記事はマップに含めない', async () => {
+      vi.mocked(getBlogs).mockResolvedValue([blogRow(1, 'blog-a')]);
+      vi.mocked(getBlogMetadata).mockResolvedValue(metadata('記事A'));
+
+      const result = await getFeatureBlogMap();
+
+      expect(result).toStrictEqual({});
+    });
+  });
+
+  describe('featureIdの重複', () => {
+    it('getBlogsの並びで先頭（createdAt降順で最新）の記事を勝者にする', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.mocked(getBlogs).mockResolvedValue([
+        blogRow(2, 'newest-blog'),
+        blogRow(1, 'oldest-blog'),
+      ]);
+      vi.mocked(getBlogMetadata)
+        .mockResolvedValueOnce(metadata('最新の記事', ['feature-1']))
+        .mockResolvedValueOnce(metadata('古い記事', ['feature-1']));
+
+      const result = await getFeatureBlogMap();
+
+      expect(result).toStrictEqual({
+        'feature-1': { slug: 'newest-blog', title: '最新の記事' },
+      });
+      warn.mockRestore();
+    });
+
+    it('メタデータの解決順に関係なく勝者が変わらない', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.mocked(getBlogs).mockResolvedValue([
+        blogRow(2, 'newest-blog'),
+        blogRow(1, 'oldest-blog'),
+      ]);
+      vi.mocked(getBlogMetadata)
+        .mockImplementationOnce(async () => {
+          await new Promise((resolve) => {
+            setTimeout(resolve, 10);
+          });
+          return metadata('最新の記事', ['feature-1']);
+        })
+        .mockResolvedValueOnce(metadata('古い記事', ['feature-1']));
+
+      const result = await getFeatureBlogMap();
+
+      expect(result).toStrictEqual({
+        'feature-1': { slug: 'newest-blog', title: '最新の記事' },
+      });
+      warn.mockRestore();
+    });
+
+    it('重複を検出したら警告を出す', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      vi.mocked(getBlogs).mockResolvedValue([
+        blogRow(2, 'newest-blog'),
+        blogRow(1, 'oldest-blog'),
+      ]);
+      vi.mocked(getBlogMetadata)
+        .mockResolvedValueOnce(metadata('最新の記事', ['feature-1']))
+        .mockResolvedValueOnce(metadata('古い記事', ['feature-1']));
+
+      await getFeatureBlogMap();
+
+      expect(warn).toHaveBeenCalledWith(
+        'featureId "feature-1" が複数の記事で指定されています: newest-blog, oldest-blog（newest-blog を使用）',
+      );
+      warn.mockRestore();
+    });
+  });
+});

--- a/apps/main/src/features/blog/application/feature-blog-map.ts
+++ b/apps/main/src/features/blog/application/feature-blog-map.ts
@@ -8,17 +8,29 @@ export type BlogLink = {
 
 export async function getFeatureBlogMap(): Promise<Record<string, BlogLink>> {
   const blogs = await getBlogs();
-  const map: Record<string, BlogLink> = {};
-
-  await Promise.all(
-    blogs.map(async (blog) => {
-      const metadata = await getBlogMetadata(blog.slug);
-      if (!metadata.featureIds) return;
-      for (const featureId of metadata.featureIds) {
-        map[featureId] = { slug: blog.slug, title: metadata.title };
-      }
-    }),
+  const metadataList = await Promise.all(
+    blogs.map(async (blog) => ({
+      slug: blog.slug,
+      metadata: await getBlogMetadata(blog.slug),
+    })),
   );
 
-  return map;
+  // 並列処理中にmapへ直接書き込むと、featureId重複時の勝者が
+  // ファイル読み込みの完了順で非決定に決まってしまう。
+  // getBlogsの並び（createdAt降順）で逐次確定し、最新記事を勝者にする。
+  const map = new Map<string, BlogLink>();
+  for (const { slug, metadata } of metadataList) {
+    for (const featureId of metadata.featureIds ?? []) {
+      const existing = map.get(featureId);
+      if (existing) {
+        console.warn(
+          `featureId "${featureId}" が複数の記事で指定されています: ${existing.slug}, ${slug}（${existing.slug} を使用）`,
+        );
+        continue;
+      }
+      map.set(featureId, { slug, title: metadata.title });
+    }
+  }
+
+  return Object.fromEntries(map);
 }

--- a/apps/main/src/features/blog/application/path.test.ts
+++ b/apps/main/src/features/blog/application/path.test.ts
@@ -3,78 +3,36 @@ import { cwd } from 'node:process';
 
 import { blogPath } from './path';
 
-vi.mock('path');
-vi.mock('process');
-
 describe('blogPath', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
+  describe('正常系', () => {
+    it('slugからブログ記事のMDXファイルパスを生成する', () => {
+      const result = blogPath('test-slug');
+
+      expect(result).toBe(
+        join(cwd(), 'src/app/blog/(articles)/test-slug/page.mdx'),
+      );
+    });
+
+    it('英小文字・数字・ハイフンのみのslugを受け付ける', () => {
+      const result = blogPath('feature-123');
+
+      expect(result).toBe(
+        join(cwd(), 'src/app/blog/(articles)/feature-123/page.mdx'),
+      );
+    });
   });
 
-  it('正しいブログファイルのパスを生成する', () => {
-    const mockCwd = '/Users/test/project';
-    const mockJoin = vi
-      .fn()
-      .mockReturnValue(
-        '/Users/test/project/src/app/blog/(articles)/test-slug/page.mdx',
-      );
-
-    vi.mocked(cwd).mockReturnValue(mockCwd);
-    vi.mocked(join).mockImplementation(mockJoin);
-
-    const result = blogPath('test-slug');
-
-    expect(cwd).toHaveBeenCalled();
-    expect(join).toHaveBeenCalledWith(
-      mockCwd,
-      'src/app/blog/(articles)/test-slug/page.mdx',
-    );
-    expect(result).toBe(
-      '/Users/test/project/src/app/blog/(articles)/test-slug/page.mdx',
-    );
-  });
-
-  it('異なるスラッグでも正しいパスを生成する', () => {
-    const mockCwd = '/root/app';
-    const mockJoin = vi
-      .fn()
-      .mockReturnValue(
-        '/root/app/src/app/blog/(articles)/another-blog/page.mdx',
-      );
-
-    vi.mocked(cwd).mockReturnValue(mockCwd);
-    vi.mocked(join).mockImplementation(mockJoin);
-
-    const result = blogPath('another-blog');
-
-    expect(join).toHaveBeenCalledWith(
-      mockCwd,
-      'src/app/blog/(articles)/another-blog/page.mdx',
-    );
-    expect(result).toBe(
-      '/root/app/src/app/blog/(articles)/another-blog/page.mdx',
-    );
-  });
-
-  it('特殊文字を含むスラッグでも動作する', () => {
-    const mockCwd = '/project';
-    const mockJoin = vi
-      .fn()
-      .mockReturnValue(
-        '/project/src/app/blog/(articles)/special-chars-123/page.mdx',
-      );
-
-    vi.mocked(cwd).mockReturnValue(mockCwd);
-    vi.mocked(join).mockImplementation(mockJoin);
-
-    const result = blogPath('special-chars-123');
-
-    expect(join).toHaveBeenCalledWith(
-      mockCwd,
-      'src/app/blog/(articles)/special-chars-123/page.mdx',
-    );
-    expect(result).toBe(
-      '/project/src/app/blog/(articles)/special-chars-123/page.mdx',
-    );
+  describe('異常系', () => {
+    it.each([
+      ['パストラバーサル', '../../etc/passwd'],
+      ['スラッシュ', 'a/b'],
+      ['バックスラッシュ', 'a\\b'],
+      ['ドット', '..'],
+      ['英大文字', 'Test-Slug'],
+      ['空文字', ''],
+      ['ヌル文字', 'slug\0'],
+    ])('%s を含むslugは例外を投げる', (_name, slug) => {
+      expect(() => blogPath(slug)).toThrow(`Invalid slug: ${slug}`);
+    });
   });
 });

--- a/apps/main/src/features/blog/application/path.ts
+++ b/apps/main/src/features/blog/application/path.ts
@@ -1,5 +1,13 @@
 import { join } from 'node:path';
 import { cwd } from 'node:process';
 
-export const blogPath = (slug: string) =>
-  join(cwd(), `src/app/blog/(articles)/${slug}/page.mdx`);
+// パストラバーサル対策: slug をファイルパスに渡す前に厳格に検証する。
+// %2F デコードで `../` 脱出を許さないよう、英小文字・数字・ハイフンのみ許可。
+const SLUG_RE = /^[a-z0-9-]+$/u;
+
+export const blogPath = (slug: string): string => {
+  if (!SLUG_RE.test(slug)) {
+    throw new Error(`Invalid slug: ${slug}`);
+  }
+  return join(cwd(), `src/app/blog/(articles)/${slug}/page.mdx`);
+};

--- a/apps/main/src/features/blog/interface/markdown.ts
+++ b/apps/main/src/features/blog/interface/markdown.ts
@@ -5,17 +5,9 @@ import { cacheLife } from 'next/cache';
 import { mdxToMarkdown } from '../application/markdown';
 import { blogPath } from '../application/path';
 
-// パストラバーサル対策: slug をファイルパスに渡す前に厳格に検証する。
-// %2F デコードで `../` 脱出を許さないよう、英小文字・数字・ハイフンのみ許可。
-const SLUG_RE = /^[a-z0-9-]+$/u;
-
 export async function getMarkdown(slug: string) {
   'use cache';
   cacheLife('max');
-
-  if (!SLUG_RE.test(slug)) {
-    throw new Error(`Invalid slug: ${slug}`);
-  }
 
   const content = await readFile(blogPath(slug), 'utf-8');
   return mdxToMarkdown(content, slug);


### PR DESCRIPTION
## 概要

ブログ基盤の防御強化2点。

### 1. パストラバーサル防御の集約

slugの形式検証（`^[a-z0-9-]+$`）は `interface/markdown.ts` の `getMarkdown` にしかなく、同じ `blogPath` でファイルパスを組み立てる `getBlogMetadata` / `getBlogToc` / `getBlogOgCode` / `getBlogsByTags` は無検証だった。現状の呼び出し元はビルド時の固定slugのみで実害はないが、防御を `blogPath` 自体に移し、不正なslugは例外にして全経路を自動的にカバーする。`getMarkdown` 側の重複検証は削除（エラーメッセージは同一で挙動不変）。

`path.test.ts` は `join`/`cwd` をモックして戻り値をそのまま検証する同語反復のテストだったため、実際のパス生成と `../` 等の拒否を検証するテストに書き換えた。

### 2. featureId重複時の勝者の決定化

`getFeatureBlogMap` は `Promise.all` の並列処理中にmapへ直接書き込んでいたため、複数記事が同じ `featureId` を持つと勝者がファイル読み込みの完了順で非決定に決まっていた。メタデータ取得は並列のまま、マップの確定を `getBlogs` の並び（createdAt降順・id降順）で逐次行い、最新記事を勝者に固定する。重複検出時は `console.warn` でビルドログに警告を残す（記事公開をブロックしないためビルドエラーにはしない）。

## レビューポイント

- 既存の全74記事のslugが `SLUG_RE` に適合することを確認済み（ビルドは壊れない）
- 検証はAGENTS.mdのレイヤー規約に合わせて `application` 層の `blogPath` に置き、`'use cache'` 境界の `interface` 層は素通しする構成
- featureテスト126件・type-check・`pnpm run check`（既存ベースラインに一致）を確認済み

## テスト

- `blogPath`: 正常系のパス生成と、トラバーサル・スラッシュ・ヌル文字等の拒否
- `getFeatureBlogMap`: マップ構築の正常系、重複時の勝者決定、メタデータ解決順（最新記事の読み込みを意図的に遅延）に依存しないことの回帰テスト、警告出力