### PR TITLE
test(main): 非同期描画を待たずに撮影されてflakyだったStoryのVRTを決定化する

### DIFF
--- a/apps/main/src/app/_components/global-layout/global-layout.stories.tsx
+++ b/apps/main/src/app/_components/global-layout/global-layout.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+import { expect } from 'storybook/test';
 
 import { GlobalLayout } from './global-layout';
 
@@ -24,5 +25,15 @@ export const OutdatedBrowser: Story = {
       safari: '9999',
       safari_ios: '9999',
     },
+  },
+  // テストは同一ページで実行されるため、browser-baseline-notice の Dismiss 実行後だと
+  // 閉じた状態が sessionStorage に残ってバナーが出なくなる。毎回クリアして状態を揃える
+  beforeEach: () => {
+    sessionStorage.removeItem('k8o:browser-baseline-notice-dismissed');
+  },
+  // バナーはクライアント側のブラウザ判定後に描画されるため、表示を待ってから
+  // VRT のスクリーンショットが撮影されるようにする
+  play: async ({ canvas }) => {
+    await expect(await canvas.findByRole('alert')).toBeInTheDocument();
   },
 };

--- a/apps/main/src/app/code-dock/_components/code-dock/code-dock.stories.tsx
+++ b/apps/main/src/app/code-dock/_components/code-dock/code-dock.stories.tsx
@@ -45,6 +45,22 @@ const meta: Meta<typeof CodeDock> = {
 export default meta;
 type Story = StoryObj<typeof CodeDock>;
 
+// 初期サンプルの自動検査はデバウンス(600ms)後に走るため、検査結果の表示まで待つ。
+// 待たずに play を終えるとスピナー+プレースホルダーの状態で VRT が撮影されて
+// flaky になる
+const waitForInitialLintResult = async (
+  canvas: ReturnType<typeof within>,
+): Promise<void> => {
+  await waitFor(
+    () => {
+      expect(
+        canvas.getByText('Unexpected console statement.'),
+      ).toBeInTheDocument();
+    },
+    { timeout: 5000 },
+  );
+};
+
 // 正常系: 初期サンプルがデバウンス後に自動で検査される
 export const Primary: Story = {
   play: async ({ canvasElement }) => {
@@ -52,14 +68,7 @@ export const Primary: Story = {
     await expect(
       canvas.getByRole('textbox', { name: 'コード' }),
     ).toBeInTheDocument();
-    await waitFor(
-      () => {
-        expect(
-          canvas.getByText('Unexpected console statement.'),
-        ).toBeInTheDocument();
-      },
-      { timeout: 5000 },
-    );
+    await waitForInitialLintResult(canvas);
   },
 };
 
@@ -71,6 +80,7 @@ export const Copy: Story = {
     await expect(button).toBeEnabled();
     await userEvent.click(button);
     await expect(button).toBeInTheDocument();
+    await waitForInitialLintResult(canvas);
   },
 };
 
@@ -113,6 +123,7 @@ export const FormatFailed: Story = {
         canvas.getByText('整形できませんでした: Unexpected token'),
       ).toBeInTheDocument();
     });
+    await waitForInitialLintResult(canvas);
   },
 };
 
@@ -125,5 +136,6 @@ export const SwitchLanguage: Story = {
     await userEvent.selectOptions(select, 'ts');
 
     await expect(select).toHaveValue('ts');
+    await waitForInitialLintResult(canvas);
   },
 };


### PR DESCRIPTION
## 概要

多数のPR（#1952, #1955, #1956, #1957, #1963, #1964, #1966, #1969 など）で、変更していないのに繰り返し changed と誤検知されていた3つのStoryのVRTを安定化する。

## 原因

VRTの撮影は play 完了後に行われ、「2連続で同一画像になるまで」最大約500ms（100ms×5回）しか待たない。この安定判定は*変化の最中*しか検出できず、「まだ変化が始まっていない」画面は安定と誤認する。

- **code-dock（Copy / FormatFailed / SwitchLanguage）**: 初期サンプルの自動検査がデバウンス600ms後に走るため、実行タイミングによってスピナー+プレースホルダーのまま撮影されたり検査結果まで写ったりしていた（スピナーは撮影時のアニメーション無効化で静止画になり、安定判定をすり抜ける）
- **global-layout（OutdatedBrowser）**: バナーがクライアント側判定後に描画されることに加え、storybook テストは同一ページで実行される（`isolate: false`）ため、browser-baseline-notice の Dismiss が先に走ると解除フラグが sessionStorage に残り、バナー自体が表示されなくなる実行順依存があった

## 変更内容

- code-dock: 検査結果の表示を待つ共有ヘルパーを導入し、Primary / Copy / FormatFailed / SwitchLanguage の play で最終状態まで待ってから撮影されるようにする。報告されていた2 Storyに加え、同じ競合構造を持つ SwitchLanguage も対象にした（修正前コードでflakeを再現済み）
- global-layout: OutdatedBrowser に sessionStorage の解除フラグをクリアする `beforeEach` と、バナー（alert）の表示を待つ play を追加（browser-baseline-notice の既存Storyと同じパターン）

## 確認

- 修正前: ローカル1回の実行で Copy / Format-Failed / Switch-Language の3枚が changed になるflakeを再現
- 修正後: フルスイートで撮影→`svrt compare` を3回実行し、いずれも `236 passed | 0 changed`
- play関数テスト248件パス、lint・型チェックともに変更ファイルへの指摘なし

## レビューメモ

Copy の撮影にはトースト「コピーに失敗しました」が写る（ヘッドレスChromiumのクリップボード制約で、環境内では一貫）。今回のflakeとは無関係のため対応しない。