### PR TITLE
style: 目次サイドレールの見出し番号（01/02）を削除する

### DIFF
--- a/apps/main/src/app/blog/_components/blog-layout/table-of-contents/side-rail.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/table-of-contents/side-rail.tsx
@@ -20,17 +20,16 @@ type TocNode = {
 const RailItem: FC<{
   node: TocNode;
   depth: number;
-  index?: number;
   activeId: string;
   onNavigate: (id: string) => void;
-}> = ({ node, depth, index, activeId, onNavigate }) => {
+}> = ({ node, depth, activeId, onNavigate }) => {
   const isActive = activeId === node.text;
   return (
     <li className={cn(depth === 1 && '[&:not(:first-child)]:mt-1')}>
       <Link
         aria-current={isActive ? 'location' : undefined}
         className={cn(
-          'flex items-baseline gap-2 rounded-r-lg py-1.5 pr-2 leading-relaxed transition-colors duration-150 ease-out',
+          'block rounded-r-lg py-1.5 pr-2 leading-relaxed transition-colors duration-150 ease-out',
           'focus-visible:ring-border-info focus-visible:outline-none focus-visible:ring-2',
           depth === 1 && 'pl-5 text-sm',
           depth === 2 && 'pl-11 text-xs',
@@ -44,17 +43,7 @@ const RailItem: FC<{
           onNavigate(node.text);
         }}
       >
-        {index !== undefined && (
-          <span
-            className={cn(
-              'shrink-0 text-xs font-normal tabular-nums transition-colors duration-150 ease-out',
-              isActive ? 'text-primary-fg font-bold' : 'text-fg-mute',
-            )}
-          >
-            {String(index + 1).padStart(2, '0')}
-          </span>
-        )}
-        <span>{node.text}</span>
+        {node.text}
       </Link>
       {node.children && node.children.length > 0 && (
         <ul>
@@ -178,11 +167,10 @@ export const TableOfContentsSideRail: FC<{
             />
           )}
           <ul className="flex flex-col">
-            {headingTree.children.map((node, index) => (
+            {headingTree.children.map((node) => (
               <RailItem
                 activeId={activeId}
                 depth={1}
-                index={index}
                 key={node.text}
                 node={node}
                 onNavigate={setActiveId}


### PR DESCRIPTION
## 概要

ブログ記事の目次サイドレール（デスクトップ表示）で、トップレベル見出しに付いていた先頭連番（01, 02 …）を削除しました。

## 動機

先頭の連番はナビゲーションの手がかりにならず、視覚的なノイズになっていたため。

## 変更内容

- 番号を描画していた `<span>`（`String(index + 1).padStart(2, '0')`）を削除
- 使われなくなった `index` プロパティ（型・受け渡し）を除去
- 番号削除に伴い不要になったレイアウトを整理（リンクを `flex items-baseline gap-2` → `block`、余分な `<span>` ラッパーを除去）

## 影響範囲

- 影響するのは目次サイドレール（`xl` 以上のデスクトップ表示）のみ
- モバイル/コンパクト版の目次（`table-of-contents.tsx`）は元々番号なしのため影響なし
- Storybook（`app/blog/blog-layout/table-of-contents-side-rail`）で表示を確認済み
