### PR TITLE
fix(database): 0063 の kind 変換を旧 CHECK 制約に弾かれない形に直す

### DIFF
--- a/packages/database/migrations/0063_rename_baseline_to_browser_support.sql
+++ b/packages/database/migrations/0063_rename_baseline_to_browser_support.sql
@@ -15,7 +15,6 @@ DROP TABLE `baseline_snapshots`;--> statement-breakpoint
 ALTER TABLE `__new_browser_support_snapshots` RENAME TO `browser_support_snapshots`;--> statement-breakpoint
 PRAGMA foreign_keys=ON;--> statement-breakpoint
 CREATE UNIQUE INDEX `browser_support_snapshots_feature_id_idx` ON `browser_support_snapshots` (`feature_id`);--> statement-breakpoint
-UPDATE `push_logs` SET `kind` = 'browser_support_updated' WHERE `kind` = 'baseline_updated';--> statement-breakpoint
 PRAGMA foreign_keys=OFF;--> statement-breakpoint
 CREATE TABLE `__new_push_logs` (
 	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
@@ -30,7 +29,7 @@ CREATE TABLE `__new_push_logs` (
 	CONSTRAINT "push_logs_kind_check" CHECK("__new_push_logs"."kind" IN ('readings_updated', 'browser_support_updated'))
 );
 --> statement-breakpoint
-INSERT INTO `__new_push_logs`("id", "kind", "title", "body", "url", "dedupe_key", "succeeded", "failed", "sent_at") SELECT "id", "kind", "title", "body", "url", "dedupe_key", "succeeded", "failed", "sent_at" FROM `push_logs`;--> statement-breakpoint
+INSERT INTO `__new_push_logs`("id", "kind", "title", "body", "url", "dedupe_key", "succeeded", "failed", "sent_at") SELECT "id", CASE WHEN "kind" = 'baseline_updated' THEN 'browser_support_updated' ELSE "kind" END, "title", "body", "url", "dedupe_key", "succeeded", "failed", "sent_at" FROM `push_logs`;--> statement-breakpoint
 DROP TABLE `push_logs`;--> statement-breakpoint
 ALTER TABLE `__new_push_logs` RENAME TO `push_logs`;--> statement-breakpoint
 PRAGMA foreign_keys=ON;--> statement-breakpoint


### PR DESCRIPTION
## 概要

本番デプロイが 07-21 から `drizzle-kit migrate` で失敗し続けている問題の修正。migration 0063 の `push_logs.kind` の値変換を、単独の `UPDATE` からテーブル再構築時の `INSERT...SELECT` の `CASE` 式へ移す。

## 原因

0063 は旧 `push_logs`（CHECK: `kind IN ('readings_updated', 'baseline_updated')`）に対して `kind = 'browser_support_updated'` へ UPDATE するが、新値は旧 CHECK に含まれないため `CHECK constraint failed: push_logs_kind_check` で失敗する。本番には `baseline_updated` の行が4件あるため必ず発火し、プレビューとローカルは該当行が0件（UPDATE が空振りで CHECK 未評価）のため通過していた。

drizzle-kit はこのエラーを表示せずに exit 1 するため、Vercel のログからは原因が読めない状態だった。

## 詳細

- 単独の `UPDATE push_logs SET kind = ...` を削除
- `__new_push_logs` への `INSERT...SELECT` で `CASE WHEN kind = 'baseline_updated' THEN 'browser_support_updated' ELSE kind END` に変換

UPDATE を再構築の後ろへ移す案は、旧値のまま新テーブルへコピーする時点で新 CHECK に弾かれるため成立しない。変換は再構築時の1回で行うのが唯一の解。

## 気をつけるポイント

- 適用済みマイグレーションの編集になるが、0063 適用済みの DB（プレビュー・ローカル）は drizzle がタイムスタンプでスキップするため再実行されない。未適用の本番だけが修正版を実行する
- マージ後の本番デプロイで 0063 と 0064（ブログ記事）が順に適用される

## テスト

修正版 0063 と 0064 の全ステートメントを、本番 DB に対してトランザクション内で順次実行し全文通過を確認（確認後ロールバック済みで本番は未変更）。変換後の kind 分布が `browser_support_updated: 4 / readings_updated: 54` になることも確認した。