### PR TITLE
feat(blog): pnpm-release-action の紹介記事を追加する

### DIFF
--- a/apps/main/src/app/_components/code-block/code-block.tsx
+++ b/apps/main/src/app/_components/code-block/code-block.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { CopyIcon, useClipboard, useToast } from '@k8o/arte-odyssey';
+import { cn } from '@repo/helpers/cn';
 import { useRef } from 'react';
 import type { ComponentProps, FC } from 'react';
 
@@ -8,6 +9,7 @@ type Props = ComponentProps<'pre'> & { 'data-lang'?: string };
 
 export const CodeBlock: FC<Props> = ({
   children,
+  className,
   'data-lang': lang,
   ...rest
 }) => {
@@ -53,7 +55,10 @@ export const CodeBlock: FC<Props> = ({
       </div>
       <pre
         {...rest}
-        className="writing-h vertical:box-border vertical:mx-4 vertical:h-max vertical:max-h-full vertical:max-w-container-lg vertical:overflow-auto my-0 overflow-x-auto rounded-t-none rounded-b-lg px-4 py-1 sm:py-4"
+        className={cn(
+          'writing-h vertical:box-border vertical:mx-4 vertical:h-max vertical:max-h-full vertical:max-w-container-lg vertical:overflow-auto my-0 overflow-x-auto rounded-t-none rounded-b-lg px-4 py-1 sm:py-4',
+          className,
+        )}
         ref={preRef}
       >
         {children}

--- a/apps/main/src/app/blog/(articles)/pnpm-release-action/layout.tsx
+++ b/apps/main/src/app/blog/(articles)/pnpm-release-action/layout.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from 'next';
+
+import { BlogLayout } from '@/app/blog/_components/blog-layout';
+import { buildBlogMetadata } from '@/features/blog/interface/metadata';
+
+const slug = 'pnpm-release-action';
+
+export function generateMetadata(): Promise<Metadata> {
+  return buildBlogMetadata(slug);
+}
+
+export default function Layout({
+  children,
+}: LayoutProps<'/blog/pnpm-release-action'>) {
+  return <BlogLayout slug={slug}>{children}</BlogLayout>;
+}

--- a/apps/main/src/app/blog/(articles)/pnpm-release-action/opengraph-image.tsx
+++ b/apps/main/src/app/blog/(articles)/pnpm-release-action/opengraph-image.tsx
@@ -1,0 +1,13 @@
+import { renderBlogOgImage } from '@/app/blog/_components/blog-og-image';
+
+export const alt = 'pnpm-release-action';
+export const size = {
+  width: 1200,
+  height: 630,
+};
+
+export const contentType = 'image/png';
+
+export default function Image() {
+  return renderBlogOgImage('pnpm-release-action');
+}

--- a/apps/main/src/app/blog/(articles)/pnpm-release-action/page.mdx
+++ b/apps/main/src/app/blog/(articles)/pnpm-release-action/page.mdx
@@ -1,0 +1,187 @@
+---
+title: 'pnpm本体に入ったリリース管理をCIにつなぐpnpm-release-actionを作った'
+description: 'pnpm 11.13で本体に入ったリリース管理は、コミットやリリースPR、タグ、GitHub Releaseをどう作るかをユーザーに委ねています。この部分を担うGitHub Actionとしてpnpm-release-actionを公開しました。リリースPRとpublishの2つのモードによるループと、その設計方針を紹介します。'
+createdAt: 2026-07-23
+updatedAt: 2026-07-23
+---
+
+import { LinkCard } from '@/app/blog/_components/link-card';
+
+# pnpm本体に入ったリリース管理をCIにつなぐpnpm-release-actionを作った
+
+## はじめに
+
+pnpm 11.13.0で、モノレポのリリース管理に必要な機能一式がpnpm本体に出揃いました。`pnpm change`で変更の意図を記録し、`pnpm version -r`でバージョンと変更履歴を更新するワークフローを、追加のツールなしで使えます。
+
+ここまで揃うと、次はこれをCIに乗せたくなります。変更の意図が溜まったらリリースPRを開き、マージされたらpublishとタグ付けとGitHub Releaseの作成まで進める、という自動化です。しかし、コミットやリリースPRを作る部分をpnpmは担いません。設計元の[RFC](https://github.com/pnpm/rfcs/blob/main/text/0006-monorepo-versioning.md)でも未解決の論点として残されていて、どう運用するかはいまのところユーザーに委ねられています。
+
+委ねられているのなら、自分の運用に合わせて自由に作れます。そのためのGitHub Actionとして、`pnpm-release-action`を作りました。
+
+<LinkCard href="https://github.com/k35o/pnpm-release-action" />
+
+この記事では、このアクションの仕組みと設計方針を紹介します。
+
+## コミットやリリースPRは誰が作るのか
+
+`pnpm version -r`が行うのはファイルの書き換えまでで、gitには一切触れません。コミットもタグも作られず、リリースPRもGitHub Releaseも存在しません。
+
+gitに触れないのは、実装が追いついていないからではありません。この機能の設計を提案したRFCには、決めきらずに残した論点を集めたUnresolved Questionsという節があります。その中に、この領域の論点が2つ挙げられています。1つは、リリースコミットやタグをpnpm自身が作るべきか、それともgitをCIに任せるべきかという論点です。もう1つは、リリースPRを開いてマージでpublishする公式のGitHub Actionを提供するか、レシピの文書化に留めるかという論点です。
+
+<LinkCard href="https://github.com/pnpm/rfcs/blob/main/text/0006-monorepo-versioning.md" />
+
+執筆時点で、この2つに結論は出ていません。実際に11.13で出荷された`pnpm version -r`はgitに触れない実装のままで、公式のGitHub Actionもまだありません（pnpm公式にあるのは、インストール用の`pnpm/action-setup`だけです）。当面この層をどう組むかは、ユーザーの手に委ねられています。
+
+`pnpm-release-action`は、この委ねられた層を引き受けるアクションです。
+
+## pnpm本体に入ったリリース管理の道具立て
+
+アクションの中身に入る前に、pnpm側を具体的に見ておきます。リリース管理は、2026年7月リリースのpnpm 11.13.0で出揃った機能群です。どのパッケージをどのバージョンに上げるかを決める工程は、これまでChangesetsをはじめとする外部ツールに任されてきました。pnpmはそれを本体の機能として取り込みました。軸になるのは`pnpm change`と`pnpm version -r`の2つのコマンドです。
+
+<LinkCard href="https://pnpm.io/versioning" />
+
+### pnpm changeで変更の意図を記録する
+
+`pnpm change`を実行すると、どのパッケージをどのレベルで上げるかを対話的に聞かれます。回答は説明文と一緒にMarkdownファイルとして`.changeset`ディレクトリに保存されます。この記事では、これをintentファイルと呼びます。
+
+```md
+---
+'@example/ui': minor
+'@example/core': patch
+---
+
+トーストコンポーネントを追加する
+```
+
+形式は従来のChangesetsと同じで、既存の`.changeset/*.md`もそのまま読まれます。intentファイルは機能PRの一部としてレビューされ、マージでベースブランチに溜まっていきます。溜まっている変更と予定されるリリース計画は、`pnpm change status`で確認できます。上のintentを置いたワークスペースでは、次のように表示されます。
+
+```txt
+Pending change intents:
+  .changeset/add-toast-component.md
+
+Release plan:
+  @example/core: 0.8.1 → 0.8.2 (patch, via intent)
+  @example/ui: 1.2.0 → 1.3.0 (minor, via intent)
+```
+
+### pnpm version -rでリリース計画を適用する
+
+`pnpm version -r`は、溜まったintentからリリース計画を組み立てて適用します。計画には、intentに書かれたバージョンアップに加えて、依存しているパッケージへの伝播も含まれます。あるパッケージが上がると、それに`workspace:`範囲で依存するパッケージも必要に応じて上がります。
+
+適用されるのは、まず各パッケージの`package.json`の`version`の更新です。あわせて、intentの説明文から各パッケージの`CHANGELOG.md`が組み立てられます。ただし、その`CHANGELOG.md`をどこに置くかは設定で選べます。デフォルトはリポジトリにコミットしない方式で、publish時に組み立ててnpmに公開するパッケージにだけ同梱します。従来どおりリポジトリにコミットしたい場合は、後述の設定で`repository`方式に切り替えます。
+
+ここで問題になるのが、どのintentが消費済みかの管理です。デフォルトの方式では、publishが終わるまでintentファイルの説明文が変更履歴の唯一のソースなので、versionの時点では削除されません。つまり、ファイルの有無では消費済みかどうかを判定できません。
+
+そこでpnpmは、どのリリースがどのintentを消費したかをledgerという台帳（`.changeset/ledger.yaml`）に記録します。エントリは`パッケージ名@バージョン`ごとで、リリースのたびに追記されます。次に示すのは、このアクション自身のリポジトリの執筆時点の台帳です。
+
+```yaml
+pnpm-release-action@0.1.0:
+  dir: ""
+  intents:
+    - action-skeleton
+    - ignore-pnpm-owned-files
+    - publish-mode
+    - self-release
+    - version-pr-mode
+pnpm-release-action@0.2.0:
+  dir: ""
+  intents:
+    - atomic-api-branch-update
+    - bundled-deps-update
+    - github-api-commits
+pnpm-release-action@0.2.1:
+  dir: ""
+  intents:
+    - drop-throttling-plugin
+pnpm-release-action@0.2.2:
+  dir: ""
+  intents:
+    - auto-merge-arming
+```
+
+この台帳が消費記録の正です。intentファイルが残っていても、再実行で同じintentが二重に消費されることはありません。
+
+### pnpm-workspace.yamlのversioningキーで設定する
+
+設定専用のファイルはなく、`pnpm-workspace.yaml`の`versioning`キーに書きます。
+
+```yaml
+versioning:
+  fixed:
+    - ["@example/cli", "@example/cli-bindings"]
+  changelog:
+    storage: repository # CHANGELOG.mdをコミットする方式に切り替える
+```
+
+`fixed`は、常に同じバージョンで一緒にリリースするパッケージのグループです。ほかにも、対象から外す`ignore`や、バージョンアップの上限を課す`maxBump`、プレリリース用のlanesといった設定が同じキーに並びます。
+
+## 2つのモードによるリリースループ
+
+ここからはアクションの話です。`pnpm-release-action`は実行のたびに、pnpmに保留中のリリース計画を問い合わせて2つのモードのどちらかを選びます。この問い合わせは使い捨てのgit worktree内で行うため、チェックアウト中の作業ツリーには触れません。
+
+intentが溜まっていればversionモードです。`pnpm-release/<ベースブランチ>`というブランチをトリガーコミットから作り直し、`pnpm version -r`を適用してlockfileを同期し、リリースPRを1つ開きます。PRはベースブランチに対して常に1つだけで、intentが増えるたびに作り直されます。PR本文には、どのパッケージがどのバージョンになるかの計画と変更履歴のプレビューが載ります。
+
+intentがなければpublishモードです。`build`入力があればそのコマンドを実行し、内蔵の`pnpm publish -r --report-summary`でnpmへ公開し、パッケージごとにタグをpushしてGitHub Releaseを作ります。npmに公開されないprivateパッケージについても、ledgerの差分からリリースを検出してタグとReleaseを作れます。
+
+つまり、リリースPRをマージすると次の実行がpublishモードになります。ループはこれだけです。
+
+なお、リリースと関係ないpushでも、intentがなければpublishモードに入ります。それでも何かが二重に出ることはありません。pnpmはレジストリにまだ無いバージョンだけをpublishし、タグとGitHub Releaseの対象もledgerの差分から決まるためです。
+
+ワークフローは次のようになります。
+
+```yaml
+name: Release
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+concurrency: ${{ github.workflow }}-${{ github.ref }}
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write # npmのOIDC trusted publishing用
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
+        id: app-token
+        with:
+          client-id: ${{ secrets.APP_CLIENT_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+      # pnpmのバージョンはpackage.jsonのpackageManagerから解決される（11.13.0以上が必要）
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
+      - uses: k35o/pnpm-release-action@5e009384bf5b1d2501f8405817b5d5578a90624e # v0.2.2
+        with:
+          build: pnpm build
+          github-token: ${{ steps.app-token.outputs.token }}
+          auto-merge: true # CIが通ったらリリースPRを自動マージ
+```
+
+認証には、デフォルトの`GITHUB_TOKEN`ではなくGitHub Appのトークンを勧めています。`GITHUB_TOKEN`で作ったPRやタグは他のワークフローを起動しないため、リリースPRのCIが走らないという定番のハマりどころがあるからです。また、デフォルトの`commit-mode: github-api`では、versionコミットをGitHub APIで作ります。GitHubがApp名義で署名してくれるので、botのコミットにも検証済みの署名が付きます。
+
+## 実装の工夫
+
+このアクションでは、薄く保つための工夫を2つしています。pnpmを再実装しないことと、パッケージの依存を小さくすることです。
+
+### pnpmを再実装しない
+
+リリース管理の難しい部分は、すべてpnpmのコマンドに委譲します。intentの解釈もリリース計画の算出も、変更履歴の生成もpublish対象の選択も、アクションは自分で計算しません。semverのロジックに至っては1行もありません。
+
+アクションが持つのは、pnpmが残したCI側の仕事だけです。コミットとブランチ、リリースPR、タグとGitHub Releaseを所有します。あわせて、後続のstepから使えるoutputs（`mode`や`published-packages`など）を公開します。この分担のおかげで、pnpm側の進化は自動的に取り込まれます。
+
+### パッケージの依存を小さくする
+
+実行時に持ち込むライブラリは、GitHub公式のツールキットと、その他ごくわずかなパッケージに絞っています。Changesets関連のパッケージにも依存していません。pnpm自体も同梱しません。リポジトリ側でセットアップされたpnpmをそのまま実行し、前提の11.13.0以上であるかだけを実行前に確認します。
+
+pnpm本体がこの層まで提供するようになれば、このアクションは不要になります。それも織り込んだうえで、薄く保っています。
+
+## おわりに
+
+pnpm本体のリリース管理はまだ新しく、その周辺はまっさらな状態です。`pnpm-release-action`はそこに置くCI層として、難しい部分を全部pnpmに委譲する薄い設計で作りました。
+
+pnpmネイティブのリリース管理をCIで完結させたい人の役に立てばうれしいです。不具合や要望があれば、リポジトリのIssueで教えてください。

--- a/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
+++ b/apps/main/src/app/blog/_components/blog-layout/blog-layout.tsx
@@ -53,7 +53,7 @@ export const BlogLayoutContent: FC<BlogLayoutContentProps> = ({
   return (
     <div className="gap-4 xl:flex">
       <ViewReporter slug={slug} />
-      <div className="m-auto flex flex-1 flex-col gap-8 xl:max-w-5xl">
+      <div className="m-auto flex min-w-0 flex-1 flex-col gap-8 xl:max-w-5xl">
         <WritingModeContent>
           <article className="bg-bg-base/90 vertical:bg-transparent vertical:rounded-none rounded-xl px-3 py-8 sm:px-10">
             <div className="flex flex-col gap-3">

--- a/packages/code-highlight/src/index.ts
+++ b/packages/code-highlight/src/index.ts
@@ -2,9 +2,15 @@ import rehypeShiki from '@shikijs/rehype';
 
 import { annotateTransformer } from './transformer.ts';
 
+// ライトは one-light、ダークは従来の plastic。インラインstyleにはライト色を出し、
+// ダーク側は annotate.css の .dark ルールが --shiki-dark 変数で上書きする
 const rehypeCodeHighlight: typeof rehypeShiki = function () {
   return rehypeShiki.call(this, {
-    theme: 'plastic',
+    themes: {
+      dark: 'plastic',
+      light: 'one-light',
+    },
+    defaultColor: 'light',
     transformers: [annotateTransformer()],
   });
 };

--- a/packages/code-highlight/src/transformer.ts
+++ b/packages/code-highlight/src/transformer.ts
@@ -87,10 +87,20 @@ export const annotateTransformer = (): ShikiTransformer => ({
     if (lang !== '' && lang !== 'text' && lang !== 'plaintext') {
       node.properties['data-lang'] = lang;
     }
+    // og は目印だけで描画に影響しないため、gutter の要否には数えない
+    const state = (this.meta as AnnotateMeta).codeAnnotate;
+    const hasVisibleAnnotation =
+      state?.annotations.some(
+        (line) =>
+          line?.some((annotation) => annotation.type !== 'og') === true,
+      ) === true;
     return {
       type: 'element',
       tagName: 'div',
-      properties: { class: 'code-annotate-block' },
+      properties: {
+        class: 'code-annotate-block',
+        ...(hasVisibleAnnotation ? { 'data-annotated': '' } : {}),
+      },
       children: [node],
     };
   },

--- a/packages/code-highlight/src/transformer.ts
+++ b/packages/code-highlight/src/transformer.ts
@@ -89,11 +89,9 @@ export const annotateTransformer = (): ShikiTransformer => ({
     }
     // og は目印だけで描画に影響しないため、gutter の要否には数えない
     const state = (this.meta as AnnotateMeta).codeAnnotate;
-    const hasVisibleAnnotation =
-      state?.annotations.some(
-        (line) =>
-          line?.some((annotation) => annotation.type !== 'og') === true,
-      ) === true;
+    const hasVisibleAnnotation = (state?.annotations ?? []).some((line) =>
+      line?.some((annotation) => annotation.type !== 'og'),
+    );
     return {
       type: 'element',
       tagName: 'div',

--- a/packages/code-highlight/src/transformer.ts
+++ b/packages/code-highlight/src/transformer.ts
@@ -90,7 +90,7 @@ export const annotateTransformer = (): ShikiTransformer => ({
     // og は目印だけで描画に影響しないため、gutter の要否には数えない
     const state = (this.meta as AnnotateMeta).codeAnnotate;
     const hasVisibleAnnotation = (state?.annotations ?? []).some((line) =>
-      line?.some((annotation) => annotation.type !== 'og'),
+      line.some((annotation) => annotation.type !== 'og'),
     );
     return {
       type: 'element',

--- a/packages/code-highlight/styles/annotate.css
+++ b/packages/code-highlight/styles/annotate.css
@@ -1,8 +1,12 @@
 @layer components {
-  /* shiki plastic 暗背景前提の固定トーン。テキスト色（白〜パステル）を潰さない alpha に抑えつつ、左バーで強調する。 */
+  /* 基準はライトテーマ（shiki one-light #FAFAFA）。ダークは末尾の .dark ルールが
+     従来の plastic (#21252B) 向けトーンへ上書きする。注釈色はテキストを潰さない
+     alpha に抑えつつ、左バーで強調する。 */
   @scope (.code-annotate-block) {
-    /* 全行の左に注釈表示用の gutter を確保し、コード本体のインデントを揃える */
-    .line {
+    /* 注釈付きブロックだけ、全行の左に ＋/－ マーカーと注釈バー用の gutter を
+       確保してコード本体のインデントを揃える。注釈が無いブロックは gutter を
+       置かず、ツールバーの言語ラベルとコードの開始位置を揃える */
+    :scope[data-annotated] .line {
       position: relative;
       padding-inline-start: 1.2em;
     }
@@ -17,41 +21,41 @@
     }
 
     .code-annotate-highlight {
-      background-color: rgb(245 200 80 / 0.16);
-      box-shadow: inset 6px 0 0 rgb(245 200 80);
+      background-color: rgb(191 135 0 / 0.14);
+      box-shadow: inset 6px 0 0 rgb(191 135 0);
     }
 
     .code-annotate-add {
-      background-color: rgb(120 220 130 / 0.16);
-      box-shadow: inset 6px 0 0 rgb(120 220 130);
+      background-color: rgb(46 160 67 / 0.14);
+      box-shadow: inset 6px 0 0 rgb(46 160 67);
     }
 
     .code-annotate-add::before {
       content: '＋';
       position: absolute;
       inset-inline-start: 0.4em;
-      color: rgb(120 220 130);
+      color: rgb(46 160 67);
       font-weight: 700;
     }
 
     .code-annotate-remove {
-      background-color: rgb(245 110 110 / 0.16);
-      box-shadow: inset 6px 0 0 rgb(245 110 110);
+      background-color: rgb(207 34 46 / 0.12);
+      box-shadow: inset 6px 0 0 rgb(207 34 46);
     }
 
     .code-annotate-remove::before {
       content: '－';
       position: absolute;
       inset-inline-start: 0.4em;
-      color: rgb(245 110 110);
+      color: rgb(207 34 46);
       font-weight: 700;
     }
 
     /* 同じ行に他の注釈 (highlight/add/remove) と重なった場合は cascade order で
        callout が後勝ちで上書きする。両方を視覚化するユースケースは想定していない。 */
     .code-annotate-has-callout {
-      background-color: rgb(120 180 245 / 0.3);
-      box-shadow: inset 6px 0 0 rgb(120 180 245);
+      background-color: rgb(80 140 220 / 0.18);
+      box-shadow: inset 6px 0 0 rgb(80 140 220);
     }
 
     /* コールアウトは対象行の直下、コード先頭の真下に配置し、上向き▲で対象行を指す */
@@ -84,9 +88,8 @@
       border-block-end: 0.5em solid rgb(80 140 220);
     }
 
-    /* コードブロックは常に暗背景（shiki plastic #21252b）。ツールバーはコードに
-       重ならないようコード上部のヘッダー行として流し込み、色はテーマトークンでは
-       なく背景に合わせた固定の淡色にする */
+    /* ツールバーはコードに重ならないようコード上部のヘッダー行として流し込み、
+       色はテーマトークンではなくコード面（shiki のテーマ背景）に合わせた固定色にする */
     :scope {
       /* 縦書き記事内でもコードブロックは横書きの島として扱い、
          ヘッダー行とコードが縦に積まれるようにする */
@@ -99,7 +102,7 @@
       align-items: center;
       gap: 0.5rem;
       padding: 0.35rem 1rem;
-      background-color: #21252b;
+      background-color: #fafafa;
       border-start-start-radius: 0.5rem;
       border-start-end-radius: 0.5rem;
     }
@@ -107,7 +110,7 @@
     .code-annotate-lang {
       font-size: 0.75rem;
       line-height: 1;
-      color: rgb(169 178 195);
+      color: rgb(105 108 119);
       text-transform: lowercase;
       user-select: none;
     }
@@ -119,7 +122,7 @@
       justify-content: center;
       padding: 0.3rem;
       border-radius: 0.4rem;
-      color: rgb(169 178 195);
+      color: rgb(105 108 119);
       cursor: pointer;
       transition:
         color 0.15s ease,
@@ -127,12 +130,12 @@
     }
 
     .code-annotate-copy:hover {
-      color: rgb(255 255 255);
-      background-color: rgb(255 255 255 / 0.12);
+      color: rgb(56 58 66);
+      background-color: rgb(0 0 0 / 0.06);
     }
 
     .code-annotate-copy:focus-visible {
-      outline: 2px solid rgb(120 180 245);
+      outline: 2px solid rgb(80 140 220);
       outline-offset: 2px;
     }
   }
@@ -141,5 +144,68 @@
      物理的な左右マージンで隣接ブロックとの間隔を確保する */
   .writing-v .code-annotate-block {
     margin-inline: 1rem;
+  }
+
+  /* ---- ダークテーマ（従来の plastic 向けトーン） ----
+     @scope 内から外側の .dark 祖先を参照しないため、素の子孫セレクタで上書きする */
+  .dark .code-annotate-block .code-annotate-highlight {
+    background-color: rgb(245 200 80 / 0.16);
+    box-shadow: inset 6px 0 0 rgb(245 200 80);
+  }
+
+  .dark .code-annotate-block .code-annotate-add {
+    background-color: rgb(120 220 130 / 0.16);
+    box-shadow: inset 6px 0 0 rgb(120 220 130);
+  }
+
+  .dark .code-annotate-block .code-annotate-add::before {
+    color: rgb(120 220 130);
+  }
+
+  .dark .code-annotate-block .code-annotate-remove {
+    background-color: rgb(245 110 110 / 0.16);
+    box-shadow: inset 6px 0 0 rgb(245 110 110);
+  }
+
+  .dark .code-annotate-block .code-annotate-remove::before {
+    color: rgb(245 110 110);
+  }
+
+  .dark .code-annotate-block .code-annotate-has-callout {
+    background-color: rgb(120 180 245 / 0.3);
+    box-shadow: inset 6px 0 0 rgb(120 180 245);
+  }
+
+  .dark .code-annotate-block .code-annotate-toolbar {
+    background-color: #21252b;
+  }
+
+  .dark .code-annotate-block .code-annotate-lang {
+    color: rgb(169 178 195);
+  }
+
+  .dark .code-annotate-block .code-annotate-copy {
+    color: rgb(169 178 195);
+  }
+
+  .dark .code-annotate-block .code-annotate-copy:hover {
+    color: rgb(255 255 255);
+    background-color: rgb(255 255 255 / 0.12);
+  }
+
+  .dark .code-annotate-block .code-annotate-copy:focus-visible {
+    outline-color: rgb(120 180 245);
+  }
+
+  /* shiki のデュアルテーマ切り替え: インラインstyleはライト色なので、
+     ダーク時はトークンごとの --shiki-dark 変数を !important で通す。
+     transformer が注入する行・コールアウトの span は変数を持たないため除外する */
+  .dark .shiki,
+  .dark .shiki span:not(.line, .code-annotate-callout-text) {
+    color: var(--shiki-dark) !important;
+    background-color: var(--shiki-dark-bg) !important;
+    font-style: var(--shiki-dark-font-style) !important;
+    font-weight: var(--shiki-dark-font-weight) !important;
+    text-decoration: var(--shiki-dark-text-decoration) !important;
   }
 }

--- a/packages/database/migrations/0064_redundant_revanche.sql
+++ b/packages/database/migrations/0064_redundant_revanche.sql
@@ -1,0 +1,29 @@
+-- 新しいタグの追加（既存なら何もしない）
+INSERT INTO tags (name) VALUES ('pnpm') ON CONFLICT (name) DO NOTHING;--> statement-breakpoint
+
+-- ブログレコードの追加（slug が一意なので id は書かない）
+INSERT INTO blogs (slug, published, created_at)
+VALUES ('pnpm-release-action', 1, '2026-07-23T00:00:00.000Z') ON CONFLICT (slug) DO NOTHING;--> statement-breakpoint
+
+-- ビューカウント初期化
+INSERT INTO blog_views (blog_id, views)
+VALUES ((SELECT id FROM blogs WHERE slug = 'pnpm-release-action'), 0)
+ON CONFLICT (blog_id) DO NOTHING;--> statement-breakpoint
+
+-- タグ紐付け (pnpm, GitHub Actions, npm, Changesets)
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (
+  (SELECT id FROM blogs WHERE slug = 'pnpm-release-action'),
+  (SELECT id FROM tags WHERE name = 'pnpm')
+) ON CONFLICT DO NOTHING;--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (
+  (SELECT id FROM blogs WHERE slug = 'pnpm-release-action'),
+  (SELECT id FROM tags WHERE name = 'GitHub Actions')
+) ON CONFLICT DO NOTHING;--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (
+  (SELECT id FROM blogs WHERE slug = 'pnpm-release-action'),
+  (SELECT id FROM tags WHERE name = 'npm')
+) ON CONFLICT DO NOTHING;--> statement-breakpoint
+INSERT INTO blog_tag (blog_id, tag_id) VALUES (
+  (SELECT id FROM blogs WHERE slug = 'pnpm-release-action'),
+  (SELECT id FROM tags WHERE name = 'Changesets')
+) ON CONFLICT DO NOTHING;

--- a/packages/database/migrations/meta/0064_snapshot.json
+++ b/packages/database/migrations/meta/0064_snapshot.json
@@ -1,0 +1,1879 @@
+{
+  "id": "10f3d973-a2f5-46a8-8e4f-c8140a8da466",
+  "prevId": "7b3e1c2a-9f4d-4e6b-8a1c-2d3e4f5a6b7c",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {
+    "ai_project_versions": {
+      "name": "ai_project_versions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_project_versions_project_id_idx": {
+          "name": "ai_project_versions_project_id_idx",
+          "columns": [
+            "project_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_project_versions_project_id_ai_projects_id_fk": {
+          "name": "ai_project_versions_project_id_ai_projects_id_fk",
+          "tableFrom": "ai_project_versions",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "ai_projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_projects": {
+      "name": "ai_projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'private'"
+        },
+        "fork_of": {
+          "name": "fork_of",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "published_version_id": {
+          "name": "published_version_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "public_snapshot": {
+          "name": "public_snapshot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_projects_slug_idx": {
+          "name": "ai_projects_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        },
+        "ai_projects_user_id_idx": {
+          "name": "ai_projects_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "ai_projects_app_idx": {
+          "name": "ai_projects_app_idx",
+          "columns": [
+            "app"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_projects_user_id_user_id_fk": {
+          "name": "ai_projects_user_id_user_id_fk",
+          "tableFrom": "ai_projects",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_share_serves": {
+      "name": "ai_share_serves",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_share_serves_created_at_idx": {
+          "name": "ai_share_serves_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "ai_usages": {
+      "name": "ai_usages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "app": {
+          "name": "app",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "ai_usages_user_id_idx": {
+          "name": "ai_usages_user_id_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        },
+        "ai_usages_created_at_idx": {
+          "name": "ai_usages_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "ai_usages_user_id_user_id_fk": {
+          "name": "ai_usages_user_id_user_id_fk",
+          "tableFrom": "ai_usages",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "article_sources": {
+      "name": "article_sources",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "site_url": {
+          "name": "site_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "article_sources_url_idx": {
+          "name": "article_sources_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "articles": {
+      "name": "articles",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "article_source_id": {
+          "name": "article_source_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "summary_attempts": {
+          "name": "summary_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "articles_url_idx": {
+          "name": "articles_url_idx",
+          "columns": [
+            "url"
+          ],
+          "isUnique": true
+        },
+        "articles_source_id_idx": {
+          "name": "articles_source_id_idx",
+          "columns": [
+            "article_source_id"
+          ],
+          "isUnique": false
+        },
+        "articles_published_at_idx": {
+          "name": "articles_published_at_idx",
+          "columns": [
+            "published_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "articles_article_source_id_article_sources_id_fk": {
+          "name": "articles_article_source_id_article_sources_id_fk",
+          "tableFrom": "articles",
+          "columnsFrom": [
+            "article_source_id"
+          ],
+          "tableTo": "article_sources",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "account": {
+      "name": "account",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "account_userId_idx": {
+          "name": "account_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "session": {
+      "name": "session",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "columns": [
+            "token"
+          ],
+          "isUnique": true
+        },
+        "session_userId_idx": {
+          "name": "session_userId_idx",
+          "columns": [
+            "user_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "tableTo": "user",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "user": {
+      "name": "user",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "columns": [
+            "email"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "verification": {
+      "name": "verification",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(cast(unixepoch('subsecond') * 1000 as integer))"
+        }
+      },
+      "indexes": {
+        "verification_identifier_idx": {
+          "name": "verification_identifier_idx",
+          "columns": [
+            "identifier"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "browser_support_snapshots": {
+      "name": "browser_support_snapshots",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "feature_id": {
+          "name": "feature_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "browser_support_snapshots_feature_id_idx": {
+          "name": "browser_support_snapshots_feature_id_idx",
+          "columns": [
+            "feature_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "browser_support_snapshots_status_check": {
+          "name": "browser_support_snapshots_status_check",
+          "value": "\"browser_support_snapshots\".\"status\" IN ('newly', 'widely')"
+        }
+      }
+    },
+    "blog_comment": {
+      "name": "blog_comment",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "comment_id": {
+          "name": "comment_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_comment_blog_id_idx": {
+          "name": "blog_comment_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_comment_comment_id_idx": {
+          "name": "blog_comment_comment_id_idx",
+          "columns": [
+            "comment_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_comment_blog_id_blogs_id_fk": {
+          "name": "blog_comment_blog_id_blogs_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_comment_comment_id_comments_id_fk": {
+          "name": "blog_comment_comment_id_comments_id_fk",
+          "tableFrom": "blog_comment",
+          "columnsFrom": [
+            "comment_id"
+          ],
+          "tableTo": "comments",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_tag": {
+      "name": "blog_tag",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blog_tag_blog_id_idx": {
+          "name": "blog_tag_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_tag_id_idx": {
+          "name": "blog_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "blog_tag_unique_idx": {
+          "name": "blog_tag_unique_idx",
+          "columns": [
+            "blog_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "blog_tag_blog_id_blogs_id_fk": {
+          "name": "blog_tag_blog_id_blogs_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "blog_tag_tag_id_tags_id_fk": {
+          "name": "blog_tag_tag_id_tags_id_fk",
+          "tableFrom": "blog_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_view_dailies": {
+      "name": "blog_view_dailies",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "blog_view_dailies_date_idx": {
+          "name": "blog_view_dailies_date_idx",
+          "columns": [
+            "date"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "blog_view_dailies_blog_id_blogs_id_fk": {
+          "name": "blog_view_dailies_blog_id_blogs_id_fk",
+          "tableFrom": "blog_view_dailies",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "blog_view_dailies_blog_id_date_pk": {
+          "columns": [
+            "blog_id",
+            "date"
+          ],
+          "name": "blog_view_dailies_blog_id_date_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blog_views": {
+      "name": "blog_views",
+      "columns": {
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "views": {
+          "name": "views",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "blog_views_blog_id_blogs_id_fk": {
+          "name": "blog_views_blog_id_blogs_id_fk",
+          "tableFrom": "blog_views",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "blogs": {
+      "name": "blogs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "blogs_slug_idx": {
+          "name": "blogs_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "comments": {
+      "name": "comments",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "feedback_id": {
+          "name": "feedback_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "comments_feedback_id_idx": {
+          "name": "comments_feedback_id_idx",
+          "columns": [
+            "feedback_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "comments_feedback_id_feedbacks_id_fk": {
+          "name": "comments_feedback_id_feedbacks_id_fk",
+          "tableFrom": "comments",
+          "columnsFrom": [
+            "feedback_id"
+          ],
+          "tableTo": "feedbacks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "feedbacks": {
+      "name": "feedbacks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "push_logs": {
+      "name": "push_logs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "dedupe_key": {
+          "name": "dedupe_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "succeeded": {
+          "name": "succeeded",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed": {
+          "name": "failed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_logs_dedupe_key_idx": {
+          "name": "push_logs_dedupe_key_idx",
+          "columns": [
+            "dedupe_key"
+          ],
+          "isUnique": true
+        },
+        "push_logs_sent_at_idx": {
+          "name": "push_logs_sent_at_idx",
+          "columns": [
+            "sent_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "push_logs_kind_check": {
+          "name": "push_logs_kind_check",
+          "value": "\"push_logs\".\"kind\" IN ('readings_updated', 'browser_support_updated')"
+        }
+      }
+    },
+    "push_subscriptions": {
+      "name": "push_subscriptions",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "endpoint": {
+          "name": "endpoint",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p256dh": {
+          "name": "p256dh",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth": {
+          "name": "auth",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "endpoint_host": {
+          "name": "endpoint_host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "push_subscriptions_endpoint_idx": {
+          "name": "push_subscriptions_endpoint_idx",
+          "columns": [
+            "endpoint"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reporting_reports": {
+      "name": "reporting_reports",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "reporting_reports_type_idx": {
+          "name": "reporting_reports_type_idx",
+          "columns": [
+            "type"
+          ],
+          "isUnique": false
+        },
+        "reporting_reports_created_at_idx": {
+          "name": "reporting_reports_created_at_idx",
+          "columns": [
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slide_tag": {
+      "name": "slide_tag",
+      "columns": {
+        "slide_id": {
+          "name": "slide_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slide_tag_slide_id_idx": {
+          "name": "slide_tag_slide_id_idx",
+          "columns": [
+            "slide_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_tag_id_idx": {
+          "name": "slide_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "slide_tag_unique_idx": {
+          "name": "slide_tag_unique_idx",
+          "columns": [
+            "slide_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "slide_tag_slide_id_slides_id_fk": {
+          "name": "slide_tag_slide_id_slides_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "slide_id"
+          ],
+          "tableTo": "slides",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "slide_tag_tag_id_tags_id_fk": {
+          "name": "slide_tag_tag_id_tags_id_fk",
+          "tableFrom": "slide_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "slides": {
+      "name": "slides",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published": {
+          "name": "published",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "slides_slug_idx": {
+          "name": "slides_slug_idx",
+          "columns": [
+            "slug"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "tags": {
+      "name": "tags",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "tags_name_idx": {
+          "name": "tags_name_idx",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talk_tag": {
+      "name": "talk_tag",
+      "columns": {
+        "talk_id": {
+          "name": "talk_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "tag_id": {
+          "name": "tag_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talk_tag_talk_id_idx": {
+          "name": "talk_tag_talk_id_idx",
+          "columns": [
+            "talk_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_tag_id_idx": {
+          "name": "talk_tag_tag_id_idx",
+          "columns": [
+            "tag_id"
+          ],
+          "isUnique": false
+        },
+        "talk_tag_unique_idx": {
+          "name": "talk_tag_unique_idx",
+          "columns": [
+            "talk_id",
+            "tag_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "talk_tag_talk_id_talks_id_fk": {
+          "name": "talk_tag_talk_id_talks_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "talk_id"
+          ],
+          "tableTo": "talks",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        },
+        "talk_tag_tag_id_tags_id_fk": {
+          "name": "talk_tag_tag_id_tags_id_fk",
+          "tableFrom": "talk_tag",
+          "columnsFrom": [
+            "tag_id"
+          ],
+          "tableTo": "tags",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "talks": {
+      "name": "talks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_url": {
+          "name": "event_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_name": {
+          "name": "event_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_date": {
+          "name": "event_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_location": {
+          "name": "event_location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "slide_url": {
+          "name": "slide_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "blog_id": {
+          "name": "blog_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "talks_blog_id_idx": {
+          "name": "talks_blog_id_idx",
+          "columns": [
+            "blog_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "talks_blog_id_blogs_id_fk": {
+          "name": "talks_blog_id_blogs_id_fk",
+          "tableFrom": "talks",
+          "columnsFrom": [
+            "blog_id"
+          ],
+          "tableTo": "blogs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -449,6 +449,13 @@
       "when": 1784609958894,
       "tag": "0063_rename_baseline_to_browser_support",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "6",
+      "when": 1784809870060,
+      "tag": "0064_redundant_revanche",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## 概要

自作の GitHub Action `pnpm-release-action` の紹介記事を追加する。あわせて、執筆中に見つかったコードブロック表示の問題を2点直す。

## 動機

pnpm 11.13 で本体に入ったリリース管理は、コミット・リリースPR・タグ・GitHub Release の作成を未解決のままユーザーに委ねている。そこを引き受けるアクションを作ったので、仕組みと設計方針を k8o.me で解説する。

## 詳細

- 記事一式（`page.mdx` / `layout.tsx` / `opengraph-image.tsx`）と migration 0064（タグ `pnpm` 新設、既存の `GitHub Actions` / `npm` / `Changesets` を紐付け）
- blog-layout の本文カラムに `min-w-0` を追加。記事内の SHA ピン行のような長い1行があるとカラムが min-content より縮めず、xl 幅で目次レールが画面外へ押し出されていた
- コードブロックをデュアルテーマ化（light: `one-light` / dark: `plastic`）。ダーク時の色値は従来と同一で、ライトモードで暗いコード面が出なくなる
- `CodeBlock` が `className` を上書きして shiki クラスが DOM に届いていなかったため `cn` でのマージに修正
- 注釈用の左 gutter（1.2em）を注釈行があるブロックだけに限定。注釈の無いブロックは言語ラベルとコードの開始位置が揃う

## 気をつけるポイント

- コードブロックの見た目が変わるため、VRT でライトモードを中心に差分が出る（意図した変更）
- rehype の出力が変わるので、手元の dev server で古い表示が出る場合は `.next` の削除が必要
- 記事の公開日は 2026-07-23 で migration に入れている

## 影響範囲

- ブログ全記事のコードブロック表示（ライトモード配色と、注釈なしブロックの左余白）
- ブログ記事レイアウト（目次レールの押し出し解消）
- DB migration（コンテンツ追加のみ、冪等）

## テスト

- code-highlight のユニットテスト 29 件、`vp check`、`type-check` 通過
- dev server 実機でライト/ダーク両テーマ、1280〜2000px の各幅、注釈あり記事（container-style-queries）の gutter 維持を確認