### PR TITLE
成果物一覧にhtml-nestとpnpm-release-actionを追加する

### DIFF
--- a/apps/main/src/features/artifacts/application/artifacts.test.ts
+++ b/apps/main/src/features/artifacts/application/artifacts.test.ts
@@ -4,7 +4,7 @@ describe('getArtifacts', () => {
   it('公開している制作物一覧を返す', () => {
     const projects = getArtifacts();
 
-    expect(projects).toHaveLength(12);
+    expect(projects).toHaveLength(14);
     expect(projects).toStrictEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -22,6 +22,18 @@ describe('getArtifacts', () => {
         expect.objectContaining({
           name: 'patrol-board',
           githubUrl: 'https://github.com/k35o/patrol-board',
+          websiteUrl: null,
+          npmPackageName: null,
+        }),
+        expect.objectContaining({
+          name: '@k8o/html-nest',
+          githubUrl: 'https://github.com/k35o/html-nest',
+          websiteUrl: 'https://k8o.me/html-nest',
+          npmPackageName: '@k8o/html-nest',
+        }),
+        expect.objectContaining({
+          name: 'pnpm-release-action',
+          githubUrl: 'https://github.com/k35o/pnpm-release-action',
           websiteUrl: null,
           npmPackageName: null,
         }),

--- a/apps/main/src/features/artifacts/application/artifacts.ts
+++ b/apps/main/src/features/artifacts/application/artifacts.ts
@@ -55,6 +55,16 @@ export const getArtifacts = (): Artifact[] => [
     npmPackageName: 'storybook-framework-hono-vite',
     tags: ['Storybook', 'Hono', 'Vite'],
   },
+  // HTML / oxlint
+  {
+    name: '@k8o/html-nest',
+    description:
+      'WHATWG HTML仕様の要素の内包関係を構造化データとして提供するエンジンと、JSXのネスト違反を検出するoxlintプラグイン。',
+    githubUrl: 'https://github.com/k35o/html-nest',
+    websiteUrl: 'https://k8o.me/html-nest',
+    npmPackageName: '@k8o/html-nest',
+    tags: ['HTML', 'oxlint', 'JSX'],
+  },
   // Vite+ / ビルドツール 系
   {
     name: '@k8o/create',
@@ -111,6 +121,15 @@ export const getArtifacts = (): Artifact[] => [
     tags: ['Dotfiles', 'chezmoi', 'Shell', 'Personal'],
   },
   // 自動化 / GitHub Actions
+  {
+    name: 'pnpm-release-action',
+    description:
+      'pnpm組み込みのリリース管理をCIへつなぎ、リリースPRの作成からnpm publish・タグ・GitHub Releasesの作成までを行うGitHub Action。',
+    githubUrl: 'https://github.com/k35o/pnpm-release-action',
+    websiteUrl: null,
+    npmPackageName: null,
+    tags: ['GitHub Actions', 'pnpm', 'Release'],
+  },
   {
     name: 'patrol-board',
     description:


### PR DESCRIPTION
## 概要

`/artifacts` の成果物一覧に、最近公開した `@k8o/html-nest` と `pnpm-release-action` の2件を追加する。

## 詳細

- `@k8o/html-nest`: 新設の「HTML / oxlint」グループとして Storybook 系の直後に配置。`websiteUrl` にサイト内エクスプローラーの `https://k8o.me/html-nest` を設定しているため、「サイトで見る」ボタンも表示される
- `pnpm-release-action`: 既存の「自動化 / GitHub Actions」グループに patrol-board と並べて配置。npm パッケージではないため GitHub リンクのみ
- 説明文は各リポジトリの README を基に、既存エントリと同じ一文スタイルで記述
- テストの件数検証を 12→14 に更新し、新規2件の URL 検証を追加

## テスト

- `pnpm -F main run test --project="features test"` 148件通過
- `pnpm run check` エラー0