### PR TITLE
chore(playgrounds): 未使用のデモ再エクスポートを削除する

### DIFF
--- a/apps/main/src/app/_components/playgrounds/abs-sign/index.ts
+++ b/apps/main/src/app/_components/playgrounds/abs-sign/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { CssMathFunctionsDemo } from './css-math-functions-demo';
 
-export { CssMathFunctionsDemo } from './css-math-functions-demo';
-
 export const absSignSection: PlaygroundSection = {
   id: 'abs-sign',
   title: 'CSS abs()とsign()関数',

--- a/apps/main/src/app/_components/playgrounds/active-view-transition/index.ts
+++ b/apps/main/src/app/_components/playgrounds/active-view-transition/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { ActiveViewTransitionDemo } from './active-view-transition-demo';
 
-export { ActiveViewTransitionDemo } from './active-view-transition-demo';
-
 export const activeViewTransitionSection: PlaygroundSection = {
   id: 'active-view-transition',
   title: ':active-view-transition-type()疑似クラス',

--- a/apps/main/src/app/_components/playgrounds/async-clipboard/index.ts
+++ b/apps/main/src/app/_components/playgrounds/async-clipboard/index.ts
@@ -2,9 +2,6 @@ import type { PlaygroundSection } from '../types';
 import { ClipboardImageDemo } from './clipboard-image-demo';
 import { ClipboardTextDemo } from './clipboard-text-demo';
 
-export { ClipboardImageDemo } from './clipboard-image-demo';
-export { ClipboardTextDemo } from './clipboard-text-demo';
-
 export const asyncClipboardSection: PlaygroundSection = {
   id: 'async-clipboard',
   title: 'Clipboard API',

--- a/apps/main/src/app/_components/playgrounds/baseline-shift/index.ts
+++ b/apps/main/src/app/_components/playgrounds/baseline-shift/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { BaselineShiftDemo } from './baseline-shift-demo';
 
-export { BaselineShiftDemo } from './baseline-shift-demo';
-
 export const baselineShiftSection: PlaygroundSection = {
   id: 'baseline-shift',
   title: 'baseline-shift',

--- a/apps/main/src/app/_components/playgrounds/caret-position-from-point/index.ts
+++ b/apps/main/src/app/_components/playgrounds/caret-position-from-point/index.ts
@@ -2,9 +2,6 @@ import type { PlaygroundSection } from '../types';
 import { CaretPositionDemo } from './caret-position-demo';
 import { DragDropDemo } from './drag-drop-demo';
 
-export { CaretPositionDemo } from './caret-position-demo';
-export { DragDropDemo } from './drag-drop-demo';
-
 export const caretPositionFromPointSection: PlaygroundSection = {
   id: 'caret-position-from-point',
   title: 'CaretPositionFromPoint',

--- a/apps/main/src/app/_components/playgrounds/composed-ranges/index.ts
+++ b/apps/main/src/app/_components/playgrounds/composed-ranges/index.ts
@@ -3,10 +3,6 @@ import { GetComposedRanges } from './get-composed-ranges';
 import { SelectionMethods } from './selection-methods';
 import { SelectionProperties } from './selection-properties';
 
-export { GetComposedRanges } from './get-composed-ranges';
-export { SelectionMethods } from './selection-methods';
-export { SelectionProperties } from './selection-properties';
-
 export const composedRangesSection: PlaygroundSection = {
   id: 'composed-ranges',
   title: 'Selectionオブジェクト',

--- a/apps/main/src/app/_components/playgrounds/container-style-queries/index.ts
+++ b/apps/main/src/app/_components/playgrounds/container-style-queries/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { ContainerStyleQueriesDemo } from './container-style-queries-demo';
 
-export { ContainerStyleQueriesDemo } from './container-style-queries-demo';
-
 export const containerStyleQueriesSection: PlaygroundSection = {
   id: 'container-style-queries',
   title: 'Container style queries',

--- a/apps/main/src/app/_components/playgrounds/content-visibility/index.ts
+++ b/apps/main/src/app/_components/playgrounds/content-visibility/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { ContentVisibilityDemo } from './content-visibility-demo';
 
-export { ContentVisibilityDemo } from './content-visibility-demo';
-
 export const contentVisibilitySection: PlaygroundSection = {
   id: 'content-visibility',
   title: 'content-visibility',

--- a/apps/main/src/app/_components/playgrounds/contrast-color/index.ts
+++ b/apps/main/src/app/_components/playgrounds/contrast-color/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { ContrastColorDemo } from './contrast-color-demo';
 
-export { ContrastColorDemo } from './contrast-color-demo';
-
 export const contrastColorSection: PlaygroundSection = {
   id: 'contrast-color',
   title: 'contrast-color',

--- a/apps/main/src/app/_components/playgrounds/crisp-edges/index.ts
+++ b/apps/main/src/app/_components/playgrounds/crisp-edges/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { CrispEdgesDemo } from './crisp-edges-demo';
 
-export { CrispEdgesDemo } from './crisp-edges-demo';
-
 export const crispEdgesSection: PlaygroundSection = {
   id: 'crisp-edges',
   title: 'image-rendering: crisp-edges',

--- a/apps/main/src/app/_components/playgrounds/details-content/index.ts
+++ b/apps/main/src/app/_components/playgrounds/details-content/index.ts
@@ -2,9 +2,6 @@ import type { PlaygroundSection } from '../types';
 import { DetailsAnimationDemo } from './details-animation-demo';
 import { DetailsContentDemo } from './details-content-demo';
 
-export { DetailsAnimationDemo } from './details-animation-demo';
-export { DetailsContentDemo } from './details-content-demo';
-
 export const detailsContentSection: PlaygroundSection = {
   id: 'details-content',
   title: '::details-content擬似要素',

--- a/apps/main/src/app/_components/playgrounds/event-timing/index.ts
+++ b/apps/main/src/app/_components/playgrounds/event-timing/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { EventTimingDemo } from './event-timing-demo';
 
-export { EventTimingDemo } from './event-timing-demo';
-
 export const eventTimingSection: PlaygroundSection = {
   id: 'event-timing',
   title: 'Event Timing',

--- a/apps/main/src/app/_components/playgrounds/field-sizing/index.ts
+++ b/apps/main/src/app/_components/playgrounds/field-sizing/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { FieldSizingDemo } from './field-sizing-demo';
 
-export { FieldSizingDemo } from './field-sizing-demo';
-
 export const fieldSizingSection: PlaygroundSection = {
   id: 'field-sizing',
   title: 'field-sizing',

--- a/apps/main/src/app/_components/playgrounds/font-family-math/index.ts
+++ b/apps/main/src/app/_components/playgrounds/font-family-math/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { FontFamilyMathDemo } from './font-family-math-demo';
 
-export { FontFamilyMathDemo } from './font-family-math-demo';
-
 export const fontFamilyMathSection: PlaygroundSection = {
   id: 'font-family-math',
   title: 'font-family: math',

--- a/apps/main/src/app/_components/playgrounds/highlight/index.ts
+++ b/apps/main/src/app/_components/playgrounds/highlight/index.ts
@@ -3,10 +3,6 @@ import { HighlightBasicDemo } from './highlight-basic-demo';
 import { HighlightPriorityDemo } from './highlight-priority-demo';
 import { HighlightSpellingDemo } from './highlight-spelling-demo';
 
-export { HighlightBasicDemo } from './highlight-basic-demo';
-export { HighlightPriorityDemo } from './highlight-priority-demo';
-export { HighlightSpellingDemo } from './highlight-spelling-demo';
-
 export const highlightSection: PlaygroundSection = {
   id: 'highlight',
   title: 'CSS Custom Highlight API',

--- a/apps/main/src/app/_components/playgrounds/input-file-webkitdirectory/index.ts
+++ b/apps/main/src/app/_components/playgrounds/input-file-webkitdirectory/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { WebkitRelativePathDemo } from './webkit-relative-path-demo';
 
-export { WebkitRelativePathDemo } from './webkit-relative-path-demo';
-
 export const inputFileWebkitdirectorySection: PlaygroundSection = {
   id: 'input-file-webkitdirectory',
   title: 'input要素のwebkitdirectory属性',

--- a/apps/main/src/app/_components/playgrounds/invoker-commands/index.ts
+++ b/apps/main/src/app/_components/playgrounds/invoker-commands/index.ts
@@ -3,10 +3,6 @@ import { CustomCommandDemo } from './custom-command-demo';
 import { DialogDemo } from './dialog-demo';
 import { PopoverDemo } from './popover-demo';
 
-export { CustomCommandDemo } from './custom-command-demo';
-export { DialogDemo } from './dialog-demo';
-export { PopoverDemo } from './popover-demo';
-
 export const invokerCommandsSection: PlaygroundSection = {
   id: 'invoker-commands',
   title: 'Invoker Commands API',

--- a/apps/main/src/app/_components/playgrounds/largest-contentful-paint/index.ts
+++ b/apps/main/src/app/_components/playgrounds/largest-contentful-paint/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { LCPDemo } from './lcp-demo';
 
-export { LCPDemo } from './lcp-demo';
-
 export const lcpSection: PlaygroundSection = {
   id: 'largest-contentful-paint',
   title: 'Largest Contentful Paint',

--- a/apps/main/src/app/_components/playgrounds/open-pseudo/index.ts
+++ b/apps/main/src/app/_components/playgrounds/open-pseudo/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { OpenPseudoDemo } from './open-pseudo-demo';
 
-export { OpenPseudoDemo } from './open-pseudo-demo';
-
 export const openPseudoSection: PlaygroundSection = {
   id: 'open-pseudo',
   title: ':open',

--- a/apps/main/src/app/_components/playgrounds/popover/index.ts
+++ b/apps/main/src/app/_components/playgrounds/popover/index.ts
@@ -2,9 +2,6 @@ import type { PlaygroundSection } from '../types';
 import { PopoverApiDemo } from './popover-api-demo';
 import { TooltipDropdownDemo } from './tooltip-dropdown-demo';
 
-export { PopoverApiDemo } from './popover-api-demo';
-export { TooltipDropdownDemo } from './tooltip-dropdown-demo';
-
 export const popoverSection: PlaygroundSection = {
   id: 'popover',
   title: 'Popover API',

--- a/apps/main/src/app/_components/playgrounds/print-color-adjust/index.ts
+++ b/apps/main/src/app/_components/playgrounds/print-color-adjust/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { PrintColorAdjustDemo } from './print-color-adjust-demo';
 
-export { PrintColorAdjustDemo } from './print-color-adjust-demo';
-
 export const printColorAdjustSection: PlaygroundSection = {
   id: 'print-color-adjust',
   title: 'CSS print-color-adjust',

--- a/apps/main/src/app/_components/playgrounds/requestclose/index.ts
+++ b/apps/main/src/app/_components/playgrounds/requestclose/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { DialogRequestCloseDemo } from './dialog-requestclose-demo';
 
-export { DialogRequestCloseDemo } from './dialog-requestclose-demo';
-
 export const requestCloseSection: PlaygroundSection = {
   id: 'requestclose',
   title: 'Dialog requestClose',

--- a/apps/main/src/app/_components/playgrounds/root-font-units/index.ts
+++ b/apps/main/src/app/_components/playgrounds/root-font-units/index.ts
@@ -2,9 +2,6 @@ import type { PlaygroundSection } from '../types';
 import { RootComparisonDemo } from './root-comparison-demo';
 import { UnitComparisonDemo } from './unit-comparison-demo';
 
-export { RootComparisonDemo } from './root-comparison-demo';
-export { UnitComparisonDemo } from './unit-comparison-demo';
-
 export const rootFontUnitsSection: PlaygroundSection = {
   id: 'root-font-units',
   title: 'rcap, rch, rex, ric',

--- a/apps/main/src/app/_components/playgrounds/scope/index.ts
+++ b/apps/main/src/app/_components/playgrounds/scope/index.ts
@@ -3,10 +3,6 @@ import { DonutScopeDemo } from './donut-scope-demo';
 import { ScopeLimitDemo } from './scope-limit-demo';
 import { ScopeProximityDemo } from './scope-proximity-demo';
 
-export { DonutScopeDemo } from './donut-scope-demo';
-export { ScopeLimitDemo } from './scope-limit-demo';
-export { ScopeProximityDemo } from './scope-proximity-demo';
-
 export const scopeSection: PlaygroundSection = {
   id: 'scope',
   title: '@scope',

--- a/apps/main/src/app/_components/playgrounds/screen-wake-lock/index.ts
+++ b/apps/main/src/app/_components/playgrounds/screen-wake-lock/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { WakeLockDemo } from './wake-lock-demo';
 
-export { WakeLockDemo } from './wake-lock-demo';
-
 export const screenWakeLockSection: PlaygroundSection = {
   id: 'screen-wake-lock',
   title: 'Screen Wake Lock API',

--- a/apps/main/src/app/_components/playgrounds/scrollbar-color/index.ts
+++ b/apps/main/src/app/_components/playgrounds/scrollbar-color/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { ScrollbarColorDemo } from './scrollbar-color-demo';
 
-export { ScrollbarColorDemo } from './scrollbar-color-demo';
-
 export const scrollbarColorSection: PlaygroundSection = {
   id: 'scrollbar-color',
   title: 'scrollbar-color',

--- a/apps/main/src/app/_components/playgrounds/scrollend/index.ts
+++ b/apps/main/src/app/_components/playgrounds/scrollend/index.ts
@@ -2,9 +2,6 @@ import type { PlaygroundSection } from '../types';
 import { ScrollendDemo } from './scrollend-demo';
 import { ScrollendTriggerDemo } from './scrollend-trigger-demo';
 
-export { ScrollendDemo } from './scrollend-demo';
-export { ScrollendTriggerDemo } from './scrollend-trigger-demo';
-
 export const scrollendSection: PlaygroundSection = {
   id: 'scrollend',
   title: 'scrollend',

--- a/apps/main/src/app/_components/playgrounds/shape-function/index.ts
+++ b/apps/main/src/app/_components/playgrounds/shape-function/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { ShapeFunctionDemo } from './shape-function-demo';
 
-export { ShapeFunctionDemo } from './shape-function-demo';
-
 export const shapeFunctionSection: PlaygroundSection = {
   id: 'shape-function',
   title: 'shape()',

--- a/apps/main/src/app/_components/playgrounds/shared-worker/index.ts
+++ b/apps/main/src/app/_components/playgrounds/shared-worker/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { SharedWorkerDemo } from './shared-worker-demo';
 
-export { SharedWorkerDemo } from './shared-worker-demo';
-
 export const sharedWorkerSection: PlaygroundSection = {
   id: 'shared-worker',
   title: 'SharedWorker',

--- a/apps/main/src/app/_components/playgrounds/spelling-grammar-error/index.ts
+++ b/apps/main/src/app/_components/playgrounds/spelling-grammar-error/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { SpellingGrammarErrorDemo } from './spelling-grammar-error-demo';
 
-export { SpellingGrammarErrorDemo } from './spelling-grammar-error-demo';
-
 export const spellingGrammarErrorSection: PlaygroundSection = {
   id: 'spelling-grammar-error',
   title: 'CSS spelling-error & grammar-error',

--- a/apps/main/src/app/_components/playgrounds/suspense-list/index.ts
+++ b/apps/main/src/app/_components/playgrounds/suspense-list/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { SuspenseListDemo } from './suspense-list-demo';
 
-export { SuspenseListDemo } from './suspense-list-demo';
-
 export const suspenseListSection: PlaygroundSection = {
   id: 'suspense-list',
   title: 'React SuspenseList',

--- a/apps/main/src/app/_components/playgrounds/text-decoration-skip-ink-all/index.ts
+++ b/apps/main/src/app/_components/playgrounds/text-decoration-skip-ink-all/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { TextDecorationSkipInkDemo } from './text-decoration-skip-ink-demo';
 
-export { TextDecorationSkipInkDemo } from './text-decoration-skip-ink-demo';
-
 export const textDecorationSkipInkAllSection: PlaygroundSection = {
   id: 'text-decoration-skip-ink-all',
   title: 'text-decoration-skip-ink: all',

--- a/apps/main/src/app/_components/playgrounds/text-indent-keywords/index.ts
+++ b/apps/main/src/app/_components/playgrounds/text-indent-keywords/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { TextIndentKeywordsDemo } from './text-indent-keywords-demo';
 
-export { TextIndentKeywordsDemo } from './text-indent-keywords-demo';
-
 export const textIndentKeywordsSection: PlaygroundSection = {
   id: 'text-indent-keywords',
   title: 'text-indent: each-line / hanging',

--- a/apps/main/src/app/_components/playgrounds/toggleevent-source/index.ts
+++ b/apps/main/src/app/_components/playgrounds/toggleevent-source/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { ToggleEventSourceDemo } from './toggleevent-source-demo';
 
-export { ToggleEventSourceDemo } from './toggleevent-source-demo';
-
 export const toggleEventSourceSection: PlaygroundSection = {
   id: 'toggleevent-source',
   title: 'ToggleEvent.source',

--- a/apps/main/src/app/_components/playgrounds/view-transitions/index.ts
+++ b/apps/main/src/app/_components/playgrounds/view-transitions/index.ts
@@ -1,8 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { ViewTransitionBasicDemo } from './view-transition-basic-demo';
 
-export { ViewTransitionBasicDemo } from './view-transition-basic-demo';
-
 export const viewTransitionsSection: PlaygroundSection = {
   id: 'view-transitions',
   title: 'View Transition API',


### PR DESCRIPTION
## 概要

Playgroundのカタログ化リファクタ（#1986）で、ブログはデモを直接importせず `<PlaygroundEmbed demo="..." sectionId="..." />` 経由で埋め込む方式に変わりました。その結果、各 `apps/main/src/app/_components/playgrounds/*/index.ts` 冒頭にあった `export { XxxDemo } from './xxx-demo'` という再エクスポートが誰からも参照されなくなり、旧方式の名残として残っていました。

このため、weeklyのknipレポートが `Unused exports` としてこれらを49件列挙し、レポートがノイズ化していました。

## 変更内容

35個の `index.ts` から、未使用の再エクスポート行（計49本・84行削除）だけを削除しました。

- `sections.ts` は `*Section` オブジェクトのみをimportするため影響なし
- `demos: [{ component }]` で使う `import` 行は残す
- Storyは `./xxx-demo` から直接importしているため影響なし

## 検証

- **knip**: exit 0、指摘ゼロ（49件すべて解消）
- **type-check** (`-F main`): パス
- **check** (lint/format): 変更ファイルにエラー・警告なし

> [!NOTE]
> `pnpm run check` には既存の6 errors/23 warningsが残りますが、いずれも `apps/ai/.../route.ts`・`reading-list/.../summarize.ts` の `no-deprecated` 等で本PRとは無関係です。