### PR TITLE
chore(deps): 不要になった override 削除と共有依存の catalog 集約でパッケージ周りを整理

### DIFF
--- a/apps/ai/package.json
+++ b/apps/ai/package.json
@@ -18,7 +18,7 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@ai-sdk/openai-compatible": "3.0.7",
+    "@ai-sdk/openai-compatible": "catalog:",
     "@ai-sdk/react": "4.0.23",
     "@k8o/arte-odyssey": "catalog:",
     "@repo/code-highlight": "workspace:*",
@@ -26,7 +26,7 @@
     "@repo/helpers": "workspace:*",
     "@tailwindcss/postcss": "catalog:",
     "@vercel/sandbox": "2.5.0",
-    "ai": "7.0.22",
+    "ai": "catalog:",
     "better-auth": "catalog:",
     "drizzle-orm": "catalog:",
     "next": "catalog:",
@@ -37,7 +37,7 @@
     "react-markdown": "10.1.0",
     "server-only": "0.0.1",
     "tailwindcss": "catalog:",
-    "zod": "4.4.3"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/apps/main/package.json
+++ b/apps/main/package.json
@@ -19,9 +19,9 @@
     "build-storybook": "storybook build"
   },
   "dependencies": {
-    "@ai-sdk/openai-compatible": "3.0.7",
+    "@ai-sdk/openai-compatible": "catalog:",
     "@k8o/arte-odyssey": "catalog:",
-    "@k8o/oxc-config": "0.2.0",
+    "@k8o/oxc-config": "catalog:",
     "@mdx-js/loader": "3.1.1",
     "@mdx-js/react": "3.1.1",
     "@next/mdx": "catalog:",
@@ -33,7 +33,7 @@
     "@repo/react-hooks": "workspace:*",
     "@tailwindcss/postcss": "catalog:",
     "@vercel/analytics": "2.0.1",
-    "ai": "7.0.22",
+    "ai": "catalog:",
     "budoux": "0.8.4",
     "drizzle-orm": "catalog:",
     "katex": "0.17.0",
@@ -54,7 +54,7 @@
     "server-only": "0.0.1",
     "tailwindcss": "catalog:",
     "uqr": "0.1.3",
-    "zod": "4.4.3"
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "knip": "knip"
   },
   "devDependencies": {
-    "@k8o/oxc-config": "0.2.0",
+    "@k8o/oxc-config": "catalog:",
     "@ls-lint/ls-lint": "2.3.1",
     "@types/node": "24.13.3",
     "@typescript/native-preview": "7.0.0-dev.20260707.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,9 +6,15 @@ settings:
 
 catalogs:
   default:
+    '@ai-sdk/openai-compatible':
+      specifier: 3.0.7
+      version: 3.0.7
     '@k8o/arte-odyssey':
       specifier: 10.8.0
       version: 10.8.0
+    '@k8o/oxc-config':
+      specifier: 0.2.0
+      version: 0.2.0
     '@next/env':
       specifier: 16.2.10
       version: 16.2.10
@@ -51,6 +57,9 @@ catalogs:
     '@vitest/ui':
       specifier: 4.1.10
       version: 4.1.10
+    ai:
+      specifier: 7.0.22
+      version: 7.0.22
     babel-plugin-react-compiler:
       specifier: 1.0.0
       version: 1.0.0
@@ -99,16 +108,16 @@ catalogs:
     wrangler:
       specifier: 4.110.0
       version: 4.110.0
-
-overrides:
-  vite-plugin-storybook-nextjs: 3.3.0
+    zod:
+      specifier: 4.4.3
+      version: 4.4.3
 
 importers:
 
   .:
     devDependencies:
       '@k8o/oxc-config':
-        specifier: 0.2.0
+        specifier: 'catalog:'
         version: 0.2.0(bb3458ff492cd1a7675d634248174ebc)
       '@ls-lint/ls-lint':
         specifier: 2.3.1
@@ -256,7 +265,7 @@ importers:
   apps/ai:
     dependencies:
       '@ai-sdk/openai-compatible':
-        specifier: 3.0.7
+        specifier: 'catalog:'
         version: 3.0.7(zod@4.4.3)
       '@ai-sdk/react':
         specifier: 4.0.23
@@ -280,7 +289,7 @@ importers:
         specifier: 2.5.0
         version: 2.5.0
       ai:
-        specifier: 7.0.22
+        specifier: 'catalog:'
         version: 7.0.22(zod@4.4.3)
       better-auth:
         specifier: 'catalog:'
@@ -313,7 +322,7 @@ importers:
         specifier: 'catalog:'
         version: 4.3.2
       zod:
-        specifier: 4.4.3
+        specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
       '@repo/typescript-config':
@@ -377,13 +386,13 @@ importers:
   apps/main:
     dependencies:
       '@ai-sdk/openai-compatible':
-        specifier: 3.0.7
+        specifier: 'catalog:'
         version: 3.0.7(zod@4.4.3)
       '@k8o/arte-odyssey':
         specifier: 'catalog:'
         version: 10.8.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(ai@7.0.22(zod@4.4.3))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(tailwindcss@4.3.2)(typescript@6.0.3)(zod@4.4.3)
       '@k8o/oxc-config':
-        specifier: 0.2.0
+        specifier: 'catalog:'
         version: 0.2.0(oxfmt@0.58.0(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)))(oxlint-tailwindcss@1.3.5)(oxlint-tsgolint@0.24.0)(oxlint@1.73.0(oxlint-tsgolint@0.24.0)(vite-plus@0.2.4(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@6.0.3))(tsx@4.22.3)(typescript@6.0.3)(vite@8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)))
       '@mdx-js/loader':
         specifier: 3.1.1
@@ -419,7 +428,7 @@ importers:
         specifier: 2.0.1
         version: 2.0.1(next@16.2.10(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       ai:
-        specifier: 7.0.22
+        specifier: 'catalog:'
         version: 7.0.22(zod@4.4.3)
       budoux:
         specifier: 0.8.4
@@ -482,7 +491,7 @@ importers:
         specifier: 0.1.3
         version: 0.1.3
       zod:
-        specifier: 4.4.3
+        specifier: 'catalog:'
         version: 4.4.3
     devDependencies:
       '@repo/typescript-config':
@@ -13001,7 +13010,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.16
+      postcss: 8.5.17
       rolldown: 1.0.2
       tinyglobby: 0.2.17
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,10 +3,7 @@ packages:
   - packages/*
 
 allowBuilds:
-  '@prisma/engines': false
-  '@swc/core': false
   esbuild: false
-  msgpackr-extract: false
   msw: false
   sharp: false
   workerd: false
@@ -14,7 +11,9 @@ allowBuilds:
 blockExoticSubdeps: true
 
 catalog:
+  '@ai-sdk/openai-compatible': 3.0.7
   '@k8o/arte-odyssey': 10.8.0
+  '@k8o/oxc-config': 0.2.0
   '@next/env': 16.2.10
   '@next/mdx': 16.2.10
   '@next/third-parties': 16.2.10
@@ -29,6 +28,7 @@ catalog:
   '@vitest/browser-playwright': 4.1.10
   '@vitest/coverage-v8': 4.1.10
   '@vitest/ui': 4.1.10
+  ai: 7.0.22
   babel-plugin-react-compiler: 1.0.0
   better-auth: 1.6.23
   chromatic: 18.0.1
@@ -45,6 +45,7 @@ catalog:
   tailwindcss: 4.3.2
   vitest: 4.1.10
   wrangler: 4.110.0
+  zod: 4.4.3
 
 minimumReleaseAge: 10080
 
@@ -52,6 +53,3 @@ minimumReleaseAgeExclude:
   - '@k8o/*'
 
 verifyDepsBeforeRun: install
-
-overrides:
-  vite-plugin-storybook-nextjs: 3.3.0


### PR DESCRIPTION
## 概要

storybook 10.5.0 化に伴い不要になった override を削除し、あわせてパッケージ周りを整理する。すべて `chore(deps)` 相当の依存整理で、**解決バージョンは一切変わらない**（`catalog:` は指定の間接化のみ）。

## 変更内容

### 1. `vite-plugin-storybook-nextjs` の override を削除
- `@storybook/nextjs-vite@10.5.0` が `vite-plugin-storybook-nextjs` を `^3.3.0` で要求するようになった（10.4.6 は `^3.2.4`）。
- `vite-plugin-storybook-nextjs` の最新版は `3.3.0` で、`^3.3.0` の解決先は `3.3.0`。override で固定していた版と一致するため不要になった。
- override を外して lockfile を再生成し、`vite-plugin-storybook-nextjs` が `3.3.0` のまま変わらないことを確認済み。

### 2. アプリ間で共有する依存を catalog に集約
このリポジトリは「複数ワークスペースで共有する依存は catalog」という規約で運用しているが、以下だけ直書きのまま例外になっていたので集約した。解決バージョンは不変。

| パッケージ | バージョン | 使用箇所 |
|---|---|---|
| `ai` | 7.0.22 | apps/ai, apps/main |
| `zod` | 4.4.3 | apps/ai, apps/main |
| `@ai-sdk/openai-compatible` | 3.0.7 | apps/ai, apps/main |
| `@k8o/oxc-config` | 0.2.0 | root, apps/main |

### 3. `allowBuilds` の dead config を削除
依存ツリーに存在しない `@prisma/engines` / `@swc/core` / `msgpackr-extract`（prisma→drizzle 移行などで残った名残）を削除。`esbuild` / `msw` / `sharp` / `workerd` は実在するため残置。

## レビュー時の補足

- lockfile の解決バージョン差分は実質ゼロ。唯一 `postcss 8.5.16 → 8.5.17`（vite の transitive）が動くが、catalog が 8.5.17 固定のため正常化方向で無害。
- `server-only@0.0.1`（全3app共有）も catalog 化候補だが、`0.0.1` の stub で更新されず低価値のため今回は見送り。
- transitive な重複バージョンや deprecated subdeps は、解消に override 追加が必要で今回の「override を減らす」方針に逆行するため対象外。
