### PR TITLE
fix: 本番CSPでブロックされていたコードドックのハイライトをwasm不要のJSエンジンで動かす

### DIFF
--- a/apps/main/src/app/code-dock/_components/code-dock/code-dock.tsx
+++ b/apps/main/src/app/code-dock/_components/code-dock/code-dock.tsx
@@ -10,7 +10,7 @@ import {
   useDebouncedTransition,
   useToast,
 } from '@k8o/arte-odyssey';
-import type { HighlightTheme } from '@repo/code-highlight/tokenize';
+import type { HighlightTheme } from '@repo/code-highlight/tokenize-client';
 import { useAsyncAction } from '@repo/react-hooks/use-async-action';
 import { useTheme } from 'next-themes';
 import { useEffect, useRef, useState } from 'react';

--- a/apps/main/src/app/code-dock/_components/code-editor/code-editor.tsx
+++ b/apps/main/src/app/code-dock/_components/code-editor/code-editor.tsx
@@ -4,7 +4,7 @@ import { FormControl } from '@k8o/arte-odyssey';
 import type {
   HighlightedCode,
   HighlightTheme,
-} from '@repo/code-highlight/tokenize';
+} from '@repo/code-highlight/tokenize-client';
 import { Fragment, useState } from 'react';
 import type { FC, ReactNode, Ref } from 'react';
 

--- a/apps/main/src/app/code-dock/_components/code-editor/use-highlighted-code.ts
+++ b/apps/main/src/app/code-dock/_components/code-editor/use-highlighted-code.ts
@@ -76,8 +76,11 @@ export const useHighlightedCode = (
         if (requestRef.current === requestId) {
           setState({ code, data, language, theme });
         }
-      } catch {
-        // ハイライトは装飾なので、失敗してもプレーン表示で続行する
+      } catch (error) {
+        // ハイライトは装飾なので、失敗してもプレーン表示で続行する。ただし
+        // 黙って握りつぶすと全損に気づけないため記録は残す (本番の
+        // removeConsole も warn は残す)
+        console.warn('コードのハイライトに失敗しました', error);
       }
     })();
   }, [code, language, theme]);

--- a/apps/main/src/app/code-dock/_components/code-editor/use-highlighted-code.ts
+++ b/apps/main/src/app/code-dock/_components/code-editor/use-highlighted-code.ts
@@ -9,11 +9,18 @@ import { useEffect, useRef, useState } from 'react';
 
 import type { LintLanguage } from '@/features/code-dock/interface/types';
 
-// shiki を初期バンドルから外すため、初回利用時に一度だけ動的 import する
+// shiki を初期バンドルから外すため、初回利用時に一度だけ動的 import する。
+// 失敗した Promise をキャッシュし続けるとチャンク読み込みの一時的な失敗で
+// 以後ずっと失敗が固定されるため、reject 時はキャッシュを捨てて再試行させる
 let tokenizeModule: Promise<typeof tokenize> | null = null;
 
 const loadTokenize = (): Promise<typeof tokenize> =>
-  (tokenizeModule ??= import('@repo/code-highlight/tokenize-client'));
+  (tokenizeModule ??= import('@repo/code-highlight/tokenize-client').catch(
+    (error: unknown) => {
+      tokenizeModule = null;
+      throw error;
+    },
+  ));
 
 // 初回ハイライトが失敗/大幅遅延しても、この時間を過ぎたらプレーンで見せる保険
 const REVEAL_FALLBACK_MS = 1500;

--- a/apps/main/src/app/code-dock/_components/code-editor/use-highlighted-code.ts
+++ b/apps/main/src/app/code-dock/_components/code-editor/use-highlighted-code.ts
@@ -1,10 +1,10 @@
 'use client';
 
-import type * as tokenize from '@repo/code-highlight/tokenize';
+import type * as tokenize from '@repo/code-highlight/tokenize-client';
 import type {
   HighlightedCode,
   HighlightTheme,
-} from '@repo/code-highlight/tokenize';
+} from '@repo/code-highlight/tokenize-client';
 import { useEffect, useRef, useState } from 'react';
 
 import type { LintLanguage } from '@/features/code-dock/interface/types';
@@ -13,7 +13,7 @@ import type { LintLanguage } from '@/features/code-dock/interface/types';
 let tokenizeModule: Promise<typeof tokenize> | null = null;
 
 const loadTokenize = (): Promise<typeof tokenize> =>
-  (tokenizeModule ??= import('@repo/code-highlight/tokenize'));
+  (tokenizeModule ??= import('@repo/code-highlight/tokenize-client'));
 
 // 初回ハイライトが失敗/大幅遅延しても、この時間を過ぎたらプレーンで見せる保険
 const REVEAL_FALLBACK_MS = 1500;

--- a/packages/code-highlight/package.json
+++ b/packages/code-highlight/package.json
@@ -17,6 +17,10 @@
       "types": "./src/tokenize.ts",
       "default": "./src/tokenize.ts"
     },
+    "./tokenize-client": {
+      "types": "./src/tokenize-client.ts",
+      "default": "./src/tokenize-client.ts"
+    },
     "./theme": {
       "types": "./src/theme.ts",
       "default": "./src/theme.ts"
@@ -29,7 +33,11 @@
     "type-check": "tsgo --noEmit"
   },
   "dependencies": {
+    "@shikijs/core": "4.3.1",
+    "@shikijs/engine-javascript": "4.3.1",
+    "@shikijs/langs": "4.3.1",
     "@shikijs/rehype": "4.3.1",
+    "@shikijs/themes": "4.3.1",
     "shiki": "4.3.1"
   },
   "devDependencies": {

--- a/packages/code-highlight/src/tokenize-client.test.ts
+++ b/packages/code-highlight/src/tokenize-client.test.ts
@@ -1,3 +1,5 @@
+import type * as shikijsCore from '@shikijs/core';
+
 import { highlightCode } from './tokenize-client.ts';
 
 const distinctColors = (
@@ -37,6 +39,32 @@ describe('highlightCode (client)', () => {
       const result = await highlightCode('SELECT * FROM users;', 'sql');
 
       expect(distinctColors(result.tokens).size).toBe(1);
+    });
+
+    it('初期化に一度失敗しても、次の呼び出しで再試行して復帰する', async () => {
+      vi.doMock('@shikijs/core', async (importOriginal) => {
+        const actual = await importOriginal<typeof shikijsCore>();
+        return {
+          ...actual,
+          createHighlighterCore: vi
+            .fn(actual.createHighlighterCore)
+            .mockRejectedValueOnce(new Error('チャンク読み込みに失敗')),
+        };
+      });
+      vi.resetModules();
+      try {
+        const { highlightCode: freshHighlightCode } =
+          await import('./tokenize-client.ts');
+
+        await expect(freshHighlightCode('const a = 1;', 'ts')).rejects.toThrow(
+          'チャンク読み込みに失敗',
+        );
+        const result = await freshHighlightCode('const a = 1;', 'ts');
+
+        expect(distinctColors(result.tokens).size).toBeGreaterThan(1);
+      } finally {
+        vi.doUnmock('@shikijs/core');
+      }
     });
   });
 

--- a/packages/code-highlight/src/tokenize-client.test.ts
+++ b/packages/code-highlight/src/tokenize-client.test.ts
@@ -1,0 +1,63 @@
+import { highlightCode } from './tokenize-client.ts';
+
+const distinctColors = (
+  tokens: Awaited<ReturnType<typeof highlightCode>>['tokens'],
+): Set<string | undefined> =>
+  new Set(tokens.flat().map((token) => token.color));
+
+const blocked = () => {
+  throw new Error('WebAssembly violates Content Security Policy directive');
+};
+
+describe('highlightCode (client)', () => {
+  describe('正常系', () => {
+    it.each(['ts', 'tsx', 'js', 'jsx'])(
+      '%s のコードが複数色のトークンにハイライトされる',
+      async (lang) => {
+        const result = await highlightCode(
+          'const greeting = "hello";\nexport const App = () => <p>{greeting}</p>;',
+          lang,
+        );
+
+        expect(distinctColors(result.tokens).size).toBeGreaterThan(1);
+      },
+    );
+
+    it('テーマごとに前景・背景色が切り替わる', async () => {
+      const dark = await highlightCode('const a = 1;', 'ts', 'plastic');
+      const light = await highlightCode('const a = 1;', 'ts', 'one-light');
+
+      expect(dark.bg).not.toBe(light.bg);
+      expect(dark.fg).not.toBe(light.fg);
+    });
+  });
+
+  describe('異常系', () => {
+    it('未対応の言語は無色 (text) にフォールバックする', async () => {
+      const result = await highlightCode('SELECT * FROM users;', 'sql');
+
+      expect(distinctColors(result.tokens).size).toBe(1);
+    });
+  });
+
+  describe('エッジケース', () => {
+    it('WebAssembly が使えない環境 (CSP で wasm がブロックされた本番ブラウザ相当) でも動く', async () => {
+      vi.stubGlobal('WebAssembly', {
+        Module: blocked,
+        compile: blocked,
+        instantiate: blocked,
+      });
+      // ハイライターは module singleton のため、初期化からブロック下で走らせる
+      vi.resetModules();
+      try {
+        const { highlightCode: freshHighlightCode } =
+          await import('./tokenize-client.ts');
+        const result = await freshHighlightCode('const a: number = 1;', 'ts');
+
+        expect(distinctColors(result.tokens).size).toBeGreaterThan(1);
+      } finally {
+        vi.unstubAllGlobals();
+      }
+    });
+  });
+});

--- a/packages/code-highlight/src/tokenize-client.ts
+++ b/packages/code-highlight/src/tokenize-client.ts
@@ -1,0 +1,49 @@
+import { createHighlighterCore } from '@shikijs/core';
+import type { HighlighterCore } from '@shikijs/core';
+import { createJavaScriptRegexEngine } from '@shikijs/engine-javascript';
+
+// 拡張子なしで import する（tokenize.ts と同じく consumer 側の型検査の都合）。
+import { CODE_SURFACE } from './theme';
+import type { HighlightedCode, HighlightTheme } from './tokenize';
+
+export type { HighlightedCode, HighlightTheme } from './tokenize';
+
+// ./tokenize (oniguruma) は wasm のコンパイルを伴い、script-src に wasm-unsafe-eval が
+// 無い CSP のブラウザでは CompileError になる。クライアントでは wasm 不要の
+// JS 正規表現エンジンを使い、言語もクライアントで扱うものだけ静的に束ねる。
+// 任意言語をハイライトするサーバー側は引き続き ./tokenize を使う。
+let highlighterPromise: Promise<HighlighterCore> | null = null;
+
+const getHighlighter = (): Promise<HighlighterCore> =>
+  (highlighterPromise ??= createHighlighterCore({
+    themes: [
+      import('@shikijs/themes/plastic'),
+      import('@shikijs/themes/one-light'),
+    ],
+    langs: [
+      import('@shikijs/langs/ts'),
+      import('@shikijs/langs/tsx'),
+      import('@shikijs/langs/js'),
+      import('@shikijs/langs/jsx'),
+    ],
+    engine: createJavaScriptRegexEngine(),
+  }));
+
+export const highlightCode = async (
+  code: string,
+  lang: string,
+  theme: HighlightTheme = 'plastic',
+): Promise<HighlightedCode> => {
+  const highlighter = await getHighlighter();
+  let result;
+  try {
+    result = highlighter.codeToTokens(code, { lang, theme });
+  } catch {
+    result = highlighter.codeToTokens(code, { lang: 'text', theme });
+  }
+  return {
+    tokens: result.tokens,
+    fg: result.fg ?? CODE_SURFACE.fg,
+    bg: result.bg ?? CODE_SURFACE.bg,
+  };
+};

--- a/packages/code-highlight/src/tokenize-client.ts
+++ b/packages/code-highlight/src/tokenize-client.ts
@@ -14,6 +14,9 @@ export type { HighlightedCode, HighlightTheme } from './tokenize';
 // 任意言語をハイライトするサーバー側は引き続き ./tokenize を使う。
 let highlighterPromise: Promise<HighlighterCore> | null = null;
 
+// 生成に失敗した Promise を ??= でキャッシュし続けると、チャンク読み込みの
+// 一時的な失敗でもセッション中ずっとハイライトが失敗し続ける。reject 時は
+// キャッシュを捨てて、次回の呼び出しで再試行できるようにする
 const getHighlighter = (): Promise<HighlighterCore> =>
   (highlighterPromise ??= createHighlighterCore({
     themes: [
@@ -27,6 +30,9 @@ const getHighlighter = (): Promise<HighlighterCore> =>
       import('@shikijs/langs/jsx'),
     ],
     engine: createJavaScriptRegexEngine(),
+  }).catch((error: unknown) => {
+    highlighterPromise = null;
+    throw error;
   }));
 
 export const highlightCode = async (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -588,7 +588,19 @@ importers:
 
   packages/code-highlight:
     dependencies:
+      '@shikijs/core':
+        specifier: 4.3.1
+        version: 4.3.1
+      '@shikijs/engine-javascript':
+        specifier: 4.3.1
+        version: 4.3.1
+      '@shikijs/langs':
+        specifier: 4.3.1
+        version: 4.3.1
       '@shikijs/rehype':
+        specifier: 4.3.1
+        version: 4.3.1
+      '@shikijs/themes':
         specifier: 4.3.1
         version: 4.3.1
       shiki:
@@ -4826,8 +4838,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.7.8:
-    resolution: {integrity: sha512-QMmb3Z/ARvYZmZneudb8cnY/4mVvZTdhUyA9TC2skwOcm7KvY9zyOdn0TApQc4rL0VM2TffFkmo3ky/lJZX7qw==}
+  deslop-js@0.8.1:
+    resolution: {integrity: sha512-a8wpwOPo6HsYyRndn17C88mNzeQD6t17yhZ8qpyFWTxj5jQeWtXDj+zJfnuT8++5A4LaNeNAnKs1edVWuadNdQ==}
 
   detect-libc@2.0.2:
     resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
@@ -6095,8 +6107,8 @@ packages:
       vite-plus:
         optional: true
 
-  oxlint-plugin-react-doctor@0.7.8:
-    resolution: {integrity: sha512-3f9/jFLIC/KRLPYqxiXSk20cq47luGy9Oz5Ru7nK7w0EI9B9zuMvAU92bK9jFiwFE7Lc9PA8ER6Y+naYaGFQGw==}
+  oxlint-plugin-react-doctor@0.8.1:
+    resolution: {integrity: sha512-ETjgoKrY0EYpK51BsbvgpWySkWaLgJ6z7yB/BfOosi+TUY4+GiDmhWfjJCeul+tpDJEFKR5MnpENjlUrmtZ5Dw==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tailwindcss@1.3.5:
@@ -6294,8 +6306,8 @@ packages:
     resolution: {integrity: sha512-aEZ9qP+/M+58x2qgfSFEWH1BxLyHe5+qkLNJOZQb5iGS017jpbRnoKhNRrXPeA6RfBrZO5wZrT9DMC1UqE1f1w==}
     engines: {node: ^20.9.0 || >=22}
 
-  react-doctor@0.7.8:
-    resolution: {integrity: sha512-G3spmtZJE/gWWPRJ3rpgUWTPRDJpEmdRja7iNZ7RAXlfpEO+NWVzPTca/cPI9hLwPo2Aq5/BZggo5JDBrwGrlA==}
+  react-doctor@0.8.1:
+    resolution: {integrity: sha512-lP/MaS7dDMeVFpWBjh8qYp6NYcb/1TmsAwSixqkqOI50fea9kfh89fyn+UUAC3vb53FGIqwvDPZIjlJR6BgGAQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -10187,7 +10199,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.7.8:
+  deslop-js@0.8.1:
     dependencies:
       '@oxc-project/types': 0.138.0
       fast-glob: 3.3.3
@@ -11886,7 +11898,7 @@ snapshots:
       '@oxfmt/binding-win32-x64-msvc': 0.59.0
       vite-plus: 0.2.5(@opentelemetry/api@1.9.1)(@types/node@24.13.3)(@vitest/browser-playwright@4.1.10)(@vitest/coverage-v8@4.1.10)(@vitest/ui@4.1.10)(esbuild@0.28.1)(jiti@2.7.0)(msw@2.15.0(@types/node@24.13.3)(typescript@7.0.2))(tsx@4.22.3)(typescript@7.0.2)(vite@8.0.14(@types/node@24.13.3)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))(yaml@2.9.0)
 
-  oxlint-plugin-react-doctor@0.7.8:
+  oxlint-plugin-react-doctor@0.8.1:
     dependencies:
       '@typescript-eslint/types': 8.60.0
       eslint-scope: 9.1.2
@@ -12164,19 +12176,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-doctor@0.7.8(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.24.0):
+  react-doctor@0.8.1(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.24.0):
     dependencies:
       '@babel/code-frame': 7.29.7
       '@sentry/node': 10.55.0
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.7.8
+      deslop-js: 0.8.1
       eslint-plugin-react-hooks: 7.1.1(eslint@10.4.1(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0(oxlint-tsgolint@0.24.0)
-      oxlint-plugin-react-doctor: 0.7.8
+      oxlint-plugin-react-doctor: 0.8.1
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -12233,7 +12245,7 @@ snapshots:
       preact: 10.29.2
       prompts: 2.4.2
       react: 19.2.7
-      react-doctor: 0.7.8(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.24.0)
+      react-doctor: 0.8.1(eslint@10.4.1(jiti@2.7.0))(oxlint-tsgolint@0.24.0)
       react-dom: 19.2.7(react@19.2.7)
       react-grab: 0.1.48(react@19.2.7)
     optionalDependencies:
@@ -13095,7 +13107,7 @@ snapshots:
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
-      postcss: 8.5.17
+      postcss: 8.5.19
       rolldown: 1.0.2
       tinyglobby: 0.2.17
     optionalDependencies:


### PR DESCRIPTION
## 概要

コードドック (/code-dock) のシンタックスハイライトが本番で一切効いていなかった問題を修正する。クライアント側のハイライトを shiki の oniguruma (wasm) エンジンから JS 正規表現エンジンに切り替えた。

## 動機

本番の CSP (`proxy.ts`) は `script-src` に `wasm-unsafe-eval` を含まないため、oniguruma エンジンの `WebAssembly.instantiate` が CompileError になる。エラーは `useHighlightedCode` の catch で握りつぶされ、1.5 秒のフォールバック後にプレーン表示になっていた。dev では CSP に `unsafe-eval` が付与されるため再現しない。

CSP に `wasm-unsafe-eval` を足す選択肢もあったが、CSP を緩めずにクライアント側を wasm 非依存にする方を選んだ。

## 詳細

- `@repo/code-highlight/tokenize-client` を新設: `@shikijs/engine-javascript` (wasm 不要) + コードドックで使う ts/tsx/js/jsx の 4 言語 + plastic/one-light の 2 テーマだけを束ねた `highlightCode` 互換エントリ
- `use-highlighted-code` の動的 import を `tokenize-client` に切り替え
- ハイライト失敗時に `console.warn` で記録するようにした (本番の `removeConsole` は warn を残す設定)。今回の障害が長期間気づけなかった要因への対処
- テスト追加: `WebAssembly` グローバルを潰した状態 (本番 CSP 相当) でもハイライトできることを直接検証。ほか 4 言語の正常系・テーマ切替・未知言語の text フォールバック

## 気をつけるポイント

- 任意言語のハイライトが必要なサーバー側 (ブログ OG 画像・apps/ai) は従来どおり oniguruma 版 `./tokenize` を使い続ける。変更なし
- JS エンジンは ts/tsx/js/jsx 文法を完全サポートしており、トークン出力は oniguruma と同一 (ダーク/ライト両テーマで実機確認済み)

## 影響範囲

- /code-dock のクライアントバンドル: エンジン部分が 629KB (gzip 234KB) → 58KB (gzip 20KB)。初回ハイライトまでの必要転送量は gzip 約 250KB → 約 85KB
- 性能: エンジン初期化 19〜27ms → 1〜8ms、定常トークナイズは同等〜約 15% 高速 (Node/V8 ベンチ)

## テスト

- パッケージテスト 39 件 / Storybook テスト 549 件 / type-check / vp check すべて通過
- dev 実機でダーク/ライト両テーマ・入力追従・言語切替を確認 (本番 CSP 相当の検証はユニットテストでカバー)