### PR TITLE
feat(blog): spelling-grammar-error記事をBaseline 2025のtext-decoration-line軸に再構成する

### DIFF
--- a/apps/main/src/app/_components/playgrounds/spelling-grammar-error/index.ts
+++ b/apps/main/src/app/_components/playgrounds/spelling-grammar-error/index.ts
@@ -1,5 +1,6 @@
 import type { PlaygroundSection } from '../types';
 import { SpellingGrammarErrorDemo } from './spelling-grammar-error-demo';
+import { TextDecorationErrorDemo } from './text-decoration-error-demo';
 
 export const spellingGrammarErrorSection: PlaygroundSection = {
   id: 'spelling-grammar-error',
@@ -11,10 +12,16 @@ export const spellingGrammarErrorSection: PlaygroundSection = {
   slug: 'spelling-grammar-error',
   demos: [
     {
+      component: TextDecorationErrorDemo,
+      title: 'text-decoration-lineによるエラー風装飾',
+      description:
+        'エラー検出とは無関係に、ブラウザ標準のエラー表示と同じ装飾を任意のテキストへ描きます。',
+    },
+    {
       component: SpellingGrammarErrorDemo,
       title: 'スペル・文法エラースタイリング',
       description:
-        '編集可能な英文にフォーカスすると、スペルミスが波線＋背景色、文法エラーが点線下線で表示されます。',
+        '編集可能な英文で、検出されたスペルミスが波線と背景色で表示されます。文法エラーの装飾は、ブラウザが文法チェックを持つ環境でのみ表示されます。',
     },
   ],
 };

--- a/apps/main/src/app/_components/playgrounds/spelling-grammar-error/spelling-grammar-error-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/spelling-grammar-error/spelling-grammar-error-demo.tsx
@@ -1,7 +1,22 @@
 import type { FC } from 'react';
 
+const APPLIED_CSS = `::spelling-error {
+  background-color: var(--color-bg-error);
+  color: var(--color-fg-error);
+  text-decoration-line: underline;
+  text-decoration-style: wavy;
+  text-decoration-color: var(--color-fg-error);
+}
+
+::grammar-error {
+  color: var(--color-fg-error);
+  text-decoration-line: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: var(--color-fg-error);
+}`;
+
 export const SpellingGrammarErrorDemo: FC = () => (
-  <div>
+  <div className="flex flex-col gap-3">
     <p
       aria-label="スペル・文法エラーを試す編集可能なテキスト"
       className="spelling-grammar-error-demo"
@@ -12,6 +27,9 @@ export const SpellingGrammarErrorDemo: FC = () => (
     >
       Check a speling error and an grammar error.
     </p>
+    <pre className="bg-bg-mute text-fg-mute sm:text-md overflow-x-auto rounded-lg px-2 py-1 text-xs sm:p-4">
+      <code>{APPLIED_CSS}</code>
+    </pre>
     {/* セレクタをデモの要素に限定し、ページ内の他の入力要素へスタイルが波及しないようにする */}
     <style>{`
         .spelling-grammar-error-demo::spelling-error {

--- a/apps/main/src/app/_components/playgrounds/spelling-grammar-error/text-decoration-error-demo.stories.tsx
+++ b/apps/main/src/app/_components/playgrounds/spelling-grammar-error/text-decoration-error-demo.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import { Playground } from '../playground';
+import { TextDecorationErrorDemo } from './text-decoration-error-demo';
+
+const playgroundTitle = TextDecorationErrorDemo.name;
+
+const meta: Meta<typeof TextDecorationErrorDemo> = {
+  title: 'playgrounds/spelling-grammar-error/TextDecorationErrorDemo',
+  component: TextDecorationErrorDemo,
+  decorators: [
+    (Story) => (
+      <Playground title={playgroundTitle}>
+        <Story />
+      </Playground>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof TextDecorationErrorDemo>;
+
+export const Default: Story = {};

--- a/apps/main/src/app/_components/playgrounds/spelling-grammar-error/text-decoration-error-demo.tsx
+++ b/apps/main/src/app/_components/playgrounds/spelling-grammar-error/text-decoration-error-demo.tsx
@@ -1,0 +1,32 @@
+import type { FC } from 'react';
+
+const APPLIED_CSS = `.spelling {
+  text-decoration-line: spelling-error;
+}
+
+.grammar {
+  text-decoration-line: grammar-error;
+}`;
+
+export const TextDecorationErrorDemo: FC = () => (
+  <div className="flex flex-col gap-3">
+    <p className="text-decoration-error-demo" lang="ja">
+      この文章では
+      <span className="spelling">誤字っぽく見せたい部分</span>と
+      <span className="grammar">文法が怪しく見せたい部分</span>
+      を、ブラウザ標準のエラー表示と同じ装飾で描いています。
+    </p>
+    <pre className="bg-bg-mute text-fg-mute sm:text-md overflow-x-auto rounded-lg px-2 py-1 text-xs sm:p-4">
+      <code>{APPLIED_CSS}</code>
+    </pre>
+    {/* セレクタをデモの要素に限定し、ページ内の他要素へスタイルが波及しないようにする */}
+    <style>{`
+        .text-decoration-error-demo .spelling {
+          text-decoration-line: spelling-error;
+        }
+        .text-decoration-error-demo .grammar {
+          text-decoration-line: grammar-error;
+        }
+      `}</style>
+  </div>
+);

--- a/apps/main/src/app/blog/(articles)/spelling-grammar-error/page.mdx
+++ b/apps/main/src/app/blog/(articles)/spelling-grammar-error/page.mdx
@@ -1,34 +1,80 @@
 ---
-title: スペルミス・文法エラーに対してスタイルを設定する::spelling-errorと::grammar-error
-description: ::spelling-errorと::grammar-error擬似要素は、ブラウザが検出したスペルミスや文法エラーにスタイルを適用できる機能です。デフォルトの下線表示をカスタマイズし、ユーザー体験を向上させられます
+title: スペルミス・文法エラーの装飾をCSSで制御する
+description: Baseline 2025入りしたtext-decoration-lineのspelling-error・grammar-error値を使うと、ブラウザ標準のエラー表示と同じ装飾を任意のテキストに与えられます。あわせて、検出された本物のエラーをスタイリングする::spelling-error・::grammar-error擬似要素も紹介します
 createdAt: 2025-06-29
-updatedAt: 2025-11-15
+updatedAt: 2026-07-29
 featureIds:
+  - text-decoration-spelling-grammar
   - spelling-grammar-error
 ---
 
 import { Alert } from '@k8o/arte-odyssey';
 import { PlaygroundEmbed } from '@/app/_components/playgrounds';
 
-# スペルミス・文法エラーに対してスタイルを設定する::spelling-errorと::grammar-error
-
-<BrowserSupportStatus featureId="spelling-grammar-error" />
+# スペルミス・文法エラーの装飾をCSSで制御する
 
 ## はじめに
 
 <Alert
-  tone="warning"
-  message="【連絡】この記事では以前、紹介する機能がFirefox 140のリリースによってBaseline入りしたと記述していましたが、実際には導入されていませんでしたのでその部分を修正しています。"
+  tone="info"
+  message="【更新】2026年7月: Baseline 2025入りしたtext-decoration-lineのspelling-error・grammar-errorを軸に記事を再構成しました。以前の版にあった、擬似要素がFirefox 140のリリースでBaseline入りしたという記述は誤りだったため、あわせて修正しています。"
 />
 
-擬似要素である`::spelling-error`と`::grammar-error`は、スペルミスや文法エラーとしてフラグ付けされたテキストに対するスタイルを定義するために使用されます。
+ブラウザはスペルミスを赤い波線、文法エラーを緑の下線のような装飾で知らせてくれます。CSSにはこの見た目を扱う機能が2つあります。エラー風の装飾を任意のテキストに与える`text-decoration-line`の値`spelling-error`と`grammar-error`、そしてブラウザが検出した本物のエラーへスタイルを当てる擬似要素`::spelling-error`と`::grammar-error`です。
 
-## ::spelling-error
+前者はBaseline 2025入りした一方、後者はまだBaselineに達していない先取りの機能です。この記事では使える状態になった値の方から紹介します。
+
+## text-decoration-lineでエラー風の装飾を描く
+
+<BrowserSupportStatus featureId="text-decoration-spelling-grammar" />
+
+`text-decoration-line`の値`spelling-error`と`grammar-error`は、Chrome 121とFirefox 137に続いてSafari 26.2が対応したことで、2025年12月にBaseline 2025入りしました。エラー検出とは無関係に、ブラウザ標準のエラー表示と同じ見た目を任意のテキストへ与えます。
+
+```css
+/* [!og] */
+.custom-spelling {
+  text-decoration-line: spelling-error;
+}
+
+.custom-grammar {
+  text-decoration-line: grammar-error;
+}
+```
+
+この値を指定したテキストには、そのブラウザがスペルミス・文法エラーの表示に使っているものと同じ装飾が描かれます。見た目は完全にブラウザ任せで、次の特徴があります。
+
+- `underline`など他の線種と組み合わせられない単独の値です
+- `text-decoration-color`や`text-decoration-style`、`text-decoration-thickness`の指定は無視されます
+- 未対応のブラウザでは装飾が描かれないだけで、他への影響はありません
+
+<PlaygroundEmbed
+  demo="text-decoration-lineによるエラー風装飾"
+  sectionId="spelling-grammar-error"
+/>
+
+ブラウザのスペルチェック（`spellcheck`）は日本語の文章を検出できませんが、この値は検出と切り離された純粋な装飾なので、デモのように日本語のテキストにもエラー風の見た目を与えられます。自前の校正機能を持つエディタで指摘箇所を示すときに、ブラウザのエラー表示と一貫した見た目を実現できます。
+
+[CSS Custom Highlight APIの記事](/blog/highlight)で紹介した`::highlight()`擬似要素の中では`text-decoration`系のプロパティが使えるため、組み合わせるとDOMを変更せずに自前で検出した誤りへネイティブ同等の装飾を引けます。
+
+```css
+::highlight(my-spellcheck) {
+  text-decoration-line: spelling-error;
+}
+```
+
+なお、この装飾は色と線だけの視覚的な表現です。実際の校正UIで使うときは、指摘の内容をテキストや支援技術にも伝わる形で併記する必要があります。
+
+## 検出されたエラーをスタイリングする擬似要素
+
+<BrowserSupportStatus featureId="spelling-grammar-error" />
+
+ここからは向きが逆の機能です。擬似要素`::spelling-error`と`::grammar-error`は、ブラウザのスペルチェックによってスペルミスや文法エラーとしてフラグ付けされたテキストに対するスタイルを定義します。まだBaselineに達していないため、先取りの機能として押さえておく位置づけです。
+
+### ::spelling-error
 
 スペルミスとしてフラグ付けされたテキストに対するスタイルを定義します。
 
 ```css
-/* [!og] */
 ::spelling-error {
   background-color: #ffcccc;
   color: #d8000c;
@@ -38,9 +84,15 @@ import { PlaygroundEmbed } from '@/app/_components/playgrounds';
 }
 ```
 
-`::spelling-error`の中では、`color`と`background-color`、`cursor`、`caret-color`、`outline`、`outlint-*`、`text-decoration`、`text-decoration-*`、`text-emphasis-color`、`text-shadow`のみが使用可能です。
+`::spelling-error`の中で使えるプロパティは、次の装飾系に限られます。
 
-## ::grammar-error
+- `color`と`background-color`
+- `text-decoration`とその関連プロパティ（`text-decoration-*`）
+- `outline`とそのlonghand（`outline-*`）
+- `cursor`と`caret-color`
+- `text-emphasis-color`と`text-shadow`
+
+### ::grammar-error
 
 文法エラーとしてフラグ付けされたテキストに対するスタイルを定義します。
 
@@ -55,25 +107,25 @@ import { PlaygroundEmbed } from '@/app/_components/playgrounds';
 
 `::grammar-error`も`::spelling-error`と同様のプロパティしか定義できません。
 
-## 例
+### spellcheckに検出させて試す
 
-`contenteditable`属性で編集可能なテキストエリアを準備しました。`spellcheck`属性が`true`に設定されているため、スペルミスや文法エラーが自動的に検出されます。
+`contenteditable`属性で編集可能なテキストエリアを準備しました。`spellcheck`属性が`true`のため、ブラウザのスペルチェックが働き、検出されたエラーが`::spelling-error`と`::grammar-error`でスタイリングされます。
 
 この例では`contenteditable`属性の値を`plaintext-only`にすることでテキストの入力しか行えないようにしています。[`plaintext-only`についても記事](/blog/contenteditable-plaintextonly)を書いているので良ければ読んでください。
-
-ここで検出されたエラーが`::spelling-error`と`::grammar-error`の擬似要素でスタイリングされます。
 
 <PlaygroundEmbed
   demo="スペル・文法エラースタイリング"
   sectionId="spelling-grammar-error"
 />
 
-そのままでは`spellcheck`属性の確認が行われず、見た目の変化がないことがあります。その場合は、テキストの一部を編集して再確認させることで、エラーが表示されるようになると思います。
+そのままでは`spellcheck`の確認が行われず、見た目の変化がないことがあります。その場合は、テキストの一部を編集して再確認させると、`speling`がスペルミスとして検出されます。
 
-また、ブラウザごとに`spellcheck`の挙動が異なるため、デフォルトの文章で両方のエラーを確認できない恐れがあります（Safariで確認しました）。期待としては、`speling`がスペルミス、`an grammar`の`an`が文法エラーとして検出されることです。
+一方、`an grammar`の`an`に期待している文法エラーの装飾は、多くの環境で表示されません。`::grammar-error`が当たるのはブラウザが文法エラーとしてフラグ付けしたテキストだけですが、Chromeは現状Webページのテキストに対する文法チェックを持たず、SafariもmacOSの文法チェックを有効にした場合に限られるためです。セレクタに対応していることと、それが当たるテキストをブラウザが作れることは別の問題です。
+
+文法エラーの装飾がどんな見た目になるかは、最初のデモの`text-decoration-line: grammar-error`で確認できます。
 
 ## おわりに
 
-Baseline 2025入りした`::spelling-error`と`::grammar-error`を紹介しました。
+スペルミス・文法エラーの装飾を扱う2つのCSS機能を紹介しました。エラーと同じ見た目を任意のテキストに与える`text-decoration-line`の値はBaseline 2025入りしており、検出された本物のエラーへスタイルを当てる擬似要素はBaseline未達の先取り機能という関係です。
 
-`spellcheck`自体が日本語対応していないので、日本語ユーザーにとってはあまり恩恵がないかもしれませんが、英語のコンテンツを扱うときのために覚えておきたいです。
+`spellcheck`自体が日本語対応していないので、擬似要素は日本語ユーザーにとってあまり恩恵がないかもしれませんが、`text-decoration-line`の方は検出に依存しない装飾として日本語でも使えるため、校正系のUIを作るときのために覚えておきたいです。


### PR DESCRIPTION
## 概要

spelling-grammar-error 記事を再構成し、Baseline 2025入りした `text-decoration-line` の `spelling-error` / `grammar-error` 値を主役に据える。擬似要素(`::spelling-error` / `::grammar-error`)はBaseline未達の先取り機能として後半に置く。

## 動機

`text-decoration-line` の両値が Safari 26.2 の対応で2025年12月にBaseline入りした(2026年Baseline到達機能のうちブログ未執筆だった1つ)。既存記事は擬似要素が主題のため、単純に節を足すと後付けの構成になる。あわせて、実際に触って見つかった「`an grammar` の文法エラー装飾が表示されない」というデモの期待外れを、正確な説明に置き換える。

## 詳細

### 記事の再構成

- タイトルを「スペルミス・文法エラーの装飾をCSSで制御する」へ変更し、description・OGPコード(`[!og]`)も値側へ移動
- はじめにで2機能(装飾を与える値 / 検出結果にスタイルを当てる擬似要素)とBaseline状況を提示し、使える状態になった値から紹介する構成へ
- 冒頭のAlertを訂正連絡(warning)から更新案内(info)へ書き換え。過去の誤記載(擬似要素がFirefox 140でBaseline入り)の修正履歴も引き継ぐ
- 値の節: 単独値であること・他の `text-decoration-*` が無視されること・未対応ブラウザでは装飾が消えるだけであることを記載。spellcheckが効かない日本語でも使える点、CSS Custom Highlight APIとの組み合わせ、視覚情報のみに頼らないアクセシビリティ注意を紹介
- 擬似要素の節: `::spelling-error` / `::grammar-error` / spellcheckに検出させて試す、を小見出しにまとめ、使用可能プロパティの列挙(読点9個の一文)を箇条書きへ分解

### 文法エラー検出の実情を明記

セレクタ対応(Chrome 121+ / Safari 17.4+)と、文法エラーをフラグ付けする検出器の有無は別問題であることを本文に追加。Chromeは現状Webテキストの文法チェックを持たないため `::grammar-error` の装飾は多くの環境で表示されず、見た目の確認は値側のデモへ誘導する。従来の「ブラウザごとに挙動が異なるため確認できない恐れがあります」という曖昧なヘッジを置き換えた。

### Playground

- 日本語テキストへ `text-decoration-line: spelling-error / grammar-error` を描くデモを追加(Story付き)
- 両デモに適用中のCSSを `<pre><code>` で併記(既存の @scope デモと同形式)。装飾がどのコードによるものか、デモ単体で分かるように
- デモの掲載順と説明文を記事の構成・実情に合わせて更新

## 気をつけるポイント

- 公開済み記事のタイトル・descriptionを変更している(スラッグ・URLは不変)
- frontmatterの `featureIds` に `text-decoration-spelling-grammar` を追加したため、マージ後はBrowser Supportフィードからこの記事へリンクされる

## 影響範囲

- /blog/spelling-grammar-error、/playground のspelling-grammar-errorセクション、Browser Supportフィードの記事リンク

## テスト

- lint 0 errors、main type-check通過、Storyテスト2/2通過
- 実ブラウザで検証: `.spelling` / `.grammar` のcomputed styleが `spelling-error` / `grammar-error` として適用されること、`CSS.supports('text-decoration-line', 'underline spelling-error')` がfalse(単独値の記述の裏付け)であることを確認
- プロパティ一覧はMDNの Allowable properties と一致を確認。ブラウザバージョンとBaseline日付(2025-12-12)は取り込みデータと一致